### PR TITLE
chore: move `jointype` enums to enums.td file

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -15,19 +15,6 @@ def AggregationInvocationUnspecified: I32EnumAttrCase<"unspecified", 0>;
 def AggregationInvocationAll: I32EnumAttrCase<"all", 1>;
 def AggregationInvocationDistinct: I32EnumAttrCase<"distinct", 2>;
 
-/// Represents the `SetOp` protobuf enum.
-def SetOpKind : I32EnumAttr<"SetOpKind",
-  "The enum values correspond to those in the SetRel.SetOp message.", [
-    I32EnumAttrCase<"unspecified", 0>,
-    I32EnumAttrCase<"minus_primary", 1>,
-    I32EnumAttrCase<"minus_multiset", 2>,
-    I32EnumAttrCase<"intersection_primary", 3>,
-    I32EnumAttrCase<"intersection_multiset", 4>,
-    I32EnumAttrCase<"union_distinct", 5>,
-    I32EnumAttrCase<"union_all", 6>] > {
-    let cppNamespace = "::mlir::substrait";
-}
-
 /// Represents the `JoinType` protobuf enum.
 def JoinTypeKind : I32EnumAttr<"JoinTypeKind",
   "The enum values correspond to those in the JoinRel.JoinType message.", [
@@ -39,6 +26,19 @@ def JoinTypeKind : I32EnumAttr<"JoinTypeKind",
     I32EnumAttrCase<"semi", 5>,
     I32EnumAttrCase<"anti", 6>,
     I32EnumAttrCase<"single", 7>] > {
+    let cppNamespace = "::mlir::substrait";
+}
+
+/// Represents the `SetOp` protobuf enum.
+def SetOpKind : I32EnumAttr<"SetOpKind",
+  "The enum values correspond to those in the SetRel.SetOp message.", [
+    I32EnumAttrCase<"unspecified", 0>,
+    I32EnumAttrCase<"minus_primary", 1>,
+    I32EnumAttrCase<"minus_multiset", 2>,
+    I32EnumAttrCase<"intersection_primary", 3>,
+    I32EnumAttrCase<"intersection_multiset", 4>,
+    I32EnumAttrCase<"union_distinct", 5>,
+    I32EnumAttrCase<"union_all", 6>] > {
     let cppNamespace = "::mlir::substrait";
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -28,4 +28,18 @@ def SetOpKind : I32EnumAttr<"SetOpKind",
     let cppNamespace = "::mlir::substrait";
 }
 
+/// Represents the `JoinType` protobuf enum.
+def JoinTypeKind : I32EnumAttr<"JoinTypeKind",
+  "The enum values correspond to those in the JoinRel.JoinType message.", [
+    I32EnumAttrCase<"unspecified", 0>,
+    I32EnumAttrCase<"inner", 1>,
+    I32EnumAttrCase<"outer", 2>,
+    I32EnumAttrCase<"left", 3>,
+    I32EnumAttrCase<"right", 4>,
+    I32EnumAttrCase<"semi", 5>,
+    I32EnumAttrCase<"anti", 6>,
+    I32EnumAttrCase<"single", 7>] > {
+    let cppNamespace = "::mlir::substrait";
+}
+
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITENUMS

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -476,17 +476,6 @@ def Substrait_FilterOp : Substrait_RelOp<"filter", [
   }];
 }
 
-def JoinTypeKind : I32EnumAttr<"JoinTypeKind",
-  "The enum values correspond to those in the JoinRel.JoinType message.", [
-    I32EnumAttrCase<"unspecified", 0>,
-    I32EnumAttrCase<"inner", 1>,
-    I32EnumAttrCase<"outer", 2>,
-    I32EnumAttrCase<"left", 3>,
-    I32EnumAttrCase<"right", 4>,
-    I32EnumAttrCase<"semi", 5>,
-    I32EnumAttrCase<"anti", 6>,
-    I32EnumAttrCase<"single", 7>] >;
-
 def Substrait_JoinOp : Substrait_RelOp<"join", [DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "join operation";
   let description = [{


### PR DESCRIPTION
Moves`jointype` enums to enums.td file as discussed.