### PR TITLE
fix: add `substrait-translate` as dependency to `check-substrait-mlir`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SUBSTRAIT_MLIR_TEST_DEPENDS
   count
   FileCheck
   substrait-opt
+  substrait-translate
   mlir_async_runtime
   mlir-cpu-runner
   mlir_c_runner_utils


### PR DESCRIPTION
`substrait-translate` not built when running `ninja check-substrait-mlir` so I added it to dependency list. 