### PR TITLE
docs: fix and extend build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ that don't have `lld`.
 ```bash
 cmake \
   -DPython3_EXECUTABLE=$(which python) \
-  -DABSL_ENABLE_INSTALL=ON \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE \
   -DCMAKE_BUILD_TYPE=Debug \
@@ -315,9 +314,9 @@ cd ${SUBSTRAIT_MLIR_BUILD_DIR} && ninja check-substrait-mlir
 You may also use `lit` to run a subset of the tests.
 
 ```bash
-llvm-lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test
-llvm-lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test/Target
-llvm-lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test/python/dialects/substrait/dialect.py
+llvm-lit -v ${SUBSTRAIT_MLIR_SOURCE_DIR}/test
+llvm-lit -v ${SUBSTRAIT_MLIR_SOURCE_DIR}/test/Target
+llvm-lit -v ${SUBSTRAIT_MLIR_SOURCE_DIR}/test/python/dialects/substrait/dialect.py
 ```
 
 ## Diagnostics via LSP servers

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ You may also use `lit` to run a subset of the tests. You may
 
 ```bash
 lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test
-lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test/Integration
-lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test/Dialect/Iterators/map.mlir
+lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test/Target
+lit -v ${SUBSTRAIT_MLIR_BUILD_DIR}/test/python/dialects/substrait/dialect.py
 ```
 
 ## Diagnostics via LSP servers

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ duckdb
 ibis==3.3.0
 ibis-framework==8.0.0
 ibis-substrait==3.2.0
-lit
 pyarrow
 
 # Plotting.

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,10 +6,6 @@
 # set by LLVM, leading to linker errors, so we deactivate them.
 set(SUBSTRAIT_CPP_SANITIZE_DEBUG_BUILD OFF)
 
-# In install mode, Abseil creates a target call `check`, which conflicts with an
-# LLVM target with the same name. In non-install mode, the target name changes.
-set(ABSL_ENABLE_INSTALL OFF)
-
 # LLVM sets this to `ON`, leading to a compilation error due to a file called
 # `time.h` in one of Abseil's folders.
 set(CMAKE_INCLUDE_CURRENT_DIR OFF)


### PR DESCRIPTION
This commit fixes several problems with the build instructions in the README and extends them. In particular, the following changes are made:

* List global prerequisites (like git, CMake, C++ compiler, etc.)
* Fix base path and define it as a first step
* Explicitly describe what paths to add to the `activate` script, including `PATH`, and adapt following commands to that
* Mention possible problems with using `lld`
* Remove the quirk with `-DABSL_ENABLE_INSTALL=ON` -- this doesn't seem to be necessary anymore
* Remove `lit` from the Python requirements because LLVM provides it in the `PATH`
* Adapt the `lit` examples to the new repository structure
