### PR TITLE
feat: introduce `interval_year` and `interval_day` types

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -75,24 +75,26 @@ def Substrait_IntervalDaySecondAttr
                                     "IntervalDaySecondType"> {
   let summary = "Substrait interval day to second type";
   let description = [{
-    This type represents a substrait interval day to second attribute type. Note that this
-    attribute does not attempt to canonicalize equivalent day-second intervals.
-  }];  
-  let parameters = (ins "int32_t":$days_value, "int32_t":$seconds_value);
-  let assemblyFormat = [{ `<` $days_value `` `d` $seconds_value `` `s` `>` }];
+    This type represents a substrait interval day to second attribute type. Note
+    that this attribute does not attempt to canonicalize equivalent day-second
+    intervals.
+  }];
+  let parameters = (ins "int32_t":$days, "int32_t":$seconds);
+  let assemblyFormat = [{ `<` $days `` `d` $seconds `` `s` `>` }];
   let genVerifyDecl = 1;
 }
 
-def Substrait_IntervalYearMonthAttr 
+def Substrait_IntervalYearMonthAttr
     : Substrait_StaticallyTypedAttr<"IntervalYearMonth", "interval_year_month",
                                     "IntervalYearMonthType"> {
   let summary = "Substrait interval year to month type";
   let description = [{
-    This type represents a substrait interval year to month attribute type. Note that this
-    attribute does not attempt to canonicalize equivalent year-month intervals.
-  }];  
-  let parameters = (ins "int32_t":$years_value, "int32_t":$months_value);
-  let assemblyFormat = [{ `<` $years_value `` `y` $months_value `` `m` `>` }];
+    This type represents a substrait interval year to month attribute type. Note
+    that this attribute does not attempt to canonicalize equivalent year-month
+    intervals.
+  }];
+  let parameters = (ins "int32_t":$years, "int32_t":$months);
+  let assemblyFormat = [{ `<` $years `` `y` $months `` `m` `>` }];
   let genVerifyDecl = 1;
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -75,10 +75,12 @@ def Substrait_IntervalDaySecondAttr
                                     "IntervalDaySecondType"> {
   let summary = "Substrait interval day to second type";
   let description = [{
-    This type represents a substrait interval day to second attribute type.
+    This type represents a substrait interval day to second attribute type. Note that this
+    attribute does not attempt to canonicalize equivalent day-second intervals.
   }];  
   let parameters = (ins "int32_t":$days_value, "int32_t":$seconds_value);
   let assemblyFormat = [{ `<` $days_value `` `d` $seconds_value `` `s` `>` }];
+  let genVerifyDecl = 1;
 }
 
 def Substrait_IntervalYearMonthAttr 
@@ -86,10 +88,12 @@ def Substrait_IntervalYearMonthAttr
                                     "IntervalYearMonthType"> {
   let summary = "Substrait interval year to month type";
   let description = [{
-    This type represents a substrait interval year to month attribute type.
+    This type represents a substrait interval year to month attribute type. Note that this
+    attribute does not attempt to canonicalize equivalent year-month intervals.
   }];  
   let parameters = (ins "int32_t":$years_value, "int32_t":$months_value);
   let assemblyFormat = [{ `<` $years_value `` `y` $months_value `` `m` `>` }];
+  let genVerifyDecl = 1;
 }
 
 def Substrait_TimeAttr

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -70,6 +70,28 @@ def Substrait_DateAttr
   let assemblyFormat = [{ `<` $value `>` }];
 }
 
+def Substrait_IntervalDaySecondAttr
+    : Substrait_StaticallyTypedAttr<"IntervalDaySecond", "interval_day_second",
+                                    "IntervalDaySecondType"> {
+  let summary = "Substrait interval day to second type";
+  let description = [{
+    This type represents a substrait interval day to second attribute type.
+  }];  
+  let parameters = (ins "int32_t":$days_value, "int32_t":$seconds_value);
+  let assemblyFormat = [{ `<` $days_value `` `d` $seconds_value `` `s` `>` }];
+}
+
+def Substrait_IntervalYearMonthAttr 
+    : Substrait_StaticallyTypedAttr<"IntervalYearMonth", "interval_year_month",
+                                    "IntervalYearMonthType"> {
+  let summary = "Substrait interval year to month type";
+  let description = [{
+    This type represents a substrait interval year to month attribute type.
+  }];  
+  let parameters = (ins "int32_t":$years_value, "int32_t":$months_value);
+  let assemblyFormat = [{ `<` $years_value `` `y` $months_value `` `m` `>` }];
+}
+
 def Substrait_TimeAttr
     : Substrait_StaticallyTypedAttr<"Time", "time", "TimeType"> {
   let summary = "Substrait time type";
@@ -156,6 +178,8 @@ def Substrait_AtomicAttributes {
     Substrait_TimestampTzAttr, // TimestampTZ
     Substrait_DateAttr, // Date
     Substrait_TimeAttr, // Time
+    Substrait_IntervalYearMonthAttr, // IntervalYear
+    Substrait_IntervalDaySecondAttr, // IntervalDay
   ];
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -33,6 +33,20 @@ def Substrait_DateType : Substrait_Type<"Date", "date"> {
   }];
 }
 
