### PR TITLE
chore: update LLVM to latest revision on Nov. 6 (38fffa630e)

### DIFF
--- a/include/substrait-mlir/Target/SubstraitPB/Export.h
+++ b/include/substrait-mlir/Target/SubstraitPB/Export.h
@@ -12,9 +12,12 @@
 #include "substrait-mlir/Target/SubstraitPB/Options.h"
 #include "llvm/Support/raw_ostream.h"
 
+namespace llvm {
+class LogicalResult;
+}
 namespace mlir {
 class Operation;
-class LogicalResult;
+using LogicalResult = llvm::LogicalResult;
 
 namespace substrait {
 


### PR DESCRIPTION
This PR updates LLVM to the latest revision available today, Nov. 6, 2024, which is llvm/llvm-project@38fffa630e, and fixes a minor breakage occuring with the update.