### PR TITLE
feat: add a custom assembly with explicit return type for `union distinct` operation

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -395,9 +395,8 @@ def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
 
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $left `u_d` $right attr-dict `:` type($left) `u_d` type($right) `->` type($result)
+    $left `u` $right attr-dict `:` type($left) `u` type($right) `->` type($result)
   }];
-
 }
 
 def Substrait_EmitOp : Substrait_RelOp<"emit", [

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -394,6 +394,10 @@ def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
   );
 
   let results = (outs Substrait_Relation:$result);
+  let assemblyFormat = [{
+    $left `u_d` $right attr-dict `:` type($left) `u_d` type($right) `->` type($result)
+  }];
+
 }
 
 def Substrait_EmitOp : Substrait_RelOp<"emit", [

--- a/test/Dialect/Substrait/union-distinct.mlir
+++ b/test/Dialect/Substrait/union-distinct.mlir
@@ -5,8 +5,8 @@
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = union_distinct %[[V0]] u_d %[[V1]] 
-// CHECK-SAME:        : tuple<si32> u_d tuple<si32> -> tuple<si32>
+// CHECK-NEXT:      %[[V2:.*]] = union_distinct %[[V0]] u %[[V1]] 
+// CHECK-SAME:        : tuple<si32> u tuple<si32> -> tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
 
 

--- a/test/Dialect/Substrait/union-distinct.mlir
+++ b/test/Dialect/Substrait/union-distinct.mlir
@@ -5,15 +5,16 @@
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = "substrait.union_distinct"(%[[V0]], %[[V1]]) 
-// CHECK-SAME:        : (tuple<si32>, tuple<si32>) -> tuple<si32>
+// CHECK-NEXT:      %[[V2:.*]] = union_distinct %[[V0]] u_d %[[V1]] 
+// CHECK-SAME:        : tuple<si32> u_d tuple<si32> -> tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = "substrait.union_distinct"(%0 , %1) : (tuple<si32>,tuple<si32>) -> tuple<si32>
+    %2 = union_distinct %0 u_d %1 : tuple<si32> u_d tuple<si32>  -> tuple<si32>
     yield %2 : tuple<si32>
   }
 }

--- a/test/Dialect/Substrait/union-distinct.mlir
+++ b/test/Dialect/Substrait/union-distinct.mlir
@@ -14,7 +14,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = union_distinct %0 u_d %1 : tuple<si32> u_d tuple<si32>  -> tuple<si32>
+    %2 = union_distinct %0 u %1 : tuple<si32> u tuple<si32> -> tuple<si32>
     yield %2 : tuple<si32>
   }
 }


### PR DESCRIPTION
Please only review top commit, bottom commit in [PR #16](https://github.com/substrait-io/substrait-mlir-contrib/pull/16).

Added custom assembly with explicit return type for Union Operation and adapted the tests.