### PR TITLE
feat: implement `extension_table` op

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -43,6 +43,9 @@ def Substrait_DefaultEmptyStringParameter
 // Substrait attributes
 //===----------------------------------------------------------------------===//
 
+/// Attribute used for `google.protobuf.Any` messages.
+def Substrait_AnyAttr : TypedStrAttr<Substrait_AnyType>;
+
 def Substrait_AdvancedExtensionAttr
     : Substrait_Attr<"AdvancedExtension", "advanced_extension"> {
   let summary = "Represents the `AdvancedExtenssion` message of Substrait";

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -547,6 +547,29 @@ def Substrait_EmitOp : Substrait_RelOp<"emit", [
   }];
 }
 
+def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table"> {
+  let summary = "Extension table operation (i.e., a `ReadRel` case)";
+  let description = [{
+    Represents a `ExtensionTable` message together with the `ReadRel` and `Rel`
+    messages that contain it.
+
+    Example:
+
+    ```mlir
+    %0 = extension_table
+           "some detail" : !substrait.any<"some url">
+           as ["a"] : tuple<si32>
+    ```
+  }];
+  let arguments = (ins
+    StringArrayAttr:$field_names,
+    Substrait_AnyAttr:$detail
+  );
+  let results = (outs Substrait_Relation:$result);
+  let assemblyFormat = "$detail `as` $field_names attr-dict `:` type($result)";
+  let hasVerifier = true;
+}
+
 def Substrait_FetchOp : Substrait_RelOp<"fetch", [
     SameOperandsAndResultType
   ]> {

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -83,7 +83,7 @@ def Substrait_AtomicTypes {
 }
 
 def Substrait_AnyType : Substrait_Type<"Any", "any"> {
-  let summary = "Represents the `type_url` of a `google.protobuf.Any` message";
+  let summary = "type of a 'google.protobuf.Any' protobuf message";
   let description = [{
     This type represents the `type_url` fields of a `google.protobuf.Any`
     message. These messages consist of an opaque byte array and a string holding

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -623,6 +623,12 @@ EmitOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
   return success();
 }
 
+LogicalResult ExtensionTableOp::verify() {
+  llvm::ArrayRef<Attribute> fieldNames = getFieldNames().getValue();
+  auto tupleType = llvm::cast<TupleType>(getResult().getType());
+  return verifyNamedStruct(getOperation(), fieldNames, tupleType);
+}
+
 LogicalResult FieldReferenceOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,

--- a/test/Dialect/Substrait/extension-table.mlir
+++ b/test/Dialect/Substrait/extension-table.mlir
@@ -1,0 +1,18 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:           %[[V0:.*]] = extension_table
+// CHECK-SAME:        "some detail" : !substrait.any<"some url">
+// CHECK-SAME:        as ["a"] : tuple<si32>
+// CHECK-NEXT:      yield %[[V0]] : tuple<si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = extension_table
+           "some detail" : !substrait.any<"some url">
+           as ["a"] : tuple<si32>
+    yield %0 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/extension-table.mlir
+++ b/test/Target/SubstraitPB/Export/extension-table.mlir
@@ -1,0 +1,48 @@
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
+// RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | FileCheck %s
+
+// CHECK:      relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     read {
+// CHECK-NEXT:       common {
+// CHECK-NEXT:         direct {
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       base_schema {
+// CHECK-NEXT:         names: "a"
+// CHECK-NEXT:         struct {
+// CHECK-NEXT:           types {
+// CHECK-NEXT:             i32 {
+// CHECK-NEXT:               nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:           nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       extension_table {
+// CHECK-NEXT:         detail {
+// CHECK-NEXT:           type_url: "some url"
+// CHECK-NEXT:           value: "some detail"
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: version {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = extension_table
+           "some detail" : !substrait.any<"some url">
+           as ["a"] : tuple<si32>
+    yield %0 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Import/extension-table.textpb
+++ b/test/Target/SubstraitPB/Import/extension-table.textpb
@@ -1,0 +1,46 @@
+# RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN: | FileCheck %s
+
+# RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN: | substrait-translate -substrait-to-protobuf \
+# RUN: | substrait-translate -protobuf-to-substrait \
+# RUN: | FileCheck %s
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation {
+# CHECK-NEXT:      %[[V0:.*]] = extension_table
+# CHECK-SAME:        "some detail" : !substrait.any<"some url">
+# CHECK-SAME:        as ["a"] : tuple<si32>
+# CHECK-NEXT:      yield %[[V0]] : tuple<si32>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      extension_table {
+        detail {
+          type_url: "some url"
+          value: "some detail"
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
This PR is based on and, therefor, contains #72.

This PR implements the `extension_table` op, the MLIR equivalent of the `ReadRel.ExtensionTable` message. Since that message uses the `google.protobuf.Any` message type, the PR also slightly extends and improves the handling of that message in the dialect. Finally, because `extension_table` is the second op corresponding to a `ReadRel` case (after `named_table`), the PR makes some effort to factor out common logic between the two, namely, how the named structs representing the schema of the op are handled. However, there is still some opportunity for factoring out further that the PR does not do, such as defining a `ReadRelInterface`.