### PR TITLE
chore: remove comma from assembly language of `set` op

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -575,7 +575,7 @@ def Substrait_SetOp : Substrait_RelOp<"set", [
 
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $kind `,` $inputs attr-dict `:` type($result) 
+    $kind $inputs attr-dict `:` type($result) 
   }];
 }
 

--- a/test/Dialect/Substrait/set.mlir
+++ b/test/Dialect/Substrait/set.mlir
@@ -6,7 +6,7 @@
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK:           %[[V2:.*]] = named_table
-// CHECK-NEXT:      %[[V3:.*]] = set unspecified, %[[V0]], %[[V1]], %[[V2]]
+// CHECK-NEXT:      %[[V3:.*]] = set unspecified %[[V0]], %[[V1]], %[[V2]]
 // CHECK-SAME:        : tuple<si32>
 // CHECK-NEXT:      yield %[[V3]] : tuple<si32>
 
@@ -15,7 +15,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
     %2 = named_table @t2 as ["c"] : tuple<si32>
-    %3 = set unspecified, %0, %1, %2: tuple<si32>
+    %3 = set unspecified %0, %1, %2: tuple<si32>
     yield %3 : tuple<si32>
   }
 }
@@ -26,7 +26,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = set minus_primary, %[[V0]], %[[V1]] 
+// CHECK-NEXT:      %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]] 
 // CHECK-SAME:        : tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
 
@@ -34,7 +34,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_primary, %0, %1 : tuple<si32>
+    %2 = set minus_primary %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -45,7 +45,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = set minus_multiset, %[[V0]], %[[V1]] 
+// CHECK-NEXT:      %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]] 
 // CHECK-SAME:        : tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
 
@@ -53,7 +53,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_multiset, %0, %1 : tuple<si32>
+    %2 = set minus_multiset %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -63,7 +63,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = set intersection_primary, %[[V0]], %[[V1]] 
+// CHECK-NEXT:      %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]] 
 // CHECK-SAME:        : tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
 
@@ -71,7 +71,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_primary, %0, %1 : tuple<si32>
+    %2 = set intersection_primary %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -81,7 +81,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = set intersection_multiset, %[[V0]], %[[V1]] 
+// CHECK-NEXT:      %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]] 
 // CHECK-SAME:        : tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
 
@@ -89,7 +89,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_multiset, %0, %1 : tuple<si32>
+    %2 = set intersection_multiset %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -99,7 +99,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = set union_distinct, %[[V0]], %[[V1]] 
+// CHECK-NEXT:      %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]] 
 // CHECK-SAME:        : tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
 
@@ -107,7 +107,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_distinct, %0, %1 : tuple<si32>
+    %2 = set union_distinct %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -117,7 +117,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = set union_all, %[[V0]], %[[V1]] 
+// CHECK-NEXT:      %[[V2:.*]] = set union_all %[[V0]], %[[V1]] 
 // CHECK-SAME:        : tuple<si32>
 // CHECK-NEXT:      yield %[[V2]] : tuple<si32>
 
@@ -125,7 +125,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_all, %0, %1 : tuple<si32>
+    %2 = set union_all %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/set.mlir
+++ b/test/Target/SubstraitPB/Export/set.mlir
@@ -27,7 +27,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set unspecified, %0, %1 : tuple<si32>
+    %2 = set unspecified %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -51,7 +51,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_primary, %0, %1 : tuple<si32>
+    %2 = set minus_primary %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -75,7 +75,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_multiset, %0, %1 : tuple<si32>
+    %2 = set minus_multiset %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -99,7 +99,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_primary, %0, %1 : tuple<si32>
+    %2 = set intersection_primary %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -123,7 +123,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_multiset, %0, %1 : tuple<si32>
+    %2 = set intersection_multiset %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -147,7 +147,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_distinct, %0, %1 : tuple<si32>
+    %2 = set union_distinct %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }
@@ -171,7 +171,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_all, %0, %1 : tuple<si32>
+    %2 = set union_all %0, %1 : tuple<si32>
     yield %2 : tuple<si32>
   }
 }

--- a/test/Target/SubstraitPB/Import/set.textpb
+++ b/test/Target/SubstraitPB/Import/set.textpb
@@ -14,7 +14,7 @@
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set unspecified, %[[V0]], %[[V1]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set unspecified %[[V0]], %[[V1]] : tuple<si32>
 # CHECK-NEXT:       yield %[[V2]] : tuple<si32>
 
 relations {
@@ -82,7 +82,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set minus_primary, %[[V0]], %[[V1]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]] : tuple<si32>
 # CHECK-NEXT:       yield %[[V2]] : tuple<si32>
 
 relations {
@@ -151,7 +151,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set minus_multiset, %[[V0]], %[[V1]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]] : tuple<si32>
 # CHECK-NEXT:       yield %[[V2]] : tuple<si32>
 
 relations {
@@ -220,7 +220,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set intersection_primary, %[[V0]], %[[V1]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]] : tuple<si32>
 # CHECK-NEXT:       yield %[[V2]] : tuple<si32>
 
 relations {
@@ -289,7 +289,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set intersection_multiset, %[[V0]], %[[V1]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]] : tuple<si32>
 # CHECK-NEXT:       yield %[[V2]] : tuple<si32>
 
 relations {
@@ -358,7 +358,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set union_distinct, %[[V0]], %[[V1]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]] : tuple<si32>
 # CHECK-NEXT:       yield %[[V2]] : tuple<si32>
 
 relations {
@@ -427,7 +427,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set union_all, %[[V0]], %[[V1]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set union_all %[[V0]], %[[V1]] : tuple<si32>
 # CHECK-NEXT:       yield %[[V2]] : tuple<si32>
 
 relations {


### PR DESCRIPTION
remove comma from assembly language of `set` op to make it cleaner.  

change from:
` %2 = set union_all, %0, %1 : tuple<si32>`
to:
` %2 = set union_all %0, %1 : tuple<si32>`

the extra comma felt unnecessary. I am also doing the `join` op assembly language in the same format as the non-comma version of this `set` op assembly language so thought I would make it the same. @ingomueller-net let me know what you think and if you agree (or not :)