### PR TITLE
feat: implement `AdvancedExtension` and at it to `Plan`

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -164,18 +164,21 @@ def Substrait_PlanOp : Substrait_Op<"plan", [
     UI32Attr:$minor_number,
     UI32Attr:$patch_number,
     DefaultValuedAttr<StrAttr, "\"\"">:$git_hash,
-    DefaultValuedAttr<StrAttr, "\"\"">:$producer
+    DefaultValuedAttr<StrAttr, "\"\"">:$producer,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
   let regions = (region RegionOf<PlanBodyOp>:$body);
   let assemblyFormat = [{
     `version` $major_number `:` $minor_number `:` $patch_number
     (`git_hash` $git_hash^)? (`producer` $producer^)?
+    (`advanced_extension` `` $advanced_extension^)?
     attr-dict-with-keyword $body
   }];
   let builders = [
       OpBuilder<(ins "uint32_t":$major, "uint32_t":$minor, "uint32_t":$patch), [{
         build($_builder, $_state, major, minor, patch,
-              StringAttr(), StringAttr());
+              /*git_hash=*/StringAttr(), /*producer*/StringAttr(),
+              /*advanced_extension=*/AdvancedExtensionAttr());
       }]>
     ];
   let extraClassDefinition = [{

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -120,6 +120,32 @@ def Substrait_AtomicAttributes {
   ];
 }
 
+def Substrait_AnyType : Substrait_Type<"Any", "any"> {
+  let summary = "Represents the `type_url` of a `google.protobuf.Any` message";
+  let description = [{
+    This type represents the `type_url` fields of a `google.protobuf.Any`
+    message. These messages consist of an opaque byte array and a string holding
+    the URL identifying the type of what is contained in the byte array.
+  }];
+  let parameters = (ins "StringAttr":$type_url);
+  let assemblyFormat = "`<` $type_url `>`";
+
+}
+
+def Substrait_AdvancedExtensionAttr
+    : Substrait_Attr<"AdvancedExtension", "advanced_extension"> {
+  let summary = "Represents the `AdvancedExtenssion` message of Substrait";
+  let parameters = (ins
+    OptionalParameter<"StringAttr">:$optimization,  // XXX: verify type
+    OptionalParameter<"StringAttr">:$enhancement
+  );
+  let assemblyFormat = [{
+    ( `optimization` `=` $optimization^ )?
+    ( `enhancement`  `=` $enhancement^  )?
+  }];
+  let genVerifyDecl = 1;
+}
+
 /// Attribute of one of the currently supported atomic types.
 def Substrait_AtomicAttribute : AnyAttrOf<Substrait_AtomicAttributes.attrs>;
 

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -39,6 +39,20 @@ void SubstraitDialect::initialize() {
 }
 
 //===----------------------------------------------------------------------===//
+// Substrait attributes
+//===----------------------------------------------------------------------===//
+
+LogicalResult AdvancedExtensionAttr::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
+    mlir::StringAttr optimization, mlir::StringAttr enhancement) {
+  if (optimization && !mlir::isa<AnyType>(optimization.getType()))
+    return emitError() << "has 'optimization' attribute of wrong type";
+  if (enhancement && !mlir::isa<AnyType>(enhancement.getType()))
+    return emitError() << "has 'enhancement' attribute of wrong type";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Substrait enums
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Substrait/plan-invalid.mlir
+++ b/test/Dialect/Substrait/plan-invalid.mlir
@@ -40,3 +40,19 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+1 {{'substrait.extension_function' op refers to @function.1, which is not a valid 'uri' op}}
   extension_function @function.2 at @function.1["somefunc"]
 }
+
+// -----
+
+// Test error if no symbol refers to an op of the wrong type.
+substrait.plan version 0 : 42 : 1
+  // expected-error@+1 {{custom op 'substrait.plan' has 'enhancement' attribute of wrong type}}
+  advanced_extension enhancement = "blup"
+{}
+
+// -----
+
+// Test error if no symbol refers to an op of the wrong type.
+substrait.plan version 0 : 42 : 1
+  // expected-error@+1 {{custom op 'substrait.plan' has 'optimization' attribute of wrong type}}
+  advanced_extension optimization = "blup"
+{}

