### PR TITLE
feat: introduce `time` type

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -62,6 +62,28 @@ def Substrait_StringType : Substrait_Type<"String", "string"> {
   }];
 }
 
+def Substrait_TimeType : Substrait_Type<"Time", "time"> {
+  let summary = "Substrait time type";
+  let description = [{
+    This type represents a substrait time type. 
+  }];
+}
+
+def Substrait_TimeAttr : Substrait_Attr<"Time", "time", 
+[TypedAttrInterface]> {
+  let summary = "Substrait time type";
+  let description = [{
+    This type represents a substrait time attribute type.
+  }];  
+  let parameters = (ins "int64_t":$value);
+  let assemblyFormat = [{ `<` $value `` `us` `>` }];
+  let extraClassDeclaration = [{ 
+    ::mlir::Type getType() const {
+      return TimeType::get(getContext());
+    }
+  }];
+}
+
 def Substrait_TimestampType : Substrait_Type<"Timestamp", "timestamp"> {
   let summary = "Substrait timezone-unaware timestamp type";
   let description = [{
@@ -107,7 +129,6 @@ def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz",
 }
 
 /// Currently supported atomic types, listed in order of substrait specification. 
-/// These correspond directly to the types in
 /// https://github.com/substrait-io/substrait/blob/main/proto/substrait/type.proto.
 // TODO(ingomueller): Add the other low-hanging fruits here.
 def Substrait_AtomicTypes {
@@ -124,6 +145,7 @@ def Substrait_AtomicTypes {
     Substrait_TimestampType, // Timestamp
     Substrait_TimestampTzType, // TimestampTZ
     Substrait_DateType, // Date
+    Substrait_TimeType, // Time
   ];
 }
 
@@ -143,6 +165,7 @@ def Substrait_AtomicAttributes {
     Substrait_TimestampAttr, // Timestamp
     Substrait_TimestampTzAttr, // TimestampTZ
     Substrait_DateAttr, // Date
+    Substrait_TimeAttr, // Time
   ];
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -129,6 +129,7 @@ def Substrait_TimestampTzAttr : Substrait_Attr<"TimestampTz", "timestamp_tz",
 }
 
 /// Currently supported atomic types, listed in order of substrait specification. 
+/// These correspond directly to the types in
 /// https://github.com/substrait-io/substrait/blob/main/proto/substrait/type.proto.
 // TODO(ingomueller): Add the other low-hanging fruits here.
 def Substrait_AtomicTypes {

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -275,6 +275,18 @@ SubstraitExporter::exportType(Location loc, mlir::Type mlirType) {
     return std::move(type);
   }
 
+  // Handle time.
+  if (mlir::isa<TimeType>(mlirType)) {
+    // TODO(ingomueller): support other nullability modes.
+    auto timeType = std::make_unique<proto::Type::Time>();
+    timeType->set_nullability(
+        Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED);
+
+    auto type = std::make_unique<proto::Type>();
+    type->set_allocated_time(timeType.release());
+    return std::move(type);
+  }
+
   // Handle tuple types.
   if (auto tupleType = llvm::dyn_cast<TupleType>(mlirType)) {
     auto structType = std::make_unique<proto::Type::Struct>();
@@ -669,6 +681,10 @@ SubstraitExporter::exportOperation(LiteralOp op) {
   // `DateType`.
   else if (auto dateType = dyn_cast<DateType>(literalType)) {
     literal->set_date(mlir::cast<DateAttr>(value).getValue());
+  }
+  // `TimeType`.
+  else if (auto timeType = dyn_cast<TimeType>(literalType)) {
+    literal->set_time(value.cast<TimeAttr>().getValue());
   } else
     op->emitOpError("has unsupported value");
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -127,6 +127,8 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
     return TimestampTzType::get(context);
   case proto::Type::kDate:
     return DateType::get(context);
+  case proto::Type::kTime:
+    return TimeType::get(context);
   case proto::Type::kStruct: {
     const proto::Type::Struct &structType = type.struct_();
     llvm::SmallVector<mlir::Type> fieldTypes;
@@ -365,6 +367,10 @@ importLiteral(ImplicitLocOpBuilder builder,
   }
   case Expression::Literal::LiteralTypeCase::kDate: {
     auto attr = DateAttr::get(context, message.date());
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kTime: {
+    auto attr = TimeAttr::get(context, message.time());
     return builder.create<LiteralOp>(attr);
   }
   // TODO(ingomueller): Support more types.

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -4,6 +4,30 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.time> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us> : !substrait.time
+// CHECK-NEXT:      yield %[[V2]] : !substrait.time
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.time> 
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.time> {
+    ^bb0(%arg : tuple<si1>):
+      %time = literal #substrait.time<200000000us> : !substrait.time
+      yield %time : !substrait.time
+    }
+    yield %1 : tuple<si1, !substrait.time> 
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.date> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000> : !substrait.date

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,6 +3,20 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.time>
+// CHECK-NEXT:    yield %0 : tuple<!substrait.time>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.time>
+    yield %0 : tuple<!substrait.time>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.date>
 // CHECK-NEXT:    yield %0 : tuple<!substrait.date>
 

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -20,6 +20,35 @@
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
+// CHECK-NEXT:            time: 200000000
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.time> {
+    ^bb0(%arg : tuple<si1>):
+      %time = literal #substrait.time<200000000us> : !substrait.time
+      yield %time : !substrait.time
+    }
+    yield %1 : tuple<si1, !substrait.time> 
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        input {
+// CHECK-NEXT:          read {
+// CHECK:             expressions {
+// CHECK-NEXT:          literal {
 // CHECK-NEXT:            date: 200000000
 
 substrait.plan version 0 : 42 : 1 {

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -103,6 +103,31 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp_tz {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp_tz>
+    yield %0 : tuple<!substrait.timestamp_tz>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              timestamp {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -16,6 +16,31 @@
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              time {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.time>
+    yield %0 : tuple<!substrait.time>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              date {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -103,6 +103,11 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              timestamp_tz {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }
@@ -114,33 +119,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp_tz>
-    yield %0 : tuple<!substrait.timestamp_tz>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: relations {
-// CHECK-NEXT:    rel {
-// CHECK-NEXT:      read {
-// CHECK:             base_schema {
-// CHECK-NEXT:          names: "a"
-// CHECK-NEXT:          struct {
-// CHECK-NEXT:            types {
-// CHECK-NEXT:              timestamp {
-// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:              }
-// CHECK-NEXT:            }
-// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:        named_table {
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp>
-    yield %0 : tuple<!substrait.timestamp>
+    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -103,6 +103,31 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              timestamp {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.timestamp>
+    yield %0 : tuple<!substrait.timestamp>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              binary {
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
 // CHECK-NEXT:              }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -70,67 +70,6 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      read {
 // CHECK:             base_schema {
 // CHECK-NEXT:          names: "a"
-// CHECK-NEXT:          names: "b"
-// CHECK-NEXT:          struct {
-// CHECK-NEXT:            types {
-// CHECK-NEXT:              timestamp {
-// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:              }
-// CHECK-NEXT:            }
-// CHECK-NEXT:            types {
-// CHECK-NEXT:              timestamp_tz {
-// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:              }
-// CHECK-NEXT:            }
-// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:        named_table {
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: relations {
-// CHECK-NEXT:    rel {
-// CHECK-NEXT:      read {
-// CHECK:             base_schema {
-// CHECK-NEXT:          names: "a"
-// CHECK-NEXT:          struct {
-// CHECK-NEXT:            types {
-// CHECK-NEXT:              timestamp {
-// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:              }
-// CHECK-NEXT:            }
-// CHECK-NEXT:            types {
-// CHECK-NEXT:              timestamp_tz {
-// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:              }
-// CHECK-NEXT:            }
-// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:        named_table {
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: relations {
-// CHECK-NEXT:    rel {
-// CHECK-NEXT:      read {
-// CHECK:             base_schema {
-// CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
 // CHECK-NEXT:              binary {

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -13,6 +13,60 @@
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.time> {
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us> : !substrait.time
+# CHECK-NEXT:      yield %[[V2]] : !substrait.time
+# CHECK-NEXT:    }
+# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.time>
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          time: 200000000
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.date> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000> : !substrait.date

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,6 +13,42 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
+# CHECK-SAME:       : tuple<!substrait.time>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            time {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan
+# CHECK-NEXT:   relation
+# CHECK-NEXT:     named_table
 # CHECK-SAME:       : tuple<!substrait.date>
 
 relations {


### PR DESCRIPTION
Implements `time` type and attribute types. Tests again added for types but not for attribute types - waiting on [this PR ](https://github.com/substrait-io/substrait-mlir-contrib/pull/39) to be merged and then will add those tests to project.mlir test file (similarly to integer, float, string, binary, date etc. types)!  

This is a stacked PR, please only review latest commit (09e06f778fef22a3f051847e54e5c06fa1bf9e76)