### PR TITLE
feat: add `aggregate` op and extend functions accordingly

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -35,6 +35,10 @@ class Substrait_StaticallyTypedAttr<string name, string attrMnemonic,
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Substrait attributes
+//===----------------------------------------------------------------------===//
+
 def Substrait_AdvancedExtensionAttr
     : Substrait_Attr<"AdvancedExtension", "advanced_extension"> {
   let summary = "Represents the `AdvancedExtenssion` message of Substrait";
@@ -90,6 +94,10 @@ def Substrait_TimestampTzAttr
   let assemblyFormat = [{ `<` $value `` `us` `>` }];
 }
 
+//===----------------------------------------------------------------------===//
+// Helpers and constraints
+//===----------------------------------------------------------------------===//
+
 /// Attributes of currently supported atomic types, listed in order of substrait
 /// specification.
 def Substrait_AtomicAttributes {
@@ -112,5 +120,15 @@ def Substrait_AtomicAttributes {
 
 /// Attribute of one of the currently supported atomic types.
 def Substrait_AtomicAttribute : AnyAttrOf<Substrait_AtomicAttributes.attrs>;
+
+/// `ArrayAttr` of `ArrayAttr`s if `i64`s.
+def I64ArrayArrayAttr : TypedArrayAttrBase<
+    I64ArrayAttr, "64-bit integer array array attribute"
+  >;
+
+/// `ArrayAttr` of `ArrayAttr`s if `i64`s with at least one element.
+def NonEmptyI64ArrayArrayAttr :
+  ConfinedAttr<I64ArrayArrayAttr, [ArrayMinCount<1>]>;
+
 
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITATTRS

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -11,9 +11,20 @@
 
 include "mlir/IR/EnumAttr.td"
 
-def AggregationInvocationUnspecified: I32EnumAttrCase<"unspecified", 0>;
-def AggregationInvocationAll: I32EnumAttrCase<"all", 1>;
-def AggregationInvocationDistinct: I32EnumAttrCase<"distinct", 2>;
+/// Represents the `AggregationInvocation` protobuf enum.
+//
+/// The enum values correspond exactly to those in the `JoinRel.JoinType` enum,
+/// i.e., conversion through integers is possible.
+def AggregationInvocation
+    : I32EnumAttr<"AggregationInvocation", "aggregate invocation type", [
+        // clang-format off
+        I32EnumAttrCase<"unspecified", 0>,
+        I32EnumAttrCase<"all", 1>,
+        I32EnumAttrCase<"distinct", 2>,
+        // clang-format on
+      ]> {
+  let cppNamespace = "::mlir::substrait";
+}
 
 /// Represents the `JoinType` protobuf enum.
 def JoinTypeKind : I32EnumAttr<"JoinTypeKind",

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -246,6 +246,7 @@ def Substrait_PlanRelOp : Substrait_Op<"relation", [
 def Substrait_YieldOp : Substrait_Op<"yield", [
     Terminator,
     ParentOneOf<[
+      "::mlir::substrait::AggregateOp",
       "::mlir::substrait::FilterOp",
       "::mlir::substrait::PlanRelOp",
       "::mlir::substrait::ProjectOp"
@@ -323,9 +324,13 @@ def Substrait_CallOp : Substrait_ExpressionOp<"call", [
   ]> {
   let summary = "Function call expression";
   let description = [{
-    Represents a `ScalarFunction` message (or, in the future, other `*Function`
-    messages) together with all messages it contains and the `Expression`
-    message it is contained in.
+    Represents a `ScalarFunction` or `AggregateFunction` message (or, in the
+    future, a `WindowFunction` message) together with all messages it contains
+    and, where applicable, the `Expression` message it is contained in. Which of
+    the message types this op corresponds to depends on the presence of the
+    (otherwise optional) aggregate or window-related attributes. For aggregate
+    functions, the invocation type is omitted from the custom assembly if it is
+    set to `all`.
 
     Currently, the specification of the function, which is in an external YAML
     file, is not taken into account, for example, to verify whether a matching
@@ -347,11 +352,33 @@ def Substrait_CallOp : Substrait_ExpressionOp<"call", [
   // TODO(ingomueller): Add support for `enum` and `type` argument types.
   let arguments = (ins
     FlatSymbolRefAttr:$callee,
-    Variadic<Substrait_FieldType>:$args
+    Variadic<Substrait_FieldType>:$args,
+    OptionalAttr<AggregationInvocation>:$aggregation_invocation
   );
   let results = (outs Substrait_FieldType:$result);
   let assemblyFormat = [{
-    $callee `(` $args `)` attr-dict `:` `(` type($args) `)` `->` type($result)
+    $callee `(` $args `)`
+    (`aggregate` `` custom<AggregationInvocation>($aggregation_invocation)^)?
+    attr-dict `:` `(` type($args) `)` `->` type($result)
+  }];
+  let builders = [
+      OpBuilder<(ins "::mlir::Type":$result,
+                     "::mlir::FlatSymbolRefAttr":$callee,
+                     "::mlir::ValueRange":$args), [{
+        build($_builder, $_state, result, callee, args,
+              AggregationInvocationAttr());
+      }]>,
+      OpBuilder<(ins "::mlir::Type":$result, "::llvm::StringRef":$callee,
+                     "::mlir::ValueRange":$args), [{
+        build($_builder, $_state, result, callee, args,
+              AggregationInvocationAttr());
+      }]>
+    ];
+  let extraClassDeclaration = [{
+    // Helpers to distinguish function types.
+    bool isAggregate() { return getAggregationInvocation().has_value(); }
+    bool isScalar() { return !isAggregate() && !isWindow(); }
+    bool isWindow() { return false; } // TODO: change once supported.
   }];
 }
 
@@ -374,6 +401,77 @@ class Substrait_RelOp<string mnemonic, list<Trait> traits = []> :
           Substrait_Relation.predicate>
       ]>>
   ]>;
+
+def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    SingleBlockImplicitTerminator<"::mlir::substrait::YieldOp">,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>,
+  ]> {
+  let summary = "Aggregate operation";
+  let description = [{
+    Represents an `AggregateRel ` message together with the `RelCommon` and the
+    messages it contains. The `measures` field is represented as a region where
+    the yielded values correspond to the `AggregateFunction`s (and thus have
+    to be produced by a `CallOp` representing an aggregate function). Filters
+    are currently not supported. The `groupings` field is represented as a
+    region yielding the unique (deduplicated) grouping expressions and an array
+    of array of references to these expressions representing the grouping sets.
+    An empty array of grouping sets corresponds to *no* `groupings` messages;
+    an array with an empty grouping set corresponds to an *empty* `groupings`
+    messages. These two protobuf representations are different even though their
+    semantic is equivalent. The op can only be exported to the protobuf format
+    if the expressions yielded by the `groupings` region are all distinct after
+    CSE. The assembly format omits an empty region of groupings, an empty region
+    of measures, and the grouping sets attribute with one grouping set that
+    consists of all values yielded from `groupings` (or the empty grouping set
+    if that region is empty).
+
+    Example:
+
+    ```mlir
+    %0 = ...
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32, si32>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        yield %2 : si32
+      }
+      grouping_sets [[0]]
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = call @function(%2) aggregate : (si32) -> si32
+        yield %3 : si32
+      }
+    ```
+  }];
+  let arguments = (ins
+    Substrait_Relation:$input,
+    I64ArrayArrayAttr:$grouping_sets
+  );
+  let results = (outs Substrait_Relation:$result);
+  let regions = (region
+    AnyRegion:$groupings,
+    AnyRegion:$measures
+  );
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result)
+    custom<AggregateRegions>($groupings, $measures, $grouping_sets)
+  }];
+  let hasRegionVerifier = 1;
+  let builders = [
+      OpBuilder<(ins
+          "::mlir::Value":$input, "::mlir::ArrayAttr":$grouping_sets,
+          "::mlir::Region *":$groupings, "::mlir::Region *":$measures
+        )>,
+    ];
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    ::llvm::StringRef $cppClass::getDefaultDialect() {
+      return SubstraitDialect::getDialectNamespace();
+    }
+  }];
+}
 
 def Substrait_CrossOp : Substrait_RelOp<"cross", [
     DeclareOpInterfaceMethods<InferTypeOpInterface>

--- a/lib/Target/SubstraitPB/CMakeLists.txt
+++ b/lib/Target/SubstraitPB/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_translation_library(MLIRTargetSubstraitPB
   MLIRIR
   MLIRSubstraitDialect
   MLIRSupport
+  MLIRTransforms
   MLIRTranslateLib
   substrait_proto
   protobuf::libprotobuf

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -228,8 +228,7 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
 mlir::FailureOr<CallOp>
 importAggregateFunction(ImplicitLocOpBuilder builder,
                         const AggregateFunction &message) {
-  MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   FailureOr<CallOp> maybeCallOp = importFunctionCommon(builder, message);
   if (failed(maybeCallOp))
@@ -254,8 +253,7 @@ importAggregateRel(ImplicitLocOpBuilder builder, const Rel &message) {
   using Grouping = AggregateRel::Grouping;
   using Measure = AggregateRel::Measure;
 
-  MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   const AggregateRel &aggregateRel = message.aggregate();
 
@@ -422,8 +420,7 @@ static mlir::FailureOr<SetOp> importSetRel(ImplicitLocOpBuilder builder,
 
 static mlir::FailureOr<ExpressionOpInterface>
 importExpression(ImplicitLocOpBuilder builder, const Expression &message) {
-  MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   Expression::RexTypeCase rex_type = message.rex_type_case();
   switch (rex_type) {
@@ -449,8 +446,7 @@ importFieldReference(ImplicitLocOpBuilder builder,
                      const Expression::FieldReference &message) {
   using ReferenceSegment = Expression::ReferenceSegment;
 
-  MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   // Emit error on unsupported cases.
   // TODO(ingomueller): support more cases.
@@ -533,7 +529,7 @@ static mlir::FailureOr<LiteralOp>
 importLiteral(ImplicitLocOpBuilder builder,
               const Expression::Literal &message) {
   MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   Expression::Literal::LiteralTypeCase literalType =
       message.literal_type_case();
@@ -709,7 +705,7 @@ static FailureOr<PlanOp> importPlan(ImplicitLocOpBuilder builder,
       SimpleExtensionDeclaration::ExtensionTypeVariation;
 
   MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   // Import version.
   const Version &version = message.version();
@@ -800,8 +796,7 @@ static FailureOr<PlanOp> importPlan(ImplicitLocOpBuilder builder,
 
 static FailureOr<PlanRelOp> importPlanRel(ImplicitLocOpBuilder builder,
                                           const PlanRel &message) {
-  MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   if (!message.has_rel() && !message.has_root()) {
     PlanRel::RelTypeCase relType = message.rel_type_case();
@@ -900,8 +895,7 @@ static mlir::FailureOr<ProjectOp> importProjectRel(ImplicitLocOpBuilder builder,
 
 static mlir::FailureOr<RelOpInterface>
 importReadRel(ImplicitLocOpBuilder builder, const Rel &message) {
-  MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   const ReadRel &readRel = message.read();
   ReadRel::ReadTypeCase readType = readRel.read_type_case();
@@ -918,8 +912,7 @@ importReadRel(ImplicitLocOpBuilder builder, const Rel &message) {
 
 static mlir::FailureOr<RelOpInterface> importRel(ImplicitLocOpBuilder builder,
                                                  const Rel &message) {
-  MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   // Import rel depending on its type.
   Rel::RelTypeCase relType = message.rel_type_case();
@@ -995,7 +988,7 @@ template <typename MessageType>
 FailureOr<CallOp> importFunctionCommon(ImplicitLocOpBuilder builder,
                                        const MessageType &message) {
   MLIRContext *context = builder.getContext();
-  Location loc = UnknownLoc::get(context);
+  Location loc = builder.getLoc();
 
   // Import `output_type`.
   const proto::Type &outputType = message.output_type();

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -27,6 +27,8 @@ static const RelCommon *getCommon(const RelType &rel) {
 FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
   Rel::RelTypeCase relType = rel.rel_type_case();
   switch (relType) {
+  case Rel::RelTypeCase::kAggregate:
+    return getCommon(rel.aggregate());
   case Rel::RelTypeCase::kCross:
     return getCommon(rel.cross());
   case Rel::RelTypeCase::kFetch:
@@ -56,6 +58,8 @@ static RelCommon *getMutableCommon(RelType *rel) {
 FailureOr<RelCommon *> getMutableCommon(Rel *rel, Location loc) {
   Rel::RelTypeCase relType = rel->rel_type_case();
   switch (relType) {
+  case Rel::RelTypeCase::kAggregate:
+    return getMutableCommon(rel->mutable_aggregate());
   case Rel::RelTypeCase::kCross:
     return getMutableCommon(rel->mutable_cross());
   case Rel::RelTypeCase::kFetch:

--- a/test/Dialect/Substrait/aggregate-invalid.mlir
+++ b/test/Dialect/Substrait/aggregate-invalid.mlir
@@ -1,0 +1,176 @@
+// RUN: substrait-opt -verify-diagnostics -split-input-file %s
+
+// Verify that wrong arg type to `groupings` is detected.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op has region #0 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+      groupings {
+      ^bb0(%arg : tuple<si1>):
+        %2 = literal 0 : si1
+        yield %2 : si1
+      }
+    yield %1 : tuple<si1>
+  }
+}
+
+// -----
+
+// Verify that wrong arg type to `measures` is detected.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op has region #1 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+      measures {
+      ^bb0(%arg : tuple<si1>):
+        %2 = literal 0 : si1
+        %3 = call @function(%2) aggregate : (si1) -> si1
+        yield %3 : si1
+      }
+    yield %1 : tuple<si1>
+  }
+}
+
+// -----
+
+// Verify that out-of-bound column refs in grouping sets are detected.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op has invalid grouping set #0: column reference 1 (column #0) is out of bounds}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2 : si1
+      }
+      grouping_sets [[1]]
+    yield %1 : tuple<si1>
+  }
+}
+
+// -----
+
+// Verify that it's detected if first occurrences of column references are not
+// densely increasing.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op has invalid grouping sets: the first occerrences of the column references must be densely increasing}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2, %2 : si1, si1
+      }
+      grouping_sets [[1, 0]]
+    yield %1 : tuple<si1, si1>
+  }
+}
+
+// -----
+
+// Verify that yielded value unused by all grouping sets is detected.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op has 'groupings' region whose operand #1 is not contained in any 'grouping_set'}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2, %2 : si1, si1
+      }
+      grouping_sets [[0]]
+    yield %1 : tuple<si1, si1>
+  }
+}
+
+// -----
+
+// Verify that missing `groupings` *and* `measures regions is detected.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{one of 'groupings' or 'measures' must be specified}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<>
+      grouping_sets [[]]
+    yield %1 : tuple<>
+  }
+}
+
+// -----
+
+// Verify that unaggregated measure is detected.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error-re@+1 {{'substrait.aggregate' op yields value from 'measures' region that was not produced by an aggregate function: {{.*}}substrait.call{{.*}}}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si32
+        %3 = call @function(%2) : (si32) -> si32
+        yield %3 : si32
+      }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// Verify that invalid aggregation invocation mode is detected.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si32
+        // expected-error@+1 {{custom op 'substrait.call' has invalid aggregate invocation type specification: foo}}
+        %3 = call @function(%2) aggregate foo : (si32) -> si32
+        yield %3 : si32
+      }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op has region #1 that yields no values (use empty region instead)}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        yield
+      }
+    yield %1 : tuple<>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op has region #0 that yields no values (use empty region instead)}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        yield
+      }
+    yield %1 : tuple<>
+  }
+}

