### PR TITLE
feat: add custom parser/printer for `fetch` count operand 

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -431,7 +431,7 @@ def Substrait_FetchOp : Substrait_RelOp<"fetch", [
   );
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $count (`offset` $offset^)? `from` $input attr-dict `:` type($input)
+    custom < CountAsAll > ($count) (`offset` $offset^)? `from` $input attr-dict `:` type($input)
   }];
 }
 

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -44,6 +44,32 @@ void SubstraitDialect::initialize() {
 #include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypeInterfaces.cpp.inc"
 
 //===----------------------------------------------------------------------===//
+// Custom Parser and Printer for Substrait
+//===----------------------------------------------------------------------===//
+
+bool parseCountAsAll(OpAsmParser &parser, IntegerAttr &count) {
+  if (!parser.parseOptionalKeyword("all")) {
+    count = parser.getBuilder().getI64IntegerAttr(-1);
+  } else {
+    int64_t result; 
+    if (!parser.parseInteger(result)) {
+      count = parser.getBuilder().getI64IntegerAttr(result);
+    } else {
+      return true;
+    } 
+  }
+  return false;
+}
+
+void printCountAsAll(OpAsmPrinter &printer, Operation* op, IntegerAttr count) {
+  if (count.getInt() == -1){
+    printer << "all";
+    return;
+  } else {
+    printer << count.getValue();
+  }
+}
+//===----------------------------------------------------------------------===//
 // Substrait operations
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Substrait/fetch.mlir
+++ b/test/Dialect/Substrait/fetch.mlir
@@ -19,6 +19,21 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]]
+// CHECK-SAME:        : tuple<si32> 
+// CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = fetch -1 offset 3 from %0 : tuple<si32> 
+    yield %1 : tuple<si32>
+  }
+}
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:           %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]]
 // CHECK-SAME:        : tuple<si32> 
 // CHECK-NEXT:      yield %[[V1]] : tuple<si32>


### PR DESCRIPTION
Added a custom parser and printer for the `fetch` count operand. When count is -1  it is replaced with the word "all" in the assembly language.
@ingomueller-net 