### PR TITLE
feat: introduce `date` type

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -106,7 +106,8 @@ def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz",
   }];
 }
 
-/// Currently supported atomic types. These correspond directly to the types in
+/// Currently supported atomic types, listed in order of substrait specification. 
+/// These correspond directly to the types in
 /// https://github.com/substrait-io/substrait/blob/main/proto/substrait/type.proto.
 // TODO(ingomueller): Add the other low-hanging fruits here.
 def Substrait_AtomicTypes {
@@ -126,7 +127,8 @@ def Substrait_AtomicTypes {
   ];
 }
 
-/// Attributes of currently supported atomic types.
+/// Attributes of currently supported atomic types, listed in order of substrait 
+/// specification. 
 def Substrait_AtomicAttributes {
   list<Attr> attrs = [
     SI1Attr, // Boolean

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -84,6 +84,22 @@ def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz",
   }];
 }
 
+def Substrait_TimestampTzType : Substrait_Type<"TimestampTz", "timestamp_tz"> {
+  let summary = "Substrait timestamp (including timezone) type";
+  let description = [{
+    This type represents a substrait timestamp (including timezone) type. 
+  }];
+}
+
+def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz"> {
+  let summary = "Substrait timestamp (including timezone) type";
+  let description = [{
+    This type represents a substrait timestamp (including timezone) attribute type.
+  }];  
+  let parameters = (ins "int64_t":$value);
+  let assemblyFormat = [{ `<` $value `>` }];
+}
+
 /// Currently supported atomic types. These correspond directly to the types in
 /// https://github.com/substrait-io/substrait/blob/main/proto/substrait/type.proto.
 // TODO(ingomueller): Add the other low-hanging fruits here.

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -97,7 +97,7 @@ def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz"> {
     This type represents a substrait timestamp (including timezone) attribute type.
   }];  
   let parameters = (ins "int64_t":$value);
-  let assemblyFormat = [{ `<` $value `>` }];
+  let assemblyFormat = [{ `<` $value `` `us` `>` }];
 }
 
 /// Currently supported atomic types. These correspond directly to the types in

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -26,19 +26,19 @@ class Substrait_Attr<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
-def Substrait_StringType : Substrait_Type<"String", "string"> {
-  let summary = "Substrait string type";
-  let description = [{
-    This type represents a substrait string type.
-  }];
-}
-
 def Substrait_BinaryType : Substrait_Type<"Binary", "binary"> {
   let summary = "Substrait binary type";
   let description = [{
     This type represents a substrait binary type.
   }];
 }
+
+def Substrait_StringType : Substrait_Type<"String", "string"> {
+  let summary = "Substrait string type";
+  let description = [{
+    This type represents a substrait string type.
+  }];
+}}
 
 def Substrait_TimestampType : Substrait_Type<"Timestamp", "timestamp"> {
   let summary = "Substrait timezone-unaware timestamp type";

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -33,12 +33,34 @@ def Substrait_BinaryType : Substrait_Type<"Binary", "binary"> {
   }];
 }
 
+def Substrait_DateType : Substrait_Type<"Date", "date"> {
+  let summary = "Substrait date type";
+  let description = [{
+    This type represents a substrait date type. 
+  }];
+}
+
+def Substrait_DateAttr : Substrait_Attr<"Date", "date",
+  [TypedAttrInterface]> {
+  let summary = "Substrait date type";
+  let description = [{
+    This type represents a substrait date attribute type.
+  }];  
+  let parameters = (ins "int32_t":$value);
+  let assemblyFormat = [{ `<` $value `>` }];
+  let extraClassDeclaration = [{ 
+    ::mlir::Type getType() const {
+      return DateType::get(getContext());
+    }
+  }];
+}
+
 def Substrait_StringType : Substrait_Type<"String", "string"> {
   let summary = "Substrait string type";
   let description = [{
     This type represents a substrait string type.
   }];
-}}
+}
 
 def Substrait_TimestampType : Substrait_Type<"Timestamp", "timestamp"> {
   let summary = "Substrait timezone-unaware timestamp type";
@@ -84,22 +106,6 @@ def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz",
   }];
 }
 
-def Substrait_TimestampTzType : Substrait_Type<"TimestampTz", "timestamp_tz"> {
-  let summary = "Substrait timestamp (including timezone) type";
-  let description = [{
-    This type represents a substrait timestamp (including timezone) type. 
-  }];
-}
-
-def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz"> {
-  let summary = "Substrait timestamp (including timezone) type";
-  let description = [{
-    This type represents a substrait timestamp (including timezone) attribute type.
-  }];  
-  let parameters = (ins "int64_t":$value);
-  let assemblyFormat = [{ `<` $value `` `us` `>` }];
-}
-
 /// Currently supported atomic types. These correspond directly to the types in
 /// https://github.com/substrait-io/substrait/blob/main/proto/substrait/type.proto.
 // TODO(ingomueller): Add the other low-hanging fruits here.
@@ -116,6 +122,7 @@ def Substrait_AtomicTypes {
     Substrait_BinaryType, // Binary
     Substrait_TimestampType, // Timestamp
     Substrait_TimestampTzType, // TimestampTZ
+    Substrait_DateType, // Date
   ];
 }
 
