### PR TITLE
feat: introduce `union distinct` operation

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -381,8 +381,8 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
 }
 
 def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
-  let summary = "union distinct operation";
   // TODO(daliashaaban): This will evolve into an operation for all SetRels.
+  let summary = "union distinct operation";
   let description = [{
     Represents the `SetRel` message where op is set to SET_OP_UNION_DISTINCT.
     This takes two inputs. 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -385,7 +385,7 @@ def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
   let summary = "union distinct operation";
   let description = [{
     Represents the `SetRel` message where op is set to SET_OP_UNION_DISTINCT.
-    This takes two inputs. 
+    The current implementation only allows for two inputs (instead of two or more).
   }];
   
   let arguments = (ins

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -380,6 +380,23 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   }];
 }
 
+def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
+  let summary = "union distinct operation";
+  let description = [{
+    Represents the `SetRel` message where op is set to SET_OP_UNION_DISTINCT.
+    This takes two inputs. 
+
+  }];
+  
+  let arguments = (ins
+    Substrait_Relation:$left,
+    Substrait_Relation:$right
+  );
+
+  let results = (outs Substrait_Relation:$result);
+
+}
+
 def Substrait_EmitOp : Substrait_RelOp<"emit", [
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
     DeclareOpInterfaceMethods<InferTypeOpInterface>

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -382,10 +382,10 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
 
 def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
   let summary = "union distinct operation";
+  // TODO(daliashaaban): This will evolve into an operation for all SetRels.
   let description = [{
     Represents the `SetRel` message where op is set to SET_OP_UNION_DISTINCT.
     This takes two inputs. 
-
   }];
   
   let arguments = (ins
@@ -394,7 +394,6 @@ def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
   );
 
   let results = (outs Substrait_Relation:$result);
-
 }
 
 def Substrait_EmitOp : Substrait_RelOp<"emit", [

--- a/test/Dialect/Substrait/union-distinct.mlir
+++ b/test/Dialect/Substrait/union-distinct.mlir
@@ -1,0 +1,19 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:           %[[V0:.*]] = named_table
+// CHECK:           %[[V1:.*]] = named_table
+// CHECK-NEXT:      %[[V2:.*]] = "substrait.union_distinct"(%[[V0]], %[[V1]]) 
+// CHECK-SAME:        : (tuple<si32>, tuple<si32>) -> tuple<si32>
+// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %2 = "substrait.union_distinct"(%0 , %1) : (tuple<si32>,tuple<si32>) -> tuple<si32>
+    yield %2 : tuple<si32>
+  }
+}


### PR DESCRIPTION
Implemented union distinct set operation in tablegen with just two input operands and a result. Custom assembly to be implemented in a subsequent PR. Added new test that checks round-trip ability of the op. 