### PR TITLE
chore: fix remaining compiler warnings

### DIFF
--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -189,7 +189,7 @@ EmitOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 
   ArrayAttr mapping = typedProperties->getMapping();
   Type inputType = operands[0].getType();
-  ArrayRef<Type> inputTypes = inputType.cast<TupleType>().getTypes();
+  ArrayRef<Type> inputTypes = mlir::cast<TupleType>(inputType).getTypes();
 
   // Map input types to output types.
   SmallVector<Type> outputTypes;
@@ -342,8 +342,6 @@ JoinOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
   case JoinTypeKind::single:
     llvm::append_range(fieldTypes, rightFieldTypes);
     break;
-  default:
-    return failure();
   }
 
   auto resultType = TupleType::get(context, fieldTypes);


### PR DESCRIPTION
There were two places left: another usage of the deprecated MLIR `cast` and a `default` label in a switch that already covers all cases.