### PR TITLE
feat: factor out `advanced_extension` logic and add it to other ops

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
+++ b/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
@@ -15,20 +15,39 @@
 #include "mlir/IR/SymbolTable.h"                  // IWYU: keep
 #include "mlir/Interfaces/InferTypeOpInterface.h" // IWYU: keep
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.h.inc" // IWYU: export
+//===----------------------------------------------------------------------===//
+// Substrait dialect
+//===----------------------------------------------------------------------===//
 
 #include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsDialect.h.inc" // IWYU: export
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitAttrInterfaces.h.inc" // IWYU: export
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpInterfaces.h.inc" // IWYU: export
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypeInterfaces.h.inc" // IWYU: export
+//===----------------------------------------------------------------------===//
+// Substrait enums
+//===----------------------------------------------------------------------===//
 
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.h.inc" // IWYU: export
+
+//===----------------------------------------------------------------------===//
+// Substrait types
+//===----------------------------------------------------------------------===//
+
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypeInterfaces.h.inc" // IWYU: export
 #define GET_TYPEDEF_CLASSES
 #include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsTypes.h.inc" // IWYU: export
 
+//===----------------------------------------------------------------------===//
+// Substrait attributes
+//===----------------------------------------------------------------------===//
+
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitAttrInterfaces.h.inc" // IWYU: export
 #define GET_ATTRDEF_CLASSES
 #include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsAttrs.h.inc" // IWYU: export
 
+//===----------------------------------------------------------------------===//
+// Substrait ops
+//===----------------------------------------------------------------------===//
+
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpInterfaces.h.inc" // IWYU: export
 #define GET_OP_CLASSES
 #include "substrait-mlir/Dialect/Substrait/IR/SubstraitOps.h.inc" // IWYU: export
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitInterfaces.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitInterfaces.td
@@ -41,6 +41,26 @@ def Substrait_ExpressionOpInterface : OpInterface<"ExpressionOpInterface"> {
   let cppNamespace = "::mlir::substrait";
 }
 