--- a/test/Dialect/Substrait/aggregate.mlir
+++ b/test/Dialect/Substrait/aggregate.mlir
@@ -1,0 +1,258 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// Check complete op with all regions and attributes.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+// CHECK-NEXT:      groupings {
+// CHECK-NEXT:        ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:        %[[V2:.*]] = literal 0 : si1
+// CHECK-NEXT:        yield %[[V2]], %[[V2]] : si1, si1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      grouping_sets {{\[}}[0], [0, 1], [1], []]
+// CHECK-NEXT:      measures {
+// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
+// CHECK-DAG:         %[[V3:.*]] = field_reference %[[ARG1]][0]
+// CHECK-DAG:         %[[V4:.*]] = literal 0
+// CHECK-DAG:         %[[V5:.*]] = call @function(%[[V3]]) aggregate :
+// CHECK-DAG:         %[[V6:.*]] = call @function(%[[V4]]) aggregate :
+// CHECK-NEXT:        yield %[[V5]], %[[V6]] : si32, si1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2, %2 : si1, si1
+      }
+      grouping_sets [[0], [0, 1], [1], []]
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = literal 0 : si1
+        %4 = call @function(%2) aggregate : (si32) -> si32
+        %5 = call @function(%3) aggregate all : (si1) -> si1
+        yield %4, %5 : si32, si1
+      }
+    yield %1 : tuple<si1, si1, si32, si1, si32>
+  }
+}
+
+// -----
+
+// Check complete op with different order.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      groupings {
+// CHECK:           }
+// CHECK-NEXT:      grouping_sets
+// CHECK-NEXT:      measures {
+// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
+// CHECK-DAG:         %[[V3:.*]] = field_reference %[[ARG1]][0]
+// CHECK-DAG:         %[[V4:.*]] = literal 0
+// CHECK-DAG:         %[[V5:.*]] = call @function(%[[V3]]) aggregate unspecified :
+// CHECK-DAG:         %[[V6:.*]] = call @function(%[[V4]]) aggregate distinct :
+// CHECK-NEXT:        yield %[[V5]], %[[V6]] : si32, si1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = literal 0 : si1
+        %4 = call @function(%2) aggregate unspecified : (si32) -> si32
+        %5 = call @function(%3) aggregate distinct : (si1) -> si1
+        yield %4, %5 : si32, si1
+      }
+      grouping_sets [[0], [0, 1], [1], []]
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2, %2 : si1, si1
+      }
+    yield %1 : tuple<si1, si1, si32, si1, si32>
+  }
+}
+
+// -----
+
+// Check op without measures.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      groupings {
+// CHECK:           }
+// CHECK-NEXT:      grouping_sets
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2, %2 : si1, si1
+      }
+      grouping_sets [[0], [0, 1], [1], []]
+    yield %1 : tuple<si1, si1, si32>
+  }
+}
+
+// -----
+
+// Check op with explicit single grouping_set.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      groupings {
+// CHECK:           }
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2, %2 : si1, si1
+      }
+      grouping_sets [[0, 1]]
+    yield %1 : tuple<si1, si1>
+  }
+}
+
+// -----
+
+// Check op with implicit single grouping_set.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      groupings {
+// CHECK:           }
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2, %2 : si1, si1
+      }
+    yield %1 : tuple<si1, si1>
+  }
+}
+
+// -----
+
+// Check op without `grouping` and no grouping sets.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      grouping_sets []
+// CHECK-NEXT:      measures {
+// CHECK:           }
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+      grouping_sets []
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = call @function(%2) aggregate : (si32) -> si32
+        yield %3 : si32
+      }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// Check op without `grouping` and implicit (empty) grouping set.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      measures {
+// CHECK:           }
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = call @function(%2) aggregate : (si32) -> si32
+        yield %3 : si32
+      }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// Check op without `grouping` and explicit empty grouping set.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      measures {
+// CHECK:           }
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+      grouping_sets [[]]
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = call @function(%2) aggregate : (si32) -> si32
+        yield %3 : si32
+      }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
@@ -1,0 +1,20 @@
+// RUN: substrait-translate -verify-diagnostics -split-input-file %s \
+// RUN:   -substrait-to-protobuf
+
+// The groupings aren't unique after CSE. This has a different meaning once
+// exported to protobuf.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.aggregate' op cannot be exported: values yielded from 'groupings' region are not all distinct after CSE}}
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        %3 = literal 0 : si1
+        yield %2, %3 : si1, si1
+      }
+    yield %1 : tuple<si1, si1>
+  }
+}

--- a/test/Target/SubstraitPB/Export/aggregate.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate.mlir
@@ -1,0 +1,230 @@
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
+// RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | FileCheck %s
+
+// Check complete op with all regions and attributes.
+
+// CHECK:      extension_uris {
+// CHECK-NEXT:   uri: "http://some.url/with/extensions.yml"
+// CHECK-NEXT: }
+// CHECK-NEXT: extensions {
+// CHECK-NEXT:   extension_function {
+// CHECK-NEXT:     name: "somefunc"
+// CHECK-NEXT:   }
+// CHECK:      relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     aggregate {
+// CHECK:            input {
+// CHECK:            groupings {
+// CHECK-NEXT:         grouping_expressions {
+// CHECK-NEXT:           literal {
+// CHECK-NEXT:             boolean: false
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       groupings {
+// CHECK-NEXT:         grouping_expressions {
+// CHECK-NEXT:           literal {
+// CHECK-NEXT:             boolean: false
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:         grouping_expressions {
+// CHECK-NEXT:           literal {
+// CHECK-NEXT:             boolean: true
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       groupings {
+// CHECK-NEXT:         grouping_expressions {
+// CHECK-NEXT:           literal {
+// CHECK-NEXT:             boolean: true
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       groupings {
+// CHECK-NEXT:       }
+// CHECK-NEXT:       measures {
+// CHECK-NEXT:         measure {
+// CHECK-NEXT:           output_type {
+// CHECK-NEXT:             i32 {
+// CHECK-NEXT:               nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:           invocation: AGGREGATION_INVOCATION_ALL
+// CHECK-NEXT:           arguments {
+// CHECK-NEXT:             value {
+// CHECK-NEXT:               selection {
+// CHECK-NOT:                  measure
+// CHECK:                    }
+// CHECK:                  }
+// CHECK:                }
+// CHECK:              }
+// CHECK:            }
+// CHECK:            measures {
+// CHECK-NEXT:         measure {
+// CHECK-NEXT:           output_type {
+// CHECK-NEXT:             bool {
+// CHECK-NEXT:               nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:           invocation: AGGREGATION_INVOCATION_ALL
+// CHECK-NEXT:           arguments {
+// CHECK-NEXT:             value {
+// CHECK-NEXT:               literal {
+// CHECK-NEXT:                 boolean: false
+// CHECK-NEXT:               }
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK:      version
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        %3 = literal -1 : si1
+        yield %2, %3 : si1, si1
+      }
+      grouping_sets [[0], [0, 1], [1], []]
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = literal 0 : si1
+        %4 = call @function(%2) aggregate : (si32) -> si32
+        %5 = call @function(%3) aggregate all : (si1) -> si1
+        yield %4, %5 : si32, si1
+      }
+    yield %1 : tuple<si1, si1, si32, si1, si32>
+  }
+}
+
+// -----
+
+// Check op without measures.
+
+// CHECK:      relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     aggregate {
+// CHECK:            input {
+// CHECK:            groupings {
+// CHECK-NOT:        measures
+// CHECK:      version
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2 : si1
+      }
+      grouping_sets [[0]]
+    yield %1 : tuple<si1>
+  }
+}
+
+// -----
+
+// Check op special invocation modes.
+
+// CHECK:      extension_uris {
+// CHECK:      relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     aggregate {
+// CHECK:            measures {
+// CHECK-NEXT:        measure {
+// CHECK-NOT:           invocation:
+// CHECK:             measure {
+// CHECK-NOT:           measure
+// CHECK:               invocation: AGGREGATION_INVOCATION_DISTINCT
+// CHECK:      version
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32, si1>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = literal 0 : si1
+        %4 = call @function(%2) aggregate unspecified : (si32) -> si32
+        %5 = call @function(%3) aggregate distinct : (si1) -> si1
+        yield %4, %5 : si32, si1
+      }
+    yield %1 : tuple<si32, si1>
+  }
+}
+
+// -----
+
+// Check op without `grouping` and no grouping sets.
+
+// CHECK:      extension_uris {
+// CHECK:      relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     aggregate {
+// CHECK-NOT:        groupings
+// CHECK:      version
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+      grouping_sets []
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %4 = call @function(%2) aggregate : (si32) -> si32
+        yield %4 : si32
+      }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// Check op without `grouping` and (implicit) empty grouping set.
+
+// CHECK:      extension_uris {
+// CHECK:      relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     aggregate {
+// CHECK:          groupings {
+// CHECK:      version
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %4 = call @function(%2) aggregate : (si32) -> si32
+        yield %4 : si32
+      }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Import/aggregate.textpb
+++ b/test/Target/SubstraitPB/Import/aggregate.textpb
@@ -1,0 +1,480 @@
+# RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
+# RUN: | FileCheck %s
+
+# RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
+# RUN: | substrait-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | FileCheck %s
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
+# CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+# CHECK-NEXT:        groupings {
+# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
+# CHECK-DAG:           %[[V2:.*]] = literal -1 : si1
+# CHECK-DAG:           %[[V3:.*]] = literal 0 : si1
+# CHECK-NEXT:          yield %[[V3]], %[[V2]] : si1, si1
+# CHECK-NEXT:        }
+# CHECK-NEXT:        grouping_sets {{\[}}[0], [0, 1], [1], []]
+# CHECK-NEXT:        measures {
+# CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
+# CHECK-DAG:           %[[V4:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
+# CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%[[V4]]) aggregate : (si32) -> si32
+# CHECK-DAG:           %[[V6:.*]] = literal 0 : si1
+# CHECK-DAG:           %[[V7:.*]] = call @[[F1]](%[[V6]]) aggregate : (si1) -> si1
+# CHECK-NEXT:          yield %[[V5]], %[[V7]] : si32, si1
+# CHECK-NEXT:        }
+# CHECK-NEXT:      yield %[[V1]] : tuple<si1, si1, si32, si1, si32>
+
+extension_uris {
+  uri: "http://some.url/with/extensions.yml"
+}
+extensions {
+  extension_function {
+    name: "somefunc"
+  }
+}
+relations {
+  rel {
+    aggregate {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      groupings {
+        grouping_expressions {
+          literal {
+            boolean: false
+          }
+        }
+      }
+      groupings {
+        grouping_expressions {
+          literal {
+            boolean: false
+          }
+        }
+        grouping_expressions {
+          literal {
+            boolean: true
+          }
+        }
+      }
+      groupings {
+        grouping_expressions {
+          literal {
+            boolean: true
+          }
+        }
+      }
+      groupings {
+      }
+      measures {
+        measure {
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          output_type {
+            bool {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              literal {
+                boolean: false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1>
+# CHECK-NEXT:        groupings {
+# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
+# CHECK-DAG:           %[[V2:.*]] = literal 0 : si1
+# CHECK-NEXT:          yield %[[V2]] : si1
+# CHECK-NEXT:        }
+# CHECK-NEXT:      yield %[[V1]] : tuple<si1>
+
+relations {
+  rel {
+    aggregate {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      groupings {
+        grouping_expressions {
+          literal {
+            boolean: false
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
+# CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32, si1>
+# CHECK-NEXT:        measures {
+# CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
+# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
+# CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate unspecified : (si32) -> si32
+# CHECK-DAG:           %[[V4:.*]] = literal 0 : si1
+# CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%[[V4]]) aggregate distinct : (si1) -> si1
+# CHECK-NEXT:          yield %[[V3]], %[[V5]] : si32, si1
+# CHECK-NEXT:        }
+# CHECK-NEXT:      yield %[[V1]] : tuple<si32, si1>
+
+extension_uris {
+  uri: "http://some.url/with/extensions.yml"
+}
+extensions {
+  extension_function {
+    name: "somefunc"
+  }
+}
+relations {
+  rel {
+    aggregate {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      groupings {
+      }
+      measures {
+        measure {
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_UNSPECIFIED
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          output_type {
+            bool {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_DISTINCT
+          arguments {
+            value {
+              literal {
+                boolean: false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
+# CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32>
+# CHECK-NEXT:        grouping_sets []
+# CHECK-NEXT:        measures {
+# CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
+# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
+# CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
+# CHECK-NEXT:          yield %[[V3]] : si32
+# CHECK-NEXT:        }
+# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+
+extension_uris {
+  uri: "http://some.url/with/extensions.yml"
+}
+extensions {
+  extension_function {
+    name: "somefunc"
+  }
+}
+relations {
+  rel {
+    aggregate {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      measures {
+        measure {
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
+# CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32>
+# CHECK-NEXT:        measures {
+# CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
+# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
+# CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
+# CHECK-NEXT:          yield %[[V3]] : si32
+# CHECK-NEXT:        }
+# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+
+extension_uris {
+  uri: "http://some.url/with/extensions.yml"
+}
+extensions {
+  extension_function {
+    name: "somefunc"
+  }
+}
+relations {
+  rel {
+    aggregate {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      groupings {
+      }
+      measures {
+        measure {
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #68.~~

This PR adds support for the `AggregateRel` from the Substrait spec in the form of the `aggregate` op. This is arguably the most complex op implemented so far. It has an optional enum argument that requires custom parsing, several optional regions that require custom parsing, an attribute that depends on the presence and contents of the regions and requires custom parsing to omit it in the common case, and return types that depend on the two regions and the attribute. What's more, the current version of the spec is such that it is almost impossibly to interpret "grouping sets" because it relies on protobuf message equality, which is something can protobuf does not offer. The current implementation, thus, implements a best effort by using op equality instead (but needs to run CSE during export to ensure op uniqueness). Finally, the PR also extends the `call` op to represent also `AggregateFunction` messages (in addition to `ScalarFunction` messages), which are used by the new `aggregate` op.