### PR TITLE
test: extend `Plan` tests to cover `RootRel` and `Rel` cases properly

### DIFF
--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -38,12 +38,25 @@ substrait.plan
 // CHECK-NEXT:     names: "z"
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+// CHECK-NEXT: relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     read {
+// CHECK:            named_table {
+// CHECK-NEXT:         names
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
 // CHECK-NEXT: version
 
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
     %0 = named_table @t as ["a", "b", "c"] : tuple<si32, tuple<si32>>
     yield %0 : tuple<si32, tuple<si32>>
+  }
+  relation  {
+    %0 = named_table @t as ["a"] : tuple<si32>
+    yield %0 : tuple<si32>
   }
 }
 

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -24,10 +24,54 @@ version {
 # -----
 
 # CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation as ["x", "y", "z"] {
+# CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : tuple<si32, tuple<si32>>
+# CHECK-NEXT:      yield %[[V0]] : tuple<si32, tuple<si32>>
+# CHECK-NEXT:    }
 # CHECK-NEXT:    relation {
-# CHECK-NEXT:      %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<si32, si32>
-# CHECK-NEXT:      yield %[[V0]] : tuple<si32, si32>
+# CHECK-NEXT:      %[[V1:.*]] = named_table @t as ["a"] : tuple<si32>
+# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
 
+relations {
+  root {
+    input {
+      read {
+        common {
+          direct {
+          }
+        }
+        base_schema {
+          names: "a"
+          names: "b"
+          names: "c"
+          struct {
+            types {
+              i32 {
+                nullability: NULLABILITY_REQUIRED
+              }
+            }
+            types {
+              struct {
+                types {
+                  i32 {
+                    nullability: NULLABILITY_REQUIRED
+                  }
+                }
+              }
+            }
+            nullability: NULLABILITY_REQUIRED
+          }
+        }
+        named_table {
+          names: "t"
+        }
+      }
+    }
+    names: "x"
+    names: "y"
+    names: "z"
+  }
+}
 relations {
   rel {
     read {
@@ -37,13 +81,7 @@ relations {
       }
       base_schema {
         names: "a"
-        names: "b"
         struct {
-          types {
-            i32 {
-              nullability: NULLABILITY_REQUIRED
-            }
-          }
           types {
             i32 {
               nullability: NULLABILITY_REQUIRED
@@ -53,7 +91,7 @@ relations {
         }
       }
       named_table {
-        names: "t1"
+        names: "t"
       }
     }
   }


### PR DESCRIPTION
This PR extends the import and export tests such that both paths cover the `RootRel` and the `Rel` cases. Previously, each of them only convered one of the two.