+def Substrait_ExtensibleOpInterface : OpInterface<"ExtensibleOpInterface"> {
+  let description = [{
+    Interface for ops with the `advanced_extension` attribute. Several relations
+    and other message types of the Substrait specification have a field with the
+    same name (or the variant `advanced_extensions`, which has the same meaning)
+    and the interface enables handling all of them transparently.
+  }];
+  let cppNamespace = "::mlir::substrait";
+  let methods = [
+    InterfaceMethod<
+      "Get the `advanced_extension` attribute",
+      "std::optional<::mlir::substrait::AdvancedExtensionAttr>",
+      "getAdvancedExtension">,
+    InterfaceMethod<
+      "Get the `advanced_extension` attribute",
+      "void", "setAdvancedExtensionAttr",
+      (ins "::mlir::substrait::AdvancedExtensionAttr":$attr)>,
+    ];
+}
+
 def Substrait_RelOpInterface : OpInterface<"RelOpInterface"> {
   let description = [{
     Interface for any relational operation in a Substrait plan. This corresponds

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -151,6 +151,7 @@ def PlanBodyOp : AnyOf<[
 
 def Substrait_PlanOp : Substrait_Op<"plan", [
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
     NoTerminator, NoRegionArguments, SingleBlock, SymbolTable
   ]> {
   let summary = "Represents a Substrait plan";
@@ -180,9 +181,13 @@ def Substrait_PlanOp : Substrait_Op<"plan", [
   let builders = [
       OpBuilder<(ins "uint32_t":$major, "uint32_t":$minor, "uint32_t":$patch), [{
         build($_builder, $_state, major, minor, patch,
-              /*git_hash=*/StringAttr(), /*producer*/StringAttr(),
-              /*advanced_extension=*/AdvancedExtensionAttr(),
-              /*expected_type_urls=*/ArrayAttr());
+              /*git_hash=*/StringAttr(), /*producer*/StringAttr());
+      }]>,
+      OpBuilder<
+        (ins "uint32_t":$major, "uint32_t":$minor, "uint32_t":$patch,
+             "::llvm::StringRef":$git_hash, "::llvm::StringRef":$producer), [{
+        build($_builder, $_state, major, minor, patch, git_hash, producer,
+              /*advanced_extension=*/AdvancedExtensionAttr());
       }]>,
       OpBuilder<
         (ins "uint32_t":$major, "uint32_t":$minor, "uint32_t":$patch,
@@ -537,6 +542,7 @@ def Substrait_NamedTableOp : Substrait_RelOp<"named_table", [
 
 def Substrait_ProjectOp : Substrait_RelOp<"project", [
     SingleBlockImplicitTerminator<"::mlir::substrait::YieldOp">,
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>
   ]> {
   let summary = "Project operation";
@@ -561,14 +567,18 @@ def Substrait_ProjectOp : Substrait_RelOp<"project", [
     }
     ```
   }];
-  let arguments = (ins Substrait_Relation:$input);
+  let arguments = (ins
+    Substrait_Relation:$input,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
+  );
   let regions = (region AnyRegion:$expressions);
   let results = (outs Substrait_Relation:$result);
   // TODO(ingomueller): We could elide/shorten the block argument from the
   //                    assembly by writing custom printers/parsers similar to
   //                    `scf.for` etc.
   let assemblyFormat = [{
-    $input attr-dict `:` type($input) `->` type($result) $expressions
+    $input (`advanced_extension` `` $advanced_extension^)?
+    attr-dict `:` type($input) `->` type($result) $expressions
   }];
   let hasRegionVerifier = 1;
   let hasFolder = 1;

--- a/lib/Target/SubstraitPB/ProtobufUtils.h
+++ b/lib/Target/SubstraitPB/ProtobufUtils.h
@@ -9,6 +9,8 @@
 #ifndef LIB_TARGET_SUBSTRAITPB_PROTOBUFUTILS_H
 #define LIB_TARGET_SUBSTRAITPB_PROTOBUFUTILS_H
 
+#include <type_traits>
+
 #include "mlir/IR/Location.h"
 
 namespace substrait::proto {
@@ -27,6 +29,59 @@ getCommon(const ::substrait::proto::Rel &rel, Location loc);
 /// given `rel`. Reports errors using the given `loc`.
 FailureOr<::substrait::proto::RelCommon *>
 getMutableCommon(::substrait::proto::Rel *rel, Location loc);
+
+/// SFINAE-based template that checks if the given (message) type has an field
+/// called `advanced_extension`: the `value` member is `true` iff it has. This
+/// is useful to deal with the two different names, `advanced_extension` and
+/// `advanced_extensions`, that are used for the same thing across different
+/// message types in the Substrait spec.
+template <typename T>
+class has_advanced_extensions {
+  template <typename C>
+  static std::true_type test(decltype(&C::advanced_extensions));
+  template <typename C>
+  static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+/// Trait class for accessing the `advanced_extension` field. The default
+/// instances is automatically used for message types that call this field
+/// `advanced_extension`; the specialization below is automatically used for
+/// message types that call it `advanced_extensions`.
+template <typename T, typename = void>
+struct advanced_extension_trait {
+  static auto has_advanced_extension(const T &message) {
+    return message.has_advanced_extension();
+  }
+  static auto advanced_extension(const T &message) {
+    return message.advanced_extension();
+  }
+  template <typename S>
+  static auto set_allocated_advanced_extension(T &message,
+                                               S &&advanced_extensions) {
+    message.set_allocated_advanced_extension(
+        std::forward<S>(advanced_extensions));
+  }
+};
+
+template <typename T>
+struct advanced_extension_trait<
+    T, std::enable_if_t<has_advanced_extensions<T>::value>> {
+  static auto has_advanced_extension(const T &message) {
+    return message.has_advanced_extensions();
+  }
+  static auto advanced_extension(const T &message) {
+    return message.advanced_extensions();
+  }
+  template <typename S>
+  static auto set_allocated_advanced_extension(T &message,
+                                               S &&advanced_extensions) {
+    message.set_allocated_advanced_extensions(
+        std::forward<S>(advanced_extensions));
+  }
+};
 
 } // namespace mlir::substrait::protobuf_utils
 

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -27,7 +27,7 @@ substrait.plan version 0 : 42 : 1 {
 
 // -----
 
-// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK:      substrait.plan
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32> {
@@ -38,6 +38,28 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = project %0 : tuple<si32> -> tuple<si32> {
+    ^bb0(%arg0: tuple<si32>):
+      yield
+    }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]]
+// CHECK-SAME:      advanced_extension optimization = "foo" : !substrait.any<"bar">
+// CHECK-SAME:      tuple<si32> -> tuple<si32> {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = project %0
+            advanced_extension optimization = "foo" : !substrait.any<"bar">
+            : tuple<si32> -> tuple<si32> {
     ^bb0(%arg0: tuple<si32>):
       yield
     }

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -1,9 +1,12 @@
-// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
 // RUN: | FileCheck %s
 
 // RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
 // RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: relations {
@@ -34,5 +37,32 @@ substrait.plan version 0 : 42 : 1 {
       yield %true, %42 : si1, si32
     }
     yield %1 : tuple<si32, si1, si32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK-NEXT:        common {
+// CHECK:             input {
+// CHECK:             advanced_extension {
+// CHECK-NEXT:        optimization {
+// CHECK-NEXT:          type_url: "bar"
+// CHECK-NEXT:          value: "foo"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = project %0
+            advanced_extension optimization = "foo" : !substrait.any<"bar">
+            : tuple<si32> -> tuple<si32> {
+    ^bb0(%arg0: tuple<si32>):
+      yield
+    }
+    yield %1 : tuple<si32>
   }
 }

--- a/test/Target/SubstraitPB/Import/project.textpb
+++ b/test/Target/SubstraitPB/Import/project.textpb
@@ -1,9 +1,13 @@
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
 # RUN: | FileCheck %s
 
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
 # RUN: | substrait-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | FileCheck %s
 
 # CHECK:      substrait.plan version 0 : 42 : 1 {
@@ -54,6 +58,57 @@ relations {
       expressions {
         literal {
           i32: 42
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan version
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]]
+# CHECK-SAME:      advanced_extension optimization = "foo" : !substrait.any<"bar">
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      advanced_extension {
+        optimization {
+          type_url: "bar"
+          value: "foo"
         }
       }
     }


### PR DESCRIPTION
This PR factors out the handling of the `shared_extension` field from the `plan` op and adds that logic to the `project` op. This mainly consisted of moving the import and export logic from the functions related to the `plan` op to dedicated functions. The PR also introduces the new `ExtensibleOpInterface` that enforces an attribute called `advanced_extension` on the op that implement it and allows to deal with all such ops transparently. Since that interface depends on an attribute, the include order of the generated code of interfaces and attributes also had to be adapted. Unfortunately, the field names in the Substrait spec also vary (singular or plural), so the PR also introduces some template magic to be able to deal with protobuf message types with both spellings. With this PR, message types with an `advanced_extension` field should be able to support it by (1) adding the `ExtensibleOpInterface` to their traits, (2) adding an `advanced_extension` parameter, and (3) adding that parameter to their assembly format (although that's technically optional; otherwise, the attribute is set through the `attributes` dictionary).