### PR TITLE
feat: introduce `timestamp` and `timestamp_tz` types

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitDialect.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitDialect.td
@@ -34,6 +34,7 @@ def Substrait_Dialect : Dialect {
     more natural in MLIR to represent several message types as a single op and
     express message sub-types with interfaces instead.
   }];
+  let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -41,37 +41,47 @@ def Substrait_BinaryType : Substrait_Type<"Binary", "binary"> {
 }
 
 def Substrait_TimestampType : Substrait_Type<"Timestamp", "timestamp"> {
-  let summary = "Substrait timestamp (excluding timezone) type";
+  let summary = "Substrait timezone-unaware timestamp type";
   let description = [{
-    This type represents a substrait timestamp (excluding timezone) type. 
+    This type represents a substrait timezone-unaware timestamp type. 
   }];
 }
 
-def Substrait_TimestampAttr : Substrait_Attr<"Timestamp", "timestamp", 
-[DeclareAttrInterfaceMethods<TypedAttrInterface>]> {
-  let summary = "Substrait timestamp (excluding timezone) type";
+def Substrait_TimestampAttr : Substrait_Attr<"Timestamp", "timestamp",
+  [TypedAttrInterface]> {
+  let summary = "Substrait timezone-unaware timestamp type";
   let description = [{
-    This type represents a substrait timestamp (excluding timezone) attribute type.
+    This type represents a substrait timezone-unaware timestamp attribute type.
   }];  
   let parameters = (ins "int64_t":$value);
   let assemblyFormat = [{ `<` $value `` `us` `>` }];
+  let extraClassDeclaration = [{ 
+    ::mlir::Type getType() const {
+      return TimestampType::get(getContext());
+    }
+  }];
 }
 
 def Substrait_TimestampTzType : Substrait_Type<"TimestampTz", "timestamp_tz"> {
-  let summary = "Substrait timestamp (including timezone) type";
+  let summary = "Substrait timezone-aware timestamp type";
   let description = [{
-    This type represents a substrait timestamp (including timezone) type. 
+    This type represents a substrait timezone-aware timestamp type. 
   }];
 }
 
 def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz",
-[DeclareAttrInterfaceMethods<TypedAttrInterface>]> {
-  let summary = "Substrait timestamp (including timezone) type";
+  [TypedAttrInterface]> {
+  let summary = "Substrait timezone-aware timestamp type";
   let description = [{
-    This type represents a substrait timestamp (including timezone) attribute type.
+    This type represents a substrait timezone-aware timestamp attribute type.
   }];  
   let parameters = (ins "int64_t":$value);
   let assemblyFormat = [{ `<` $value `` `us` `>` }];
+  let extraClassDeclaration = [{ 
+    ::mlir::Type getType() const {
+      return TimestampTzType::get(getContext());
+    }
+  }];
 }
 
 /// Currently supported atomic types. These correspond directly to the types in

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -47,7 +47,8 @@ def Substrait_TimestampType : Substrait_Type<"Timestamp", "timestamp"> {
   }];
 }
 