@@ -133,6 +140,7 @@ def Substrait_AtomicAttributes {
     TypedStrAttr<Substrait_BinaryType>, // Binary
     Substrait_TimestampAttr, // Timestamp
     Substrait_TimestampTzAttr, // TimestampTZ
+    Substrait_DateAttr, // Date
   ];
 }
 

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -656,7 +656,7 @@ SubstraitExporter::exportOperation(LiteralOp op) {
     literal->set_timestamp_tz(value.cast<TimestampTzAttr>().getValue());
   }
   // `DateType`.
-  else if (auto binaryType = dyn_cast<DateType>(literalType)) {
+  else if (auto dateType = dyn_cast<DateType>(literalType)) {
     literal->set_date(value.cast<DateAttr>().getValue());
   } else
     op->emitOpError("has unsupported value");

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -253,7 +253,7 @@ SubstraitExporter::exportType(Location loc, mlir::Type mlirType) {
   }
 
   // Handle date.
-  if (mlirType.isa<DateType>()) {
+  if (mlir::isa<DateType>(mlirType)) {
     // TODO(ingomueller): support other nullability modes.
     auto dateType = std::make_unique<proto::Type::Date>();
     dateType->set_nullability(
@@ -657,7 +657,7 @@ SubstraitExporter::exportOperation(LiteralOp op) {
   }
   // `DateType`.
   else if (auto dateType = dyn_cast<DateType>(literalType)) {
-    literal->set_date(value.cast<DateAttr>().getValue());
+    literal->set_date(mlir::cast<DateAttr>(value).getValue());
   } else
     op->emitOpError("has unsupported value");
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -116,6 +116,8 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
     return TimestampType::get(context);
   case proto::Type::kTimestampTz:
     return TimestampTzType::get(context);
+  case proto::Type::kDate:
+    return DateType::get(context);
   case proto::Type::kStruct: {
     const proto::Type::Struct &structType = type.struct_();
     llvm::SmallVector<mlir::Type> fieldTypes;
@@ -350,6 +352,10 @@ importLiteral(ImplicitLocOpBuilder builder,
   }
   case Expression::Literal::LiteralTypeCase::kTimestampTz: {
     auto attr = TimestampTzAttr::get(context, message.timestamp_tz());
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kDate: {
+    auto attr = DateAttr::get(context, message.date());
     return builder.create<LiteralOp>(attr);
   }
   // TODO(ingomueller): Support more types.

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -4,6 +4,30 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.date> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000> : !substrait.date
+// CHECK-NEXT:      yield %[[V2]] : !substrait.date
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.date>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.date> {
+    ^bb0(%arg : tuple<si1>):
+      %date = literal #substrait.date<200000000> : !substrait.date
+      yield %date : !substrait.date
+    }
+    yield %1 : tuple<si1, !substrait.date> 
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> 

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,6 +3,20 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.date>
+// CHECK-NEXT:    yield %0 : tuple<!substrait.date>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.date>
+    yield %0 : tuple<!substrait.date>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
 // CHECK-NEXT:    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
   

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -20,6 +20,33 @@
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
+// CHECK-NEXT:            date: 200000000
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.date> {
+    ^bb0(%arg : tuple<si1>):
+      %date = literal #substrait.date<200000000> : !substrait.date
+      yield %date : !substrait.date
+    }
+    yield %1 : tuple<si1, !substrait.date> 
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        input {
+// CHECK-NEXT:          read {
+// CHECK:             expressions {
+// CHECK-NEXT:          literal {
 // CHECK-NEXT:            timestamp: 10000000000
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -47,6 +47,31 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp_tz {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp_tz>
+    yield %0 : tuple<!substrait.timestamp_tz>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              timestamp {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -14,6 +14,31 @@
 // CHECK-NEXT:      read {
 // CHECK:             base_schema {
 // CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              date {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.date>
+    yield %0 : tuple<!substrait.date>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          names: "b"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
@@ -45,6 +70,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      read {
 // CHECK:             base_schema {
 // CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          names: "b"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
 // CHECK-NEXT:              timestamp {

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -47,6 +47,11 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              timestamp_tz {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }
@@ -58,33 +63,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp_tz>
-    yield %0 : tuple<!substrait.timestamp_tz>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: relations {
-// CHECK-NEXT:    rel {
-// CHECK-NEXT:      read {
-// CHECK:             base_schema {
-// CHECK-NEXT:          names: "a"
-// CHECK-NEXT:          struct {
-// CHECK-NEXT:            types {
-// CHECK-NEXT:              timestamp {
-// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:              }
-// CHECK-NEXT:            }
-// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:        named_table {
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp>
-    yield %0 : tuple<!substrait.timestamp>
+    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -47,6 +47,31 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp>
+    yield %0 : tuple<!substrait.timestamp>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              binary {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -13,6 +13,60 @@
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.date> {
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000> : !substrait.date
+# CHECK-NEXT:      yield %[[V2]] : !substrait.date
+# CHECK-NEXT:    }
+# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.date>
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          date: 200000000
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us> 

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,6 +13,42 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
+# CHECK-SAME:       : tuple<!substrait.date>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            date {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan
+# CHECK-NEXT:   relation
+# CHECK-NEXT:     named_table
 # CHECK-SAME:       : tuple<!substrait.timestamp, !substrait.timestamp_tz>
 
 relations {


### PR DESCRIPTION
This PR introduces the `date` atomic type and its associated attribute types. The `date` type represents a calendar date within the range [1000-01-01..9999-12-31]. Internally, it is stored as an `int32` value representing the number of days since the epoch date (1970-01-01). 