### PR TITLE
docs: add a basic `CONTRIBUTING.md` file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ Contributions to this repository (and any other repository in the
 This project follows
 [Substrait Community Principles](https://substrait.io/community/#principles).
 
-## Contribution process
+## Contribution Process
 
-### Code reviews
+### Code Reviews
 
 This project is bound by the governance rules of the Substrait project and,
 therefor, follows the
@@ -27,3 +27,17 @@ defined in the governance rules of the Substrait project. In particular, all
 submissions, including submissions by project members, require a review. We use
 GitHub [pull requests](https://help.github.com/articles/about-pull-requests/)
 for this purpose.
+
+### Style Guide
+
+This project bridges MLIR and Substrait, so it adopts styles from both
+communities. In particular:
+
+* Substrait MLIR follows the
+  [MLIR style guide](https://mlir.llvm.org/getting_started/DeveloperGuide/)
+  for code style and design considerations.
+* Substrait MLIR uses
+  [conventional commits](https://www.conventionalcommits.org/) like the other
+  Substrait repositories.
+* C++ and Python files are formatted according to
+  [`.clang-format`](.clang-format) and [`.style.yapf`](.style.yapf).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project.
+
+## Before You Begin
+
+### Sign our Contributor License Agreement
+
+Contributions to this repository (and any other repository in the
+[`substrait-io`](https://github.com/substrait-io)) must be accompanied by a
+[Contributor License Agreement](https://cla-assistant.io/substrait-io/substrait)
+(CLA) as per the [Substrait Governance rules](https://substrait.io/governance/).
+
+### Review our Community Principles
+
+This project follows
+[Substrait Community Principles](https://substrait.io/community/#principles).
+
+## Contribution process
+
+### Code reviews
+
+This project is bound by the governance rules of the Substrait project and,
+therefor, follows the
+[processs](https://substrait.io/governance/#substrait-voting-process)
+defined in the governance rules of the Substrait project. In particular, all
+submissions, including submissions by project members, require a review. We use
+GitHub [pull requests](https://help.github.com/articles/about-pull-requests/)
+for this purpose.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ implement database query compilers.
 Licensed under the Apache license with LLVM Exceptions. See [LICENSE](LICENSE)
 for more information.
 
+## Contributing
+
+Check out the [the dedicated document](CONTRIBUTING.md) for how to contribute.
+
 ## Motivation
 
 Substrait defines a serialization format for data-intensive compute operations


### PR DESCRIPTION
This PR depends on and, therefor, includes #5.

The current file only covers the most basic aspects. I plan to add CI checks to enforce formatting etc. in the near future and will extend this file as I do.