### PR TITLE
feat: add return type inference for `union distinct` operation

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -380,7 +380,7 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   }];
 }
 
-def Substrait_UnionDistinct_Op : Substrait_RelOp<"union_distinct"> {
+def Substrait_UnionDistinctOp : Substrait_RelOp<"union_distinct"> {
   // TODO(daliashaaban): This will evolve into an operation for all SetRels.
   let summary = "union distinct operation";
   let description = [{

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -380,7 +380,9 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   }];
 }
 
-def Substrait_UnionDistinctOp : Substrait_RelOp<"union_distinct"> {
+def Substrait_UnionDistinctOp : Substrait_RelOp<"union_distinct", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]> {
   // TODO(daliashaaban): This will evolve into an operation for all SetRels.
   let summary = "union distinct operation";
   let description = [{

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -93,10 +93,6 @@ LogicalResult UnionDistinctOp::inferReturnTypes(
   TypeRange leftFieldTypes = cast<TupleType>(leftInput.getType()).getTypes();
   TypeRange rightFieldTypes = cast<TupleType>(rightInput.getType()).getTypes();
 
-  if (leftFieldTypes != rightFieldTypes)
-    return emitError(loc.value())
-           << "left and right inputs must have the same field types";
-
   auto resultType = TupleType::get(context, leftFieldTypes);
 
   inferredReturnTypes = SmallVector<Type>{resultType};

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -93,6 +93,10 @@ LogicalResult UnionDistinctOp::inferReturnTypes(
   TypeRange leftFieldTypes = cast<TupleType>(leftInput.getType()).getTypes();
   TypeRange rightFieldTypes = cast<TupleType>(rightInput.getType()).getTypes();
 
+  if (leftFieldTypes != rightFieldTypes)
+    return ::emitError(loc.value())
+           << "left and right inputs must have the same field types";
+
   auto resultType = TupleType::get(context, leftFieldTypes);
 
   inferredReturnTypes = SmallVector<Type>{resultType};

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -82,6 +82,28 @@ CrossOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
   return success();
 }
 
+LogicalResult UnionDistinctOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
+
+  Value leftInput = operands[0];
+  Value rightInput = operands[1];
+
+  TypeRange leftFieldTypes = cast<TupleType>(leftInput.getType()).getTypes();
+  TypeRange rightFieldTypes = cast<TupleType>(rightInput.getType()).getTypes();
+
+  if (leftFieldTypes != rightFieldTypes)
+    return emitError(loc.value())
+           << "left and right inputs must have the same field types";
+
+  auto resultType = TupleType::get(context, leftFieldTypes);
+
+  inferredReturnTypes = SmallVector<Type>{resultType};
+
+  return success();
+}
+
 OpFoldResult EmitOp::fold(FoldAdaptor adaptor) {
   MLIRContext *context = getContext();
   Type i64 = IntegerType::get(context, 64);

--- a/test/Dialect/Substrait/union-distinct-invalid.mlir
+++ b/test/Dialect/Substrait/union-distinct-invalid.mlir
@@ -1,15 +1,6 @@
 // RUN: substrait-opt -split-input-file %s \
 // RUN: | FileCheck %s
 
-// CHECK-LABEL: substrait.plan
-// CHECK:         relation
-// CHECK:           %[[V0:.*]] = named_table
-// CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = union_distinct %[[V0]] u %[[V1]] 
-// CHECK-SAME:        : tuple<si32> u tuple<si32> -> tuple<si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
-
-
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>

--- a/test/Dialect/Substrait/union-distinct-invalid.mlir
+++ b/test/Dialect/Substrait/union-distinct-invalid.mlir
@@ -1,5 +1,4 @@
-// RUN: substrait-opt -split-input-file %s \
-// RUN: | FileCheck %s
+// RUN: substrait-opt -verify-diagnostics -split-input-file %s 
 
 substrait.plan version 0 : 42 : 1 {
   relation {

--- a/test/Dialect/Substrait/union-distinct-invalid.mlir
+++ b/test/Dialect/Substrait/union-distinct-invalid.mlir
@@ -4,6 +4,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si1>
+    // expected-error@+2 {{'substrait.union_distinct' op failed to infer returned types}}
     // expected-error@+1 {{left and right inputs must have the same field types}}
     %2 = union_distinct %0 u %1 : tuple<si32> u tuple<si1> -> tuple<si32>
     yield %2 : tuple<si32>

--- a/test/Dialect/Substrait/union-distinct-invalid.mlir
+++ b/test/Dialect/Substrait/union-distinct-invalid.mlir
@@ -1,0 +1,21 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:           %[[V0:.*]] = named_table
+// CHECK:           %[[V1:.*]] = named_table
+// CHECK-NEXT:      %[[V2:.*]] = union_distinct %[[V0]] u %[[V1]] 
+// CHECK-SAME:        : tuple<si32> u tuple<si32> -> tuple<si32>
+// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si1>
+    // expected-error@+1 {{left and right inputs must have the same field types}}
+    %2 = union_distinct %0 u %1 : tuple<si32> u tuple<si32> -> tuple<si32>
+    yield %2 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/union-distinct-invalid.mlir
+++ b/test/Dialect/Substrait/union-distinct-invalid.mlir
@@ -6,7 +6,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si1>
     // expected-error@+1 {{left and right inputs must have the same field types}}
-    %2 = union_distinct %0 u %1 : tuple<si32> u tuple<si32> -> tuple<si32>
+    %2 = union_distinct %0 u %1 : tuple<si32> u tuple<si1> -> tuple<si32>
     yield %2 : tuple<si32>
   }
 }


### PR DESCRIPTION
Added return type inference for `union distinct` operation. Added a check to make sure that left and right operand types matched, not sure if this should be done or not. 

Please only review latest commit. Other two commits in other PR's ([PR 16](https://github.com/substrait-io/substrait-mlir-contrib/pull/16), [PR 17](https://github.com/substrait-io/substrait-mlir-contrib/pull/17)). 