### PR TITLE
feat: add stubs for native Python modules for type hints

### DIFF
--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: run YAPF to test if python code is correctly formatted
-      uses: AlexanderMelde/yapf-action@v1.0
+      uses: AlexanderMelde/yapf-action@efc672c0c96776f74b4fb4197b334dc07035ec4f # v2.0
       with:
         args: --verbose

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,6 @@
+# These files are generated; we want as little changes to them as possible
+python/substrait_mlir/_mlir_libs/**/*.pyi
+
+# Ignore code that isn't ours
+third_party/
+build*/

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -29,6 +29,14 @@ declare_mlir_python_extension(SubstraitMLIRPythonSources.DialectExtension
   SubstraitMLIRCAPI
 )
 
+declare_mlir_python_sources(SubstraitMLIRPythonSources.MLIRLibs
+  ADD_TO_PARENT SubstraitMLIRPythonSources
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/substrait_mlir"
+  SOURCES
+    _mlir_libs/_substraitDialects/__init__.pyi
+    _mlir_libs/_substraitDialects/substrait.pyi
+)
+
 # ###############################################################################
 # Common CAPI
 # ###############################################################################

--- a/python/substrait_mlir/_mlir_libs/_substraitDialects/__init__.pyi
+++ b/python/substrait_mlir/_mlir_libs/_substraitDialects/__init__.pyi
@@ -1,0 +1,3 @@
+from __future__ import annotations
+from . import substrait
+__all__ = ['substrait']

--- a/python/substrait_mlir/_mlir_libs/_substraitDialects/substrait.pyi
+++ b/python/substrait_mlir/_mlir_libs/_substraitDialects/substrait.pyi
@@ -1,0 +1,32 @@
+# Generated with plus manual fixes:
+#   pybind11-stubgen substrait_mlir._mlir_libs._substraitDialects -o python`
+from __future__ import annotations
+from typing import Optional
+from substrait_mlir.ir import Context, Module, Operation
+__all__ = ['from_binpb', 'from_json', 'from_textpb', 'register_dialect', 'to_binpb', 'to_json', 'to_textpb']
+def from_binpb(input, context: Optional[Context] = None) -> Module:
+    """
+    Import a Substrait plan in the binary protobuf format
+    """
+def from_json(input, context: Optional[Context] = None) -> Module:
+    """
+    Import a Substrait plan in the JSON format
+    """
+def from_textpb(input, context: Optional[Context] = None) -> Module:
+    """
+    Import a Substrait plan in the textual protobuf format
+    """
+def register_dialect(context: Optional[Context] = None, load: bool = True) -> None:
+    ...
+def to_binpb(op: Operation) -> str:
+    """
+    Export a Substrait plan into the binary protobuf format
+    """
+def to_json(op: Operation, pretty: bool = False) -> str:
+    """
+    Export a Substrait plan into the JSON format
+    """
+def to_textpb(op: Operation) -> str:
+    """
+    Export a Substrait plan into the textual protobuf format
+    """


### PR DESCRIPTION
~~This PR is currently based and, therefor, includes on #14 (in order to reuse the CI build cache from that PR).~~

This PR adds semi-generated `.pyi` files that provide typing hints for the native Python modules of this repository.