+def Substrait_IntervalDaySecondType : Substrait_Type<"IntervalDaySecond", "interval_day_second"> {
+  let summary = "Substrait interval day to second type";
+  let description = [{
+    This type represents a substrait interval day to second type. 
+  }];
+}
+
+def Substrait_IntervalYearMonthType : Substrait_Type<"IntervalYearMonth", "interval_year_month"> {
+  let summary = "Substrait interval year to month type";
+  let description = [{
+    This type represents a substrait interval year to month type. 
+  }];
+}
+
 def Substrait_StringType : Substrait_Type<"String", "string"> {
   let summary = "Substrait string type";
   let description = [{
@@ -79,6 +93,8 @@ def Substrait_AtomicTypes {
     Substrait_TimestampTzType, // TimestampTZ
     Substrait_DateType, // Date
     Substrait_TimeType, // Time
+    Substrait_IntervalYearMonthType, // IntervalYear
+    Substrait_IntervalDaySecondType, // IntervalDay
   ];
 }
 

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -68,20 +68,22 @@ LogicalResult AdvancedExtensionAttr::verify(
   return success();
 }
 
-
-LogicalResult mlir::substrait::IntervalYearMonthAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic ()> emitError,
- int32_t year, int32_t month){
+LogicalResult mlir::substrait::IntervalYearMonthAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError, int32_t year,
+    int32_t month) {
   if (year < -100000 || year > 100000)
     return emitError() << "year must be in a range of [-10,000..10,000] years";
   return success();
- }
+}
 
-LogicalResult mlir::substrait::IntervalDaySecondAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic ()> emitError, 
- int32_t days, int32_t seconds){
+LogicalResult mlir::substrait::IntervalDaySecondAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError, int32_t days,
+    int32_t seconds) {
   if (days < -3650000 || days > 3650000)
-    return emitError() << "days must be in a range of [-3,650,000..3,650,000] days";
+    return emitError()
+           << "days must be in a range of [-3,650,000..3,650,000] days";
   return success();
- }
+}
 
 //===----------------------------------------------------------------------===//
 // Substrait enums

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -73,6 +73,9 @@ LogicalResult mlir::substrait::IntervalYearMonthAttr::verify(
     int32_t month) {
   if (year < -100000 || year > 100000)
     return emitError() << "year must be in a range of [-10,000..10,000] years";
+  if (month < -120000 || month > 120000)
+    return emitError()
+           << "month must be in a range of [120,000..120,000] months";
   return success();
 }
 

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -68,6 +68,21 @@ LogicalResult AdvancedExtensionAttr::verify(
   return success();
 }
 
+
+LogicalResult mlir::substrait::IntervalYearMonthAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic ()> emitError,
+ int32_t year, int32_t month){
+  if (year < -100000 || year > 100000)
+    return emitError() << "year must be in a range of [-10,000..10,000] years";
+  return success();
+ }
+
+LogicalResult mlir::substrait::IntervalDaySecondAttr::verify(llvm::function_ref<mlir::InFlightDiagnostic ()> emitError, 
+ int32_t days, int32_t seconds){
+  if (days < -3650000 || days > 3650000)
+    return emitError() << "days must be in a range of [-3,650,000..3,650,000] days";
+  return success();
+ }
+
 //===----------------------------------------------------------------------===//
 // Substrait enums
 //===----------------------------------------------------------------------===//

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -933,8 +933,8 @@ SubstraitExporter::exportOperation(LiteralOp op) {
     auto intervalYearToMonth = std::make_unique<
         ::substrait::proto::Expression_Literal_IntervalYearToMonth>();
     auto intervalYearMonth = mlir::cast<IntervalYearMonthAttr>(value);
-    int32_t intervalYear = intervalYearMonth.getYearsValue();
-    int32_t intervalMonth = intervalYearMonth.getMonthsValue();
+    int32_t intervalYear = intervalYearMonth.getYears();
+    int32_t intervalMonth = intervalYearMonth.getMonths();
     intervalYearToMonth->set_years(intervalYear);
     intervalYearToMonth->set_months(intervalMonth);
     literal->set_allocated_interval_year_to_month(
@@ -943,8 +943,8 @@ SubstraitExporter::exportOperation(LiteralOp op) {
     auto intervalDaytoSecond = std::make_unique<
         ::substrait::proto::Expression_Literal_IntervalDayToSecond>();
     auto intervalDaySecond = mlir::cast<IntervalDaySecondAttr>(value);
-    int32_t intervalDay = intervalDaySecond.getDaysValue();
-    int32_t intervalSecond = intervalDaySecond.getSecondsValue();
+    int32_t intervalDay = intervalDaySecond.getDays();
+    int32_t intervalSecond = intervalDaySecond.getSeconds();
     intervalDaytoSecond->set_days(intervalDay);
     intervalDaytoSecond->set_seconds(intervalSecond);
     literal->set_allocated_interval_day_to_second(

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -929,13 +929,12 @@ SubstraitExporter::exportOperation(LiteralOp op) {
     literal->set_time(mlir::cast<TimeAttr>(value).getValue());
   }
   // `IntervalType`'s.
-  else if (auto timeType = dyn_cast<IntervalYearMonthType>(literalType)) {
+  else if (auto intervalType = dyn_cast<IntervalYearMonthType>(literalType)) {
     auto intervalYearToMonth = std::make_unique<
         ::substrait::proto::Expression_Literal_IntervalYearToMonth>();
-    auto intervalYear =
-        mlir::cast<IntervalYearMonthAttr>(value).getYearsValue();
-    auto intervalMonth =
-        mlir::cast<IntervalYearMonthAttr>(value).getMonthsValue();
+    auto intervalYearMonth = mlir::cast<IntervalYearMonthAttr>(value);
+    int32_t intervalYear = intervalYearMonth.getYearsValue();
+    int32_t intervalMonth = intervalYearMonth.getMonthsValue();
     intervalYearToMonth->set_years(intervalYear);
     intervalYearToMonth->set_months(intervalMonth);
     literal->set_allocated_interval_year_to_month(
@@ -943,9 +942,9 @@ SubstraitExporter::exportOperation(LiteralOp op) {
   } else if (auto timeType = dyn_cast<IntervalDaySecondType>(literalType)) {
     auto intervalDaytoSecond = std::make_unique<
         ::substrait::proto::Expression_Literal_IntervalDayToSecond>();
-    auto intervalDay = mlir::cast<IntervalDaySecondAttr>(value).getDaysValue();
-    auto intervalSecond =
-        mlir::cast<IntervalDaySecondAttr>(value).getSecondsValue();
+    auto intervalDaySecond = mlir::cast<IntervalDaySecondAttr>(value);
+    int32_t intervalDay = intervalDaySecond.getDaysValue();
+    int32_t intervalSecond = intervalDaySecond.getSecondsValue();
     intervalDaytoSecond->set_days(intervalDay);
     intervalDaytoSecond->set_seconds(intervalSecond);
     literal->set_allocated_interval_day_to_second(

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -339,6 +339,29 @@ SubstraitExporter::exportType(Location loc, mlir::Type mlirType) {
     return std::move(type);
   }
 
+  // Handle interval_year.
+  if (mlir::isa<IntervalYearMonthType>(mlirType)) {
+    // TODO(ingomueller): support other nullability modes.
+    auto intervalYearType = std::make_unique<proto::Type::IntervalYear>();
+    intervalYearType->set_nullability(
+        Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED);
+
+    auto type = std::make_unique<proto::Type>();
+    type->set_allocated_interval_year(intervalYearType.release());
+    return std::move(type);
+  }
+  // Handle interval_day.
+  if (mlir::isa<IntervalDaySecondType>(mlirType)) {
+    // TODO(ingomueller): support other nullability modes.
+    auto intervalDayType = std::make_unique<proto::Type::IntervalDay>();
+    intervalDayType->set_nullability(
+        Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED);
+
+    auto type = std::make_unique<proto::Type>();
+    type->set_allocated_interval_day(intervalDayType.release());
+    return std::move(type);
+  }
+
   // Handle tuple types.
   if (auto tupleType = llvm::dyn_cast<TupleType>(mlirType)) {
     auto structType = std::make_unique<proto::Type::Struct>();
@@ -904,6 +927,29 @@ SubstraitExporter::exportOperation(LiteralOp op) {
   // `TimeType`.
   else if (auto timeType = dyn_cast<TimeType>(literalType)) {
     literal->set_time(mlir::cast<TimeAttr>(value).getValue());
+  }
+  // `IntervalType`'s.
+  else if (auto timeType = dyn_cast<IntervalYearMonthType>(literalType)) {
+    auto intervalYearToMonth = std::make_unique<
+        ::substrait::proto::Expression_Literal_IntervalYearToMonth>();
+    auto intervalYear =
+        mlir::cast<IntervalYearMonthAttr>(value).getYearsValue();
+    auto intervalMonth =
+        mlir::cast<IntervalYearMonthAttr>(value).getMonthsValue();
+    intervalYearToMonth->set_years(intervalYear);
+    intervalYearToMonth->set_months(intervalMonth);
+    literal->set_allocated_interval_year_to_month(
+        intervalYearToMonth.release());
+  } else if (auto timeType = dyn_cast<IntervalDaySecondType>(literalType)) {
+    auto intervalDaytoSecond = std::make_unique<
+        ::substrait::proto::Expression_Literal_IntervalDayToSecond>();
+    auto intervalDay = mlir::cast<IntervalDaySecondAttr>(value).getDaysValue();
+    auto intervalSecond =
+        mlir::cast<IntervalDaySecondAttr>(value).getSecondsValue();
+    intervalDaytoSecond->set_days(intervalDay);
+    intervalDaytoSecond->set_seconds(intervalSecond);
+    literal->set_allocated_interval_day_to_second(
+        intervalDaytoSecond.release());
   } else
     op->emitOpError("has unsupported value");
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -207,6 +207,10 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
     return DateType::get(context);
   case proto::Type::kTime:
     return TimeType::get(context);
+  case proto::Type::kIntervalYear:
+    return IntervalYearMonthType::get(context);
+  case proto::Type::kIntervalDay:
+    return IntervalDaySecondType::get(context);
   case proto::Type::kStruct: {
     const proto::Type::Struct &structType = type.struct_();
     llvm::SmallVector<mlir::Type> fieldTypes;
@@ -646,6 +650,18 @@ importLiteral(ImplicitLocOpBuilder builder,
   }
   case Expression::Literal::LiteralTypeCase::kTime: {
     auto attr = TimeAttr::get(context, message.time());
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kIntervalYearToMonth: {
+    auto attr = IntervalYearMonthAttr::get(
+        context, message.interval_year_to_month().years(),
+        message.interval_year_to_month().months());
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kIntervalDayToSecond: {
+    auto attr = IntervalDaySecondAttr::get(
+        context, message.interval_day_to_second().days(),
+        message.interval_day_to_second().seconds());
     return builder.create<LiteralOp>(attr);
   }
   // TODO(ingomueller): Support more types.

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -4,6 +4,32 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>{{$}}
+// CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>{{$}}
+// CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    ^bb0(%arg : tuple<si1>):
+      %interval_year_month = literal #substrait.interval_year_month<2024y 1m> 
+      %interval_day_second = literal #substrait.interval_day_second<9d 8000s> 
+      yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
+    }
+    yield %1 : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.time> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>{{$}}

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,6 +3,20 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK-NEXT:    yield %0 : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+    yield %0 : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.time>
 // CHECK-NEXT:    yield %0 : tuple<!substrait.time>
 

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -20,6 +20,44 @@
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
+// CHECK-NEXT:            interval_year_to_month {
+// CHECK-NEXT:              years: 2024
+// CHECK-NEXT:              months: 1
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        expressions {
+// CHECK-NEXT:          literal {
+// CHECK-NEXT:            interval_day_to_second {
+// CHECK-NEXT:              days: 9
+// CHECK-NEXT:              seconds: 8000
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    ^bb0(%arg : tuple<si1>):
+      %interval_year_month = literal #substrait.interval_year_month<2024y 1m> 
+      %interval_day_second = literal #substrait.interval_day_second<9d 8000s> 
+      yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
+    }
+    yield %1 : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        input {
+// CHECK-NEXT:          read {
+// CHECK:             expressions {
+// CHECK-NEXT:          literal {
 // CHECK-NEXT:            time: 200000000
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -14,6 +14,37 @@
 // CHECK-NEXT:      read {
 // CHECK:             base_schema {
 // CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          names: "b"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              interval_year {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              interval_day {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+    yield %0 : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
 // CHECK-NEXT:              time {

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -13,6 +13,72 @@
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>
+# CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>
+# CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
+# CHECK-NEXT:    }
+# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          interval_year_to_month {
+            years: 2024
+            months: 1
+          }
+        }
+      }
+      expressions {
+        literal {
+          interval_day_to_second {
+            days: 9
+            seconds: 8000
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.time> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,6 +13,48 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
+# CHECK-SAME:       : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        names: "b"
+        struct {
+          types {
+            interval_year {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          types {
+            interval_day {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan
+# CHECK-NEXT:   relation
+# CHECK-NEXT:     named_table
 # CHECK-SAME:       : tuple<!substrait.time>
 
 relations {


### PR DESCRIPTION
This PR introduces two new atomic interval types:

1) Interval Year to Month
Supports a range of [-10,000..10,000] years, with month-level precision. Typically stored as separate integers for years and months (e.g., 12y 3m), but only the total number of months is considered significant. For example, 1y 0m is equivalent to 0y 12m or 1001y -12000m.
2) Interval Day to Second
Supports a range of [-3,650,000..3,650,000] days, with second precision. Typically stored as separate integers for days and seconds, but only the total number of seconds is considered significant. For example, 1d 0s is equivalent to 0d 86400s.