### PR TITLE
style: clean up `SubstraitEnums.td`

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -27,8 +27,11 @@ def AggregationInvocation
 }
 
 /// Represents the `JoinType` protobuf enum.
-def JoinTypeKind : I32EnumAttr<"JoinTypeKind",
-  "The enum values correspond to those in the JoinRel.JoinType message.", [
+///
+/// The enum values correspond exactly to those in the `JoinRel.JoinType` enum,
+/// i.e., conversion through integers is possible.
+def JoinType : I32EnumAttr<"JoinType", "", [
+    // clang-format off
     I32EnumAttrCase<"unspecified", 0>,
     I32EnumAttrCase<"inner", 1>,
     I32EnumAttrCase<"outer", 2>,
@@ -36,21 +39,28 @@ def JoinTypeKind : I32EnumAttr<"JoinTypeKind",
     I32EnumAttrCase<"right", 4>,
     I32EnumAttrCase<"semi", 5>,
     I32EnumAttrCase<"anti", 6>,
-    I32EnumAttrCase<"single", 7>] > {
-    let cppNamespace = "::mlir::substrait";
+    I32EnumAttrCase<"single", 7>,
+    // clang-format on
+  ]> {
+  let cppNamespace = "::mlir::substrait";
 }
 
 /// Represents the `SetOp` protobuf enum.
-def SetOpKind : I32EnumAttr<"SetOpKind",
-  "The enum values correspond to those in the SetRel.SetOp message.", [
+///
+/// The enum values correspond exactly to those in the `SetRel.SetOp` enum,
+/// i.e., conversion through integers is possible.
+def SetOpKind : I32EnumAttr<"SetOpKind", "", [
+    // clang-format off
     I32EnumAttrCase<"unspecified", 0>,
     I32EnumAttrCase<"minus_primary", 1>,
     I32EnumAttrCase<"minus_multiset", 2>,
     I32EnumAttrCase<"intersection_primary", 3>,
     I32EnumAttrCase<"intersection_multiset", 4>,
     I32EnumAttrCase<"union_distinct", 5>,
-    I32EnumAttrCase<"union_all", 6>] > {
-    let cppNamespace = "::mlir::substrait";
+    I32EnumAttrCase<"union_all", 6>,
+    // clang-format on
+  ]> {
+  let cppNamespace = "::mlir::substrait";
 }
 
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITENUMS

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -617,7 +617,7 @@ def Substrait_JoinOp : Substrait_RelOp<"join", [DeclareOpInterfaceMethods<InferT
   let arguments = (ins
     Substrait_Relation:$left,
     Substrait_Relation:$right,
-    JoinTypeKind:$join_type
+    JoinType:$join_type
   );
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -637,24 +637,24 @@ JoinOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 
   // Get accessor to `join_type`.
   Adaptor adaptor(operands, attributes, properties, regions);
-  JoinTypeKind join_type = adaptor.getJoinType();
+  JoinType join_type = adaptor.getJoinType();
 
   SmallVector<mlir::Type> fieldTypes;
 
   switch (join_type) {
-  case JoinTypeKind::unspecified:
-  case JoinTypeKind::inner:
-  case JoinTypeKind::outer:
-  case JoinTypeKind::right:
-  case JoinTypeKind::left:
+  case JoinType::unspecified:
+  case JoinType::inner:
+  case JoinType::outer:
+  case JoinType::right:
+  case JoinType::left:
     llvm::append_range(fieldTypes, leftFieldTypes);
     llvm::append_range(fieldTypes, rightFieldTypes);
     break;
-  case JoinTypeKind::semi:
-  case JoinTypeKind::anti:
+  case JoinType::semi:
+  case JoinType::anti:
     llvm::append_range(fieldTypes, leftFieldTypes);
     break;
-  case JoinTypeKind::single:
+  case JoinType::single:
     llvm::append_range(fieldTypes, rightFieldTypes);
     break;
   }

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -516,8 +516,7 @@ static mlir::FailureOr<JoinOp> importJoinRel(ImplicitLocOpBuilder builder,
   Value leftVal = leftOp.value()->getResult(0);
   Value rightVal = rightOp.value()->getResult(0);
 
-  std::optional<JoinTypeKind> join_type =
-      static_cast<::JoinTypeKind>(joinRel.type());
+  std::optional<JoinType> join_type = static_cast<JoinType>(joinRel.type());
 
   // Check for unsupported set operations.
   if (!join_type)


### PR DESCRIPTION
This PR makes some clean-ups to `SubstraitEnums.td`:

* Reformat (mostly) according to `clang-format`.
* Remove unnecessary `Kind` suffix in `JoinTypeKind`.
* Move `summary` property of enum `def`s to comment.
* Rephrase those comments to make them clearer.