-def Substrait_TimestampAttr : Substrait_Attr<"Timestamp", "timestamp"> {
+def Substrait_TimestampAttr : Substrait_Attr<"Timestamp", "timestamp", 
+[DeclareAttrInterfaceMethods<TypedAttrInterface>]> {
   let summary = "Substrait timestamp (excluding timezone) type";
   let description = [{
     This type represents a substrait timestamp (excluding timezone) attribute type.
@@ -63,7 +64,8 @@ def Substrait_TimestampTzType : Substrait_Type<"TimestampTz", "timestamp_tz"> {
   }];
 }
 
-def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz"> {
+def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz",
+[DeclareAttrInterfaceMethods<TypedAttrInterface>]> {
   let summary = "Substrait timestamp (including timezone) type";
   let description = [{
     This type represents a substrait timestamp (including timezone) attribute type.

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -63,6 +63,22 @@ def Substrait_TimestampAttr : Substrait_Attr<"Timestamp", "timestamp"> {
   let assemblyFormat = [{ `<` $value `>` }];
 }
 
+def Substrait_TimestampTzType : Substrait_Type<"TimestampTz", "timestamp_tz"> {
+  let summary = "Substrait timestamp (including timezone) type";
+  let description = [{
+    This type represents a substrait timestamp (including timezone) type. 
+  }];
+}
+
+def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz"> {
+  let summary = "Substrait timestamp (including timezone) type";
+  let description = [{
+    This type represents a substrait timestamp (including timezone) attribute type.
+  }];  
+  let parameters = (ins "int64_t":$value);
+  let assemblyFormat = [{ `<` $value `>` }];
+}
+
 /// Currently supported atomic types. These correspond directly to the types in
 /// https://github.com/substrait-io/substrait/blob/main/proto/substrait/type.proto.
 // TODO(ingomueller): Add the other low-hanging fruits here.
@@ -78,6 +94,7 @@ def Substrait_AtomicTypes {
     Substrait_StringType, // String
     Substrait_BinaryType, // Binary
     Substrait_TimestampType, // Timestamp
+    Substrait_TimestampTzType, // TimestampTZ
   ];
 }
 
@@ -94,6 +111,7 @@ def Substrait_AtomicAttributes {
     TypedStrAttr<Substrait_StringType>, // String
     TypedStrAttr<Substrait_BinaryType>, // Binary
     Substrait_TimestampAttr, // Timestamp
+    Substrait_TimestampTzAttr, // TimestampTZ
   ];
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -26,6 +26,13 @@ class Substrait_Attr<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
+def Substrait_BinaryType : Substrait_Type<"Binary", "binary"> {
+  let summary = "Substrait binary type";
+  let description = [{
+    This type represents a substrait binary type.
+  }];
+}
+
 def Substrait_StringType : Substrait_Type<"String", "string"> {
   let summary = "Substrait string type";
   let description = [{
@@ -38,6 +45,22 @@ def Substrait_BinaryType : Substrait_Type<"Binary", "binary"> {
   let description = [{
     This type represents a substrait binary type.
   }];
+
+
+def Substrait_TimestampType : Substrait_Type<"Timestamp", "timestamp"> {
+  let summary = "Substrait timestamp (excluding timezone) type";
+  let description = [{
+    This type represents a substrait timestamp (excluding timezone) type. 
+  }];
+}
+
+def Substrait_TimestampAttr : Substrait_Attr<"Timestamp", "timestamp"> {
+  let summary = "Substrait timestamp (excluding timezone) type";
+  let description = [{
+    This type represents a substrait timestamp (excluding timezone) attribute type.
+  }];  
+  let parameters = (ins "int64_t":$value);
+  let assemblyFormat = [{ `<` $value `>` }];
 }
 
 /// Currently supported atomic types. These correspond directly to the types in
@@ -54,6 +77,7 @@ def Substrait_AtomicTypes {
     F64, // FP64
     Substrait_StringType, // String
     Substrait_BinaryType, // Binary
+    Substrait_TimestampType, // Timestamp
   ];
 }
 
@@ -69,6 +93,7 @@ def Substrait_AtomicAttributes {
     F64Attr, // FP64
     TypedStrAttr<Substrait_StringType>, // String
     TypedStrAttr<Substrait_BinaryType>, // Binary
+    Substrait_TimestampAttr, // Timestamp
   ];
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -26,13 +26,6 @@ class Substrait_Attr<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def Substrait_BinaryType : Substrait_Type<"Binary", "binary"> {
-  let summary = "Substrait binary type";
-  let description = [{
-    This type represents a substrait binary type.
-  }];
-}
-
 def Substrait_StringType : Substrait_Type<"String", "string"> {
   let summary = "Substrait string type";
   let description = [{
@@ -45,7 +38,7 @@ def Substrait_BinaryType : Substrait_Type<"Binary", "binary"> {
   let description = [{
     This type represents a substrait binary type.
   }];
-
+}
 
 def Substrait_TimestampType : Substrait_Type<"Timestamp", "timestamp"> {
   let summary = "Substrait timestamp (excluding timezone) type";
@@ -60,7 +53,7 @@ def Substrait_TimestampAttr : Substrait_Attr<"Timestamp", "timestamp"> {
     This type represents a substrait timestamp (excluding timezone) attribute type.
   }];  
   let parameters = (ins "int64_t":$value);
-  let assemblyFormat = [{ `<` $value `>` }];
+  let assemblyFormat = [{ `<` $value `` `us` `>` }];
 }
 
 def Substrait_TimestampTzType : Substrait_Type<"TimestampTz", "timestamp_tz"> {
@@ -76,7 +69,7 @@ def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz"> {
     This type represents a substrait timestamp (including timezone) attribute type.
   }];  
   let parameters = (ins "int64_t":$value);
-  let assemblyFormat = [{ `<` $value `>` }];
+  let assemblyFormat = [{ `<` $value `` `us` `>` }];
 }
 
 /// Currently supported atomic types. These correspond directly to the types in

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -87,10 +87,14 @@ void printCountAsAll(OpAsmPrinter &printer, Operation *op, IntegerAttr count) {
 //===----------------------------------------------------------------------===//
 
 /// Implement the getType method for custom type `TimestampAttr`.
-::mlir::Type TimestampAttr::getType() const { return TimestampType::get(getContext()); }
+::mlir::Type TimestampAttr::getType() const {
+  return TimestampType::get(getContext());
+}
 
 /// Implement the getType method for custom type `TimestampTzAttr`.
-::mlir::Type TimestampTzAttr::getType() const { return TimestampTzType::get(getContext()); }
+::mlir::Type TimestampTzAttr::getType() const {
+  return TimestampTzType::get(getContext());
+}
 
 //===----------------------------------------------------------------------===//
 // Substrait operations

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -83,20 +83,6 @@ void printCountAsAll(OpAsmPrinter &printer, Operation *op, IntegerAttr count) {
 }
 
 //===----------------------------------------------------------------------===//
-// Substrait attributes
-//===----------------------------------------------------------------------===//
-
-/// Implement the getType method for custom type `TimestampAttr`.
-::mlir::Type TimestampAttr::getType() const {
-  return TimestampType::get(getContext());
-}
-
-/// Implement the getType method for custom type `TimestampTzAttr`.
-::mlir::Type TimestampTzAttr::getType() const {
-  return TimestampTzType::get(getContext());
-}
-
-//===----------------------------------------------------------------------===//
 // Substrait operations
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -81,6 +81,17 @@ void printCountAsAll(OpAsmPrinter &printer, Operation *op, IntegerAttr count) {
   // Normal integer.
   printer << count.getValue();
 }
+
+//===----------------------------------------------------------------------===//
+// Substrait attributes
+//===----------------------------------------------------------------------===//
+
+/// Implement the getType method for custom type `TimestampAttr`.
+::mlir::Type TimestampAttr::getType() const { return TimestampType::get(getContext()); }
+
+/// Implement the getType method for custom type `TimestampTzAttr`.
+::mlir::Type TimestampTzAttr::getType() const { return TimestampTzType::get(getContext()); }
+
 //===----------------------------------------------------------------------===//
 // Substrait operations
 //===----------------------------------------------------------------------===//

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -228,6 +228,18 @@ SubstraitExporter::exportType(Location loc, mlir::Type mlirType) {
     return std::move(type);
   }
 
+  // Handle timestamp.
+  if (mlirType.isa<TimestampType>()) {
+    // TODO(ingomueller): support other nullability modes.
+    auto timestampType = std::make_unique<proto::Type::Timestamp>();
+    timestampType->set_nullability(
+        Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED);
+
+    auto type = std::make_unique<proto::Type>();
+    type->set_allocated_timestamp(timestampType.release());
+    return std::move(type);
+  }
+
   // Handle tuple types.
   if (auto tupleType = llvm::dyn_cast<TupleType>(mlirType)) {
     auto structType = std::make_unique<proto::Type::Struct>();
@@ -612,6 +624,10 @@ SubstraitExporter::exportOperation(LiteralOp op) {
   // `BinaryType`.
   else if (auto binaryType = dyn_cast<BinaryType>(literalType)) {
     literal->set_binary(value.cast<StringAttr>().getValue().str());
+  } 
+  // `TimestampType`s.
+  else if (literalType.isa<TimestampType>()) {
+    literal->set_timestamp(value.cast<TimestampAttr>().getValue());
   } else
     op->emitOpError("has unsupported value");
 

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -636,7 +636,7 @@ SubstraitExporter::exportOperation(LiteralOp op) {
   // `BinaryType`.
   else if (auto binaryType = dyn_cast<BinaryType>(literalType)) {
     literal->set_binary(value.cast<StringAttr>().getValue().str());
-  } 
+  }
   // `TimestampType`s.
   else if (literalType.isa<TimestampType>()) {
     literal->set_timestamp(value.cast<TimestampAttr>().getValue());

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -112,6 +112,8 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
     return StringType::get(context);
   case proto::Type::kBinary:
     return BinaryType::get(context);
+  case proto::Type::kTimestamp:
+    return TimestampType::get(context);
   case proto::Type::kStruct: {
     const proto::Type::Struct &structType = type.struct_();
     llvm::SmallVector<mlir::Type> fieldTypes;
@@ -338,6 +340,10 @@ importLiteral(ImplicitLocOpBuilder builder,
   }
   case Expression::Literal::LiteralTypeCase::kBinary: {
     auto attr = StringAttr::get(message.binary(), BinaryType::get(context));
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kTimestamp: {
+    auto attr = TimestampAttr::get(context, message.timestamp());
     return builder.create<LiteralOp>(attr);
   }
   // TODO(ingomueller): Support more types.

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -114,6 +114,8 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
     return BinaryType::get(context);
   case proto::Type::kTimestamp:
     return TimestampType::get(context);
+  case proto::Type::kTimestampTz:
+    return TimestampTzType::get(context);
   case proto::Type::kStruct: {
     const proto::Type::Struct &structType = type.struct_();
     llvm::SmallVector<mlir::Type> fieldTypes;
@@ -344,6 +346,10 @@ importLiteral(ImplicitLocOpBuilder builder,
   }
   case Expression::Literal::LiteralTypeCase::kTimestamp: {
     auto attr = TimestampAttr::get(context, message.timestamp());
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kTimestampTz: {
+    auto attr = TimestampTzAttr::get(context, message.timestamp_tz());
     return builder.create<LiteralOp>(attr);
   }
   // TODO(ingomueller): Support more types.

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -4,6 +4,32 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> : !substrait.timestamp
+// CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us> : !substrait.timestamp_tz
+// CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    ^bb0(%arg : tuple<si1>):
+      %timestamp = literal #substrait.timestamp<10000000000us> 
+      %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
+      yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
+    }
+    yield %1 : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.binary> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -6,8 +6,8 @@
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> : !substrait.timestamp
-// CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us> : !substrait.timestamp_tz
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> 
+// CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us> 
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
 // CHECK-NEXT:    }
 // CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,6 +3,20 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+  
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.binary>
 // CHECK-NEXT:    yield %0 : tuple<!substrait.binary>
 

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -20,6 +20,39 @@
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
+// CHECK-NEXT:            timestamp: 10000000000
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        expressions {
+// CHECK-NEXT:          literal {
+// CHECK-NEXT:            timestamp_tz: 10000000000
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    ^bb0(%arg : tuple<si1>):
+      %timestamp = literal #substrait.timestamp<10000000000us> : !substrait.timestamp
+      %timestamp_tz = literal #substrait.timestamp_tz<10000000000us> : !substrait.timestamp_tz
+      yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
+    }
+    yield %1 : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        input {
+// CHECK-NEXT:          read {
+// CHECK:             expressions {
+// CHECK-NEXT:          literal {
 // CHECK-NEXT:            binary: "4,5,6,7"
 
 substrait.plan version 0 : 42 : 1 {

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -32,8 +32,8 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
-      %timestamp = literal #substrait.timestamp<10000000000us> : !substrait.timestamp
-      %timestamp_tz = literal #substrait.timestamp_tz<10000000000us> : !substrait.timestamp_tz
+      %timestamp = literal #substrait.timestamp<10000000000us> 
+      %timestamp_tz = literal #substrait.timestamp_tz<10000000000us> 
       yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
     }
     yield %1 : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -14,7 +14,13 @@
 // CHECK-NEXT:      read {
 // CHECK:             base_schema {
 // CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          names: "b"
 // CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
 // CHECK-NEXT:            types {
 // CHECK-NEXT:              timestamp_tz {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
@@ -27,33 +33,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp_tz>
-    yield %0 : tuple<!substrait.timestamp_tz>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: relations {
-// CHECK-NEXT:    rel {
-// CHECK-NEXT:      read {
-// CHECK:             base_schema {
-// CHECK-NEXT:          names: "a"
-// CHECK-NEXT:          struct {
-// CHECK-NEXT:            types {
-// CHECK-NEXT:              timestamp {
-// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:              }
-// CHECK-NEXT:            }
-// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:        named_table {
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp>
-    yield %0 : tuple<!substrait.timestamp>
+    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -16,6 +16,31 @@
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp>
+    yield %0 : tuple<!substrait.timestamp>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              binary {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -16,6 +16,31 @@
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp_tz {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp_tz>
+    yield %0 : tuple<!substrait.timestamp_tz>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              timestamp {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -13,6 +13,66 @@
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> : !substrait.timestamp
+# CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us> : !substrait.timestamp_tz
+# CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
+# CHECK-NEXT:    }
+# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          timestamp: 10000000000
+        }
+      }
+      expressions {
+        literal {
+          timestamp_tz: 10000000000
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.binary> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -15,8 +15,8 @@
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> : !substrait.timestamp
-# CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us> : !substrait.timestamp_tz
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> 
+# CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us> 
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
 # CHECK-NEXT:    }
 # CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,6 +13,42 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
+# CHECK-SAME:       : tuple<!substrait.timestamp_tz>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            timestamp_tz {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan
+# CHECK-NEXT:   relation
+# CHECK-NEXT:     named_table
 # CHECK-SAME:       : tuple<!substrait.timestamp>
 
 relations {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,6 +13,42 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
+# CHECK-SAME:       : tuple<!substrait.timestamp>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            timestamp {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan
+# CHECK-NEXT:   relation
+# CHECK-NEXT:     named_table
 # CHECK-SAME:       : tuple<!substrait.binary>
 
 relations {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,7 +13,7 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.timestamp_tz>
+# CHECK-SAME:       : tuple<!substrait.timestamp, !substrait.timestamp_tz>
 
 relations {
   rel {
@@ -24,45 +24,15 @@ relations {
       }
       base_schema {
         names: "a"
-        struct {
-          types {
-            timestamp_tz {
-              nullability: NULLABILITY_REQUIRED
-            }
-          }
-          nullability: NULLABILITY_REQUIRED
-        }
-      }
-      named_table {
-        names: "t1"
-      }
-    }
-  }
-}
-version {
-  minor_number: 42
-  patch_number: 1
-}
-
-# -----
-
-# CHECK:      substrait.plan
-# CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.timestamp>
-
-relations {
-  rel {
-    read {
-      common {
-        direct {
-        }
-      }
-      base_schema {
-        names: "a"
+        names: "b"
         struct {
           types {
             timestamp {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          types {
+            timestamp_tz {
               nullability: NULLABILITY_REQUIRED
             }
           }


### PR DESCRIPTION
Introduce both timestamp types and respective attribute types: `timestamp` and `timestamp_tz`

Note this is a stacked PR: 

`timestamp` in this commit (4b01b29b470821f585b714e33fd93066e7c155e5)

`timestamp_tz` in second commit (36761b360f73dc379b7f4f7adda7cefd281d0554)

Added tests for both timestamp types but NOT for timestamp attribute types. Waiting on https://github.com/substrait-io/substrait-mlir-contrib/pull/39 to be merged and then will add those tests to project.mlir test file (similarly to integer/float types)! @ingomueller-net 