--- a/test/Dialect/Substrait/plan-invalid.mlir
+++ b/test/Dialect/Substrait/plan-invalid.mlir
@@ -43,7 +43,7 @@ substrait.plan version 0 : 42 : 1 {
 
 // -----
 
-// Test error if no symbol refers to an op of the wrong type.
+// Test error if the `enhancement` attribute has the wrong/no type.
 substrait.plan version 0 : 42 : 1
   // expected-error@+1 {{custom op 'substrait.plan' has 'enhancement' attribute of wrong type}}
   advanced_extension enhancement = "blup"
@@ -51,7 +51,7 @@ substrait.plan version 0 : 42 : 1
 
 // -----
 
-// Test error if no symbol refers to an op of the wrong type.
+// Test error if the `optimization` attribute has the wrong/no type.
 substrait.plan version 0 : 42 : 1
   // expected-error@+1 {{custom op 'substrait.plan' has 'optimization' attribute of wrong type}}
   advanced_extension optimization = "blup"

--- a/test/Dialect/Substrait/plan.mlir
+++ b/test/Dialect/Substrait/plan.mlir
@@ -86,3 +86,17 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @other.extension at "http://other.url/with/more/extensions.yml"
   extension_function @other.function at @other.extension["someotherfunc"]
 }
+
+// -----
+
+// CHECK:      substrait.plan
+// CHECK-SAME:   advanced_extension
+// CHECK-SAME:     optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+// CHECK-SAME:     enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+// CHECK-NEXT: }
+
+substrait.plan version 0 : 42 : 1
+    advanced_extension
+      optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+      enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+{}

--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -138,3 +138,47 @@ substrait.plan version 0 : 42 : 1 {
   // If not handled carefully, parsing this symbol into an anchor may clash.
   extension_uri @extension_uri.0 at "http://other.url/with/more/extensions.yml"
 }
+
+// -----
+
+// CHECK:       advanced_extensions {
+// CHECK-NEXT:    optimization {
+// CHECK-NEXT:      type_url: "http://some.url/with/type.proto"
+// CHECK-NEXT:      value: "protobuf message"
+// CHECK-NEXT:    }
+// CHECK-NEXT:    enhancement {
+// CHECK-NEXT:      type_url: "http://other.url/with/type.proto"
+// CHECK-NEXT:      value: "other protobuf message"
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// CHECK-NEXT:  version
+
+substrait.plan version 0 : 42 : 1
+    advanced_extension
+      optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+      enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+{}
+
+// -----
+
+// CHECK:       advanced_extensions {
+// CHECK-NEXT:    optimization {
+// CHECK-NOT:     enhancement {
+// CHECK-:      version
+
+substrait.plan version 0 : 42 : 1
+    advanced_extension
+      optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+{}
+
+// -----
+
+// CHECK:       advanced_extensions {
+// CHECK-NEXT:    enhancement {
+// CHECK-NOT:     optimization {
+// CHECK-:      version
+
+substrait.plan version 0 : 42 : 1
+    advanced_extension
+      enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+{}

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -187,3 +187,62 @@ version {
   minor_number: 42
   patch_number: 1
 }
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK-SAME:   advanced_extension
+# CHECK-SAME:     optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+# CHECK-SAME:     enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+# CHECK-NEXT: }
+
+advanced_extensions {
+  optimization {
+    type_url: "http://some.url/with/type.proto"
+    value: "protobuf message"
+  }
+  enhancement {
+    type_url: "http://other.url/with/type.proto"
+    value: "other protobuf message"
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK-SAME:   advanced_extension
+# CHECK-SAME:     optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+# CHECK-NEXT: }
+
+advanced_extensions {
+  optimization {
+    type_url: "http://some.url/with/type.proto"
+    value: "protobuf message"
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK-SAME:   advanced_extension
+# CHECK-SAME:     enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+# CHECK-NEXT: }
+
+advanced_extensions {
+  enhancement {
+    type_url: "http://other.url/with/type.proto"
+    value: "other protobuf message"
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
This PR implements the `AdvanceExtension` message type as a custom attribute with two `StringAttr`s as well as an `AnyType` with a parameter for the type URL to represent the `Any` messages as typed `StringAttr`s. The PR also adds those attributes to the `PlanOp` in order to represent the `advanced_extensions` message of the `Plan` message.

We do not currently need this attribute but it is one of the few missing fields of the `Plan` message as well as many other messages we have otherwise implemented, so it allows us to get to higher coverage with relatively little effort.