### PR TITLE
chore: fix all test file spacing issues and remove redundant split input file lines

### DIFF
--- a/test/Dialect/Substrait/fetch.mlir
+++ b/test/Dialect/Substrait/fetch.mlir
@@ -16,6 +16,8 @@ substrait.plan version 0 : 42 : 1 {
   }
 }
 
+// -----
+
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
@@ -30,6 +32,8 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si32>
   }
 }
+
+// -----
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
@@ -46,6 +50,8 @@ substrait.plan version 0 : 42 : 1 {
   }
 }
 
+// -----
+
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
@@ -60,6 +66,8 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si32>
   }
 }
+
+// -----
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation

--- a/test/Dialect/Substrait/named-table-invalid.mlir
+++ b/test/Dialect/Substrait/named-table-invalid.mlir
@@ -22,7 +22,6 @@ substrait.plan version 0 : 42 : 1 {
   }
 }
 
-
 // -----
 
 // Test error if providing duplicate field names in the same nesting level.

--- a/test/Dialect/Substrait/named-table.mlir
+++ b/test/Dialect/Substrait/named-table.mlir
@@ -5,6 +5,7 @@
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as [] : tuple<>
 // CHECK-NEXT:    yield %[[V0]] :
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as [] : tuple<>
@@ -18,6 +19,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<si32>
 // CHECK-NEXT:    yield %[[V0]] :
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
@@ -31,6 +33,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<si32, si32>
 // CHECK-NEXT:    yield %[[V0]] :
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
@@ -45,6 +48,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         %[[V0:.*]] = named_table @t1
 // CHECK-SAME:      as ["outer", "inner"] : tuple<tuple<si32>>
 // CHECK-NEXT:    yield %[[V0]] :
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["outer", "inner"] : tuple<tuple<si32>>
@@ -59,6 +63,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         %[[V0:.*]] = named_table @t1
 // CHECK-SAME:      as ["a", "a"] : tuple<tuple<si32>>
 // CHECK-NEXT:    yield %[[V0]] :
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "a"] : tuple<tuple<si32>>

--- a/test/Dialect/Substrait/plan.mlir
+++ b/test/Dialect/Substrait/plan.mlir
@@ -4,6 +4,7 @@
 // CHECK:      substrait.plan version 0 : 42 : 1
 // CHECK-SAME:   git_hash "hash" producer "producer" {
 // CHECK-NEXT: }
+
 substrait.plan
   version 0 : 42 : 1
   git_hash "hash"
@@ -18,6 +19,7 @@ substrait.plan
 // CHECK-NEXT:     yield
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @foo::@bar as ["a", "b"] : tuple<si32, si32>
@@ -37,6 +39,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:     yield
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @foo::@bar as ["a", "b"] : tuple<si32, si32>
@@ -74,6 +77,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   extension_uri @other.extension at "http://other.url/with/more/extensions.yml"
 // CHECK-NEXT:   extension_function @other.function at @other.extension["someotherfunc"]
 // CHECK-NEXT: }
+
 substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]

--- a/test/Dialect/Substrait/project-invalid.mlir
+++ b/test/Dialect/Substrait/project-invalid.mlir
@@ -14,6 +14,7 @@ substrait.plan version 0 : 42 : 1 {
 }
 
 // -----
+
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>

--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -15,6 +15,7 @@
 // CHECK-DAG:     git_hash: "hash"
 // CHECK-DAG:     producer: "producer"
 // CHECK-NEXT:  }
+
 substrait.plan
   version 0 : 42 : 1
   git_hash "hash"
@@ -112,7 +113,6 @@ substrait.plan version 0 : 42 : 1 {
 }
 
 // -----
-
 
 // CHECK:      extension_uris {
 // CHECK-NEXT:   uri: "http://some.url/with/extensions.yml"

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -13,6 +13,7 @@
 # CHECK-LABEL: substrait.plan version 0 : 42 : 1
 # CHECK-SAME:    git_hash "hash" producer "producer" {
 # CHECK-NEXT:  }
+
 version {
   minor_number: 42
   patch_number: 1
@@ -26,6 +27,7 @@ version {
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<si32, si32>
 # CHECK-NEXT:      yield %[[V0]] : tuple<si32, si32>
+
 relations {
   rel {
     read {


### PR DESCRIPTION
Saw some spacing errors in one test file and then decided I might as well go through all the test files and fixed all the spacing issues as well as removed redundant "split input file" lines from some of the tests. 