### PR TITLE
feat: implement support for the `PlanVersion` message type

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -35,6 +35,10 @@ class Substrait_StaticallyTypedAttr<string name, string attrMnemonic,
   }];
 }
 
+/// `StringAttr` parameter that is the empty string by default.
+def Substrait_DefaultEmptyStringParameter
+    : DefaultValuedParameter<"StringAttr", [{mlir::StringAttr::get($_ctxt, "")}]>;
+
 //===----------------------------------------------------------------------===//
 // Substrait attributes
 //===----------------------------------------------------------------------===//
@@ -92,6 +96,40 @@ def Substrait_TimestampTzAttr
   }];
   let parameters = (ins "int64_t":$value);
   let assemblyFormat = [{ `<` $value `` `us` `>` }];
+}
+
+def Substrait_VersionAttr : Substrait_Attr<"Version", "version"> {
+  let summary = "Substrait version";
+  let description = [{
+    Represents the `Version` message type.
+  }];
+  let parameters = (ins
+    "uint32_t":$major_number,
+    "uint32_t":$minor_number,
+    "uint32_t":$patch_number,
+    Substrait_DefaultEmptyStringParameter:$git_hash,
+    Substrait_DefaultEmptyStringParameter:$producer
+
+  );
+  // TODO(ingomueller): make this even nicer with custom printer/parser
+  let assemblyFormat = [{
+    `` $major_number `` `:` `` $minor_number `` `:` `` $patch_number
+    (`git_hash` $git_hash^)? (`producer` $producer^)?
+  }];
+  let builders = [
+    AttrBuilder<(ins "uint32_t":$major, "uint32_t":$minor, "uint32_t":$patch), [{
+      return $_get($_ctxt, major, minor, patch,
+                   /*git_hash=*/StringAttr(),
+                   /*producer=*/StringAttr());
+    }]>,
+    AttrBuilder<(ins "uint32_t":$major, "uint32_t":$minor, "uint32_t":$patch,
+                    "::llvm::StringRef":$git_hash,
+                    "::llvm::StringRef":$producer), [{
+      auto gitHashAttr = ::mlir::StringAttr::get($_ctxt, git_hash);
+      auto producerAttr = ::mlir::StringAttr::get($_ctxt, producer);
+      return $_get($_ctxt, major, minor, patch, gitHashAttr, producerAttr);
+    }]>,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -134,9 +134,9 @@ def Substrait_ExtensionTypeVariationOp :
 }
 
 //===----------------------------------------------------------------------===//
-// Plan
+// Top-level ops
 //===----------------------------------------------------------------------===//
-// The definitions in this section are related to the top-level `Plan` message.
+// The definitions in this section are related to the top-level messages.
 // See https://substrait.io/serialization/binary_serialization/ and
 // https://github.com/substrait-io/substrait/blob/main/proto/substrait/plan.proto.
 //===----------------------------------------------------------------------===//
@@ -148,6 +148,19 @@ def PlanBodyOp : AnyOf<[
     IsOp<"::mlir::substrait::ExtensionTypeOp">,
     IsOp<"::mlir::substrait::ExtensionTypeVariationOp">,
   ]>;
+
+def Substrait_PlanVersionOp : Substrait_Op<"plan_version"> {
+  let summary = "Represents a stand-alone plan version";
+  let description = [{
+    This op represents the `PlanVersion` message type of Substrait. It carries
+    the version information as an attribute, so it also subsumes the `Version`
+    message type.
+  }];
+  let arguments = (ins
+    Substrait_VersionAttr:$version
+  );
+  let assemblyFormat = "$version attr-dict";
+}
 
 def Substrait_PlanOp : Substrait_Op<"plan", [
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,

--- a/include/substrait-mlir/Target/SubstraitPB/Import.h
+++ b/include/substrait-mlir/Target/SubstraitPB/Import.h
@@ -22,8 +22,12 @@ class OwningOpRef;
 namespace substrait {
 
 OwningOpRef<ModuleOp>
-translateProtobufToSubstrait(llvm::StringRef input, MLIRContext *context,
-                             substrait::ImportExportOptions options = {});
+translateProtobufToSubstraitPlan(llvm::StringRef input, MLIRContext *context,
+                                 substrait::ImportExportOptions options = {});
+
+OwningOpRef<ModuleOp> translateProtobufToSubstraitPlanVersion(
+    llvm::StringRef input, MLIRContext *context,
+    substrait::ImportExportOptions options = {});
 
 } // namespace substrait
 } // namespace mlir

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -48,7 +48,7 @@ MlirModule mlirSubstraitImportPlan(MlirContext context, MlirStringRef input,
   ImportExportOptions options;
   options.serdeFormat = convertSerdeFormat(format);
   OwningOpRef<ModuleOp> owning =
-      translateProtobufToSubstrait(unwrap(input), unwrap(context), options);
+      translateProtobufToSubstraitPlan(unwrap(input), unwrap(context), options);
   if (!owning)
     return MlirModule{nullptr};
   return MlirModule{owning.release().getOperation()};

--- a/test/Dialect/Substrait/plan-version.mlir
+++ b/test/Dialect/Substrait/plan-version.mlir
@@ -1,0 +1,17 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK:      substrait.plan_version 0:42:1 git_hash "hash" producer "producer"
+substrait.plan_version 0:42:1 git_hash "hash" producer "producer"
+
+// CHECK-NEXT: substrait.plan_version 1:2:3 producer "other producer"{{$}}
+substrait.plan_version 1:2:3 producer "other producer"
+
+// CHECK-NEXT: substrait.plan_version 1:33:7 git_hash "other hash"{{$}}
+substrait.plan_version 1:33:7 git_hash "other hash"
+
+// CHECK-NEXT: substrait.plan_version 3:2:1{{$}}
+substrait.plan_version 3:2:1
+
+// CHECK-NEXT: substrait.plan_version 6:6:6{{$}}
+substrait.plan_version 6:6:6 git_hash "" producer ""

--- a/test/Target/SubstraitPB/Export/plan-version.mlir
+++ b/test/Target/SubstraitPB/Export/plan-version.mlir
@@ -1,0 +1,60 @@
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | substrait-translate -protobuf-to-substrait-plan-version \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
+// RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: version {
+// CHECK-DAG:     minor_number: 42
+// CHECK-DAG:     patch_number: 1
+// CHECK-DAG:     git_hash: "hash"
+// CHECK-DAG:     producer: "producer"
+// CHECK-NEXT:  }
+
+substrait.plan_version 0:42:1 git_hash "hash" producer "producer"
+
+// -----
+
+// CHECK-LABEL: version {
+// CHECK-DAG:     major_number: 1
+// CHECK-DAG:     minor_number: 2
+// CHECK-DAG:     patch_number: 3
+// CHECK-DAG:     producer: "other producer"
+// CHECK-NEXT:  }
+
+substrait.plan_version 1:2:3 producer "other producer"
+
+// -----
+
+// CHECK-LABEL: version {
+// CHECK-DAG:     major_number: 1
+// CHECK-DAG:     minor_number: 33
+// CHECK-DAG:     patch_number: 7
+// CHECK-DAG:     git_hash: "other hash"
+// CHECK-NEXT:  }
+
+substrait.plan_version 1:33:7 git_hash "other hash"
+
+// -----
+
+// CHECK-LABEL: version {
+// CHECK-DAG:     major_number: 3
+// CHECK-DAG:     minor_number: 2
+// CHECK-DAG:     patch_number: 1
+// CHECK-NEXT:  }
+
+substrait.plan_version 3:2:1
+
+// -----
+
+// CHECK-LABEL: version {
+// CHECK-NOT:     git_hash
+// CHECK-NOT:     producer
+// CHECK:       }
+
+substrait.plan_version 1:2:3 git_hash "" producer ""

--- a/test/Target/SubstraitPB/Import/plan-version.textpb
+++ b/test/Target/SubstraitPB/Import/plan-version.textpb
@@ -1,0 +1,55 @@
+# RUN: substrait-translate -protobuf-to-substrait-plan-version %s \
+# RUN:   --split-input-file="# ""-----" \
+# RUN: | FileCheck %s
+
+# RUN: substrait-translate -protobuf-to-substrait-plan-version %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
+# RUN: | substrait-translate -protobuf-to-substrait-plan-version \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | FileCheck %s
+
+# CHECK-LABEL: substrait.plan_version 0:42:1
+# CHECK-SAME:    git_hash "hash" producer "producer"
+
+version {
+  minor_number: 42
+  patch_number: 1
+  git_hash: "hash"
+  producer: "producer"
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan_version 1:2:3
+# CHECK-SAME:    producer "other producer"{{$}}
+
+version {
+  major_number: 1
+  minor_number: 2
+  patch_number: 3
+  producer: "other producer"
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan_version 1:33:7
+# CHECK-SAME:    git_hash "other hash"{{$}}
+
+version {
+  major_number: 1
+  minor_number: 33
+  patch_number: 7
+  git_hash: "other hash"
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan_version 3:2:1{{$}}
+
+version {
+  major_number: 3
+  minor_number: 2
+  patch_number: 1
+}

--- a/test/python/dialects/substrait/translate.py
+++ b/test/python/dialects/substrait/translate.py
@@ -101,7 +101,7 @@ def testBinPB():
 def testInvalid():
   try:
     ss.from_json('this is not json')
-    # CHECK-NEXT: error: could not deserialize JSON as 'Plan' message:
+    # CHECK-NEXT: error: could not deserialize JSON as 'substrait.proto.Plan' message:
     # CHECK-NEXT: Unexpected token.
     # CHECK-NEXT: this is not json
   except ValueError as ex:


### PR DESCRIPTION
~~This PR depends on and, therefor, currently includes #68.~~

This PR introduces support for the `PlanVersion` message type. This is done by introduces the `VersionAttr`, which corresponds to the `Version` message type, which, in turn, is the type of the only field of `PlanVersion`.

Since `PlanVersion` is a top-level message, this PR extends the import mechanism: when reading a protobuf message, we need to know which type it is, so when we translate a protobuf message into MLIR, we need to specify which message type the input is. The PR, thus, adds a new flag to the `substrait-translate` tool, together with a corresponding top-level translation function. This also slightly changed some existing error messages and the corresponding tests.

This PR does not yet factor out the handling of the version of the `Plan` message type. That should follow up soon but, since the new `VersionAttr` has a slightly different assembly format than the corresponding part of the `PlanOp`, that change will require to modify all test cases, which would bloat this PR.