### PR TITLE
chore: fix to make already merged `union_distinct` related functions be in alphabetical order

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -380,27 +380,6 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   }];
 }
 
-def Substrait_UnionDistinctOp : Substrait_RelOp<"union_distinct", [
-    DeclareOpInterfaceMethods<InferTypeOpInterface>
-  ]> {
-  // TODO(daliashaaban): This will evolve into an operation for all SetRels.
-  let summary = "union distinct operation";
-  let description = [{
-    Represents the `SetRel` message where op is set to SET_OP_UNION_DISTINCT.
-    The current implementation only allows for two inputs (instead of two or more).
-  }];
-  
-  let arguments = (ins
-    Substrait_Relation:$left,
-    Substrait_Relation:$right
-  );
-
-  let results = (outs Substrait_Relation:$result);
-  let assemblyFormat = [{
-    $left `u` $right attr-dict `:` type($left) `u` type($right) `->` type($result)
-  }];
-}
-
 def Substrait_EmitOp : Substrait_RelOp<"emit", [
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
     DeclareOpInterfaceMethods<InferTypeOpInterface>
@@ -543,6 +522,27 @@ def Substrait_ProjectOp : Substrait_RelOp<"project", [
     ::llvm::StringRef $cppClass::getDefaultDialect() {
       return SubstraitDialect::getDialectNamespace();
     }
+  }];
+}
+
+def Substrait_UnionDistinctOp : Substrait_RelOp<"union_distinct", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]> {
+  // TODO(daliashaaban): This will evolve into an operation for all SetRels.
+  let summary = "union distinct operation";
+  let description = [{
+    Represents the `SetRel` message where op is set to SET_OP_UNION_DISTINCT.
+    The current implementation only allows for two inputs (instead of two or more).
+  }];
+  
+  let arguments = (ins
+    Substrait_Relation:$left,
+    Substrait_Relation:$right
+  );
+
+  let results = (outs Substrait_Relation:$result);
+  let assemblyFormat = [{
+    $left `u` $right attr-dict `:` type($left) `u` type($right) `->` type($result)
   }];
 }
 

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -82,28 +82,6 @@ CrossOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
   return success();
 }
 
-LogicalResult UnionDistinctOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
-    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
-    llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
-
-  Value leftInput = operands[0];
-  Value rightInput = operands[1];
-
-  TypeRange leftFieldTypes = cast<TupleType>(leftInput.getType()).getTypes();
-  TypeRange rightFieldTypes = cast<TupleType>(rightInput.getType()).getTypes();
-
-  if (leftFieldTypes != rightFieldTypes)
-    return ::emitError(loc.value())
-           << "left and right inputs must have the same field types";
-
-  auto resultType = TupleType::get(context, leftFieldTypes);
-
-  inferredReturnTypes = SmallVector<Type>{resultType};
-
-  return success();
-}
-
 OpFoldResult EmitOp::fold(FoldAdaptor adaptor) {
   MLIRContext *context = getContext();
   Type i64 = IntegerType::get(context, 64);
@@ -272,6 +250,28 @@ LiteralOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 
   Type resultType = attr.getType();
   inferredReturnTypes.emplace_back(resultType);
+
+  return success();
+}
+
+LogicalResult UnionDistinctOp::inferReturnTypes(
+    MLIRContext *context, std::optional<Location> loc, ValueRange operands,
+    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
+    llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
+
+  Value leftInput = operands[0];
+  Value rightInput = operands[1];
+
+  TypeRange leftFieldTypes = cast<TupleType>(leftInput.getType()).getTypes();
+  TypeRange rightFieldTypes = cast<TupleType>(rightInput.getType()).getTypes();
+
+  if (leftFieldTypes != rightFieldTypes)
+    return ::emitError(loc.value())
+           << "left and right inputs must have the same field types";
+
+  auto resultType = TupleType::get(context, leftFieldTypes);
+
+  inferredReturnTypes = SmallVector<Type>{resultType};
 
   return success();
 }


### PR DESCRIPTION
Following feedback from the previous PR, I put the union_distinct op type inference function and the union_distinct op declaration in their correct alphabetical locations.