### PR TITLE
feat: implement `cast` op for `Cast` expression

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
+++ b/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
@@ -13,6 +13,7 @@
 #include "mlir/IR/Dialect.h"                      // IWYU: keep
 #include "mlir/IR/OpImplementation.h"             // IWYU: keep
 #include "mlir/IR/SymbolTable.h"                  // IWYU: keep
+#include "mlir/Interfaces/CastInterfaces.h"       // IWYU: keep
 #include "mlir/Interfaces/InferTypeOpInterface.h" // IWYU: keep
 
 //===----------------------------------------------------------------------===//

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -26,6 +26,20 @@ def AggregationInvocation
   let cppNamespace = "::mlir::substrait";
 }
 
+/// Represents the `FailureBehavior` enum.
+///
+/// The enum values correspond exactly to those in the `Cast.FailureBehavior`
+/// enum, i.e., conversion through integers is possible.
+def FailureBehavior : I32EnumAttr<"FailureBehavior", "", [
+    // clang-format off
+    I32EnumAttrCase<"unspecified", 0>,
+    I32EnumAttrCase<"return_null", 1>,
+    I32EnumAttrCase<"throw_exception", 2>,
+    // clang-format on
+  ]> {
+  let cppNamespace = "::mlir::substrait";
+}
+
 /// Represents the `JoinType` protobuf enum.
 ///
 /// The enum values correspond exactly to those in the `JoinRel.JoinType` enum,

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -14,6 +14,7 @@ include "substrait-mlir/Dialect/Substrait/IR/SubstraitDialect.td"
 include "substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td"
 include "substrait-mlir/Dialect/Substrait/IR/SubstraitInterfaces.td"
 include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td"
+include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
@@ -284,6 +285,40 @@ class Substrait_ExpressionOp<string mnemonic, list<Trait> traits = []> :
   Substrait_Op<mnemonic, traits # [
     Substrait_ExpressionOpInterface, Pure
   ]>;
+
+def Substrait_CastOp : Substrait_ExpressionOp<"cast", [
+     DeclareOpInterfaceMethods<CastOpInterface>
+  ]> {
+  let summary = "Cast expression";
+  let description = [{
+    Represents a `Cast` message.
+
+    Example:
+
+    ```mlir
+    %0 = literal 42 : si32
+    %1 = cast %0 : si32 to si64
+    ```
+  }];
+  let arguments = (ins
+    Substrait_FieldType:$input,
+    FailureBehavior:$failure_behavior
+  );
+  // TODO(ingomueller): verify that result type is nullable if
+  // `failure_behavior` is set to `return_null` once we have implemented
+  // nullability.
+  let results = (outs Substrait_FieldType:$result);
+  let assemblyFormat = [{
+    $input `or` $failure_behavior attr-dict `:` type($input) `to` type($result)
+  }];
+  let extraClassDefinition = [{
+    /// Implement `CastOpInterface`.
+    bool $cppClass::areCastCompatible(::mlir::TypeRange inputs,
+                                      ::mlir::TypeRange outputs) {
+      return true;
+    }
+  }];
+}
 
 def Substrait_FieldReferenceOp : Substrait_ExpressionOp<"field_reference", [
     DeclareOpInterfaceMethods<InferTypeOpInterface>

--- a/lib/Dialect/Substrait/IR/CMakeLists.txt
+++ b/lib/Dialect/Substrait/IR/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_dialect_library(MLIRSubstraitDialect
   Substrait.cpp
 
   LINK_LIBS PUBLIC
+  MLIRCastInterfaces
   MLIRInferTypeOpInterface
   MLIRIR
 

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -50,6 +50,7 @@ public:
 
   DECLARE_EXPORT_FUNC(AggregateOp, Rel)
   DECLARE_EXPORT_FUNC(CallOp, Expression)
+  DECLARE_EXPORT_FUNC(CastOp, Expression)
   DECLARE_EXPORT_FUNC(CrossOp, Rel)
   DECLARE_EXPORT_FUNC(EmitOp, Rel)
   DECLARE_EXPORT_FUNC(ExpressionOpInterface, Expression)
@@ -502,6 +503,44 @@ SubstraitExporter::exportOperation(CallOp op) {
   return op->emitOpError() << "with aggregate function not expected here";
 }
 
+FailureOr<std::unique_ptr<Expression>>
+SubstraitExporter::exportOperation(CastOp op) {
+  using FailureBehavior = Expression::Cast::FailureBehavior;
+
+  Location loc = op.getLoc();
+
+  // Export `input` as `Expression` message.
+  Value inputVal = op.getInput();
+  auto definingOp = llvm::dyn_cast_if_present<ExpressionOpInterface>(
+      inputVal.getDefiningOp());
+  if (!definingOp)
+    return op->emitOpError()
+           << "with 'input' that was not produced by Substrait expression op";
+
+  FailureOr<std::unique_ptr<Expression>> input = exportOperation(definingOp);
+  if (failed(input))
+    return failure();
+
+  // Build message for `output_type`.
+  FailureOr<std::unique_ptr<proto::Type>> outputType =
+      exportType(loc, op.getResult().getType());
+  if (failed(outputType))
+    return failure();
+
+  // Build `Cast` message.
+  auto cast = std::make_unique<Expression::Cast>();
+  cast->set_allocated_input(input->release());
+  cast->set_allocated_type(outputType->release());
+  cast->set_failure_behavior(
+      static_cast<FailureBehavior>(op.getFailureBehavior()));
+
+  // Build `Expression` message.
+  auto expression = std::make_unique<Expression>();
+  expression->set_allocated_cast(cast.release());
+
+  return expression;
+}
+
 FailureOr<std::unique_ptr<Rel>> SubstraitExporter::exportOperation(CrossOp op) {
   // Build `RelCommon` message.
   auto relCommon = std::make_unique<RelCommon>();
@@ -625,7 +664,7 @@ FailureOr<std::unique_ptr<Expression>>
 SubstraitExporter::exportOperation(ExpressionOpInterface op) {
   return llvm::TypeSwitch<Operation *, FailureOr<std::unique_ptr<Expression>>>(
              op)
-      .Case<CallOp, FieldReferenceOp, LiteralOp>(
+      .Case<CallOp, CastOp, FieldReferenceOp, LiteralOp>(
           [&](auto op) { return exportOperation(op); })
       .Default(
           [](auto op) { return op->emitOpError("not supported for export"); });

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -75,6 +75,7 @@ struct SimpleOperationInfo : public llvm::DenseMapInfo<Operation *> {
 DECLARE_IMPORT_FUNC(AggregateFunction, AggregateFunction, CallOp)
 DECLARE_IMPORT_FUNC(AggregateRel, Rel, AggregateOp)
 DECLARE_IMPORT_FUNC(Any, pb::Any, StringAttr)
+DECLARE_IMPORT_FUNC(Cast, Expression::Cast, CastOp)
 DECLARE_IMPORT_FUNC(CrossRel, Rel, CrossOp)
 DECLARE_IMPORT_FUNC(FetchRel, Rel, FetchOp)
 DECLARE_IMPORT_FUNC(FilterRel, Rel, FilterOp)
@@ -372,6 +373,31 @@ importAggregateRel(ImplicitLocOpBuilder builder, const Rel &message) {
   return aggregateOp;
 }
 
+static mlir::FailureOr<CastOp> importCast(ImplicitLocOpBuilder builder,
+                                          const Expression::Cast &message) {
+  MLIRContext *context = builder.getContext();
+
+  // Import `input` field.
+  const Expression &input = message.input();
+  FailureOr<ExpressionOpInterface> inputOp = importExpression(builder, input);
+  if (failed(inputOp))
+    return failure();
+
+  // Import `type` field.
+  const proto::Type &type = message.type();
+  FailureOr<mlir::Type> mlirType = importType(context, type);
+  if (failed(mlirType))
+    return failure();
+
+  // Import `failure_behavior` field.
+  auto failureBehavior =
+      static_cast<FailureBehavior>(message.failure_behavior());
+
+  // Create `cast` op.
+  Value inputVal = inputOp.value()->getResult(0);
+  return builder.create<CastOp>(mlirType.value(), inputVal, failureBehavior);
+}
+
 static mlir::FailureOr<CrossOp> importCrossRel(ImplicitLocOpBuilder builder,
                                                const Rel &message) {
   const CrossRel &crossRel = message.cross();
@@ -425,6 +451,8 @@ importExpression(ImplicitLocOpBuilder builder, const Expression &message) {
 
   Expression::RexTypeCase rex_type = message.rex_type_case();
   switch (rex_type) {
+  case Expression::kCast:
+    return importCast(builder, message.cast());
   case Expression::kLiteral:
     return importLiteral(builder, message.literal());
   case Expression::kSelection:

--- a/test/Dialect/Substrait/cast.mlir
+++ b/test/Dialect/Substrait/cast.mlir
@@ -1,0 +1,30 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] :
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:      %[[V2:.*]] = literal 42 : si32
+// CHECK-NEXT:      %[[V3:.*]] = cast %[[V2]] or return_null : si32 to si64
+// CHECK-NEXT:      %[[V4:.*]] = cast %[[V2]] or throw_exception : si32 to si64
+// CHECK-NEXT:      %[[V5:.*]] = cast %[[V2]] or unspecified : si32 to si64
+// CHECK-NEXT:      yield %[[V3]], %[[V4]], %[[V5]] : si64, si64, si64
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] :
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = project %0 : tuple<si32> -> tuple<si32, si64, si64, si64> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal 42 : si32
+      %3 = cast %2 or return_null : si32 to si64
+      %4 = cast %2 or throw_exception : si32 to si64
+      %5 = cast %2 or unspecified : si32 to si64
+      yield %3, %4, %5 : si64, si64, si64
+    }
+    yield %1 : tuple<si32, si64, si64, si64>
+  }
+}

--- a/test/Target/SubstraitPB/Export/cast.mlir
+++ b/test/Target/SubstraitPB/Export/cast.mlir
@@ -1,0 +1,73 @@
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
+// RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK:             expressions {
+// CHECK-NEXT:          cast {
+// CHECK-NEXT:            type {
+// CHECK-NEXT:              i64 {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            input {
+// CHECK-NEXT:              literal {
+// CHECK-NEXT:                i32: 42
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            failure_behavior: FAILURE_BEHAVIOR_RETURN_NULL
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        expressions {
+// CHECK-NEXT:          cast {
+// CHECK-NEXT:            type {
+// CHECK-NEXT:              i64 {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            input {
+// CHECK-NEXT:              literal {
+// CHECK-NEXT:                i32: 42
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            failure_behavior: FAILURE_BEHAVIOR_THROW_EXCEPTION
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        expressions {
+// CHECK-NEXT:          cast {
+// CHECK-NEXT:            type {
+// CHECK-NEXT:              i64 {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            input {
+// CHECK-NEXT:              literal {
+// CHECK-NEXT:                i32: 42
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = project %0 : tuple<si32> -> tuple<si32, si64, si64, si64> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal 42 : si32
+      %3 = cast %2 or return_null : si32 to si64
+      %4 = cast %2 or throw_exception : si32 to si64
+      %5 = cast %2 or unspecified : si32 to si64
+      yield %3, %4, %5 : si64, si64, si64
+    }
+    yield %1 : tuple<si32, si64, si64, si64>
+  }
+}

--- a/test/Target/SubstraitPB/Import/cast.textpb
+++ b/test/Target/SubstraitPB/Import/cast.textpb
@@ -1,0 +1,102 @@
+# RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
+# RUN: | FileCheck %s
+
+# RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
+# RUN: | substrait-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | FileCheck %s
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      named_table
+# CHECK-NEXT:      project
+# CHECK-NEXT:      (%[[V0:.*]]: tuple<si32>):
+# CHECK-DAG:         %[[V1:.*]] = cast %{{.*}} or return_null : si32 to si64
+# CHECK-DAG:         %[[V2:.*]] = cast %{{.*}} or throw_exception : si32 to si64
+# CHECK-DAG:         %[[V3:.*]] = cast %{{.*}} or unspecified : si32 to si64
+# CHECK-NEXT:        yield %[[V1]], %[[V2]], %[[V3]] :
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        cast {
+          type {
+            i64 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          input {
+            literal {
+              i32: 42
+            }
+          }
+          failure_behavior: FAILURE_BEHAVIOR_RETURN_NULL
+        }
+      }
+      expressions {
+        cast {
+          type {
+            i64 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          input {
+            literal {
+              i32: 42
+            }
+          }
+          failure_behavior: FAILURE_BEHAVIOR_THROW_EXCEPTION
+        }
+      }
+      expressions {
+        cast {
+          type {
+            i64 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          input {
+            literal {
+              i32: 42
+            }
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
This PR depends on and, therefor, includes #75.

This PR implements the `cast` op, which corresponds to the `Cast` expression in Substrait. This is one of the few remaining message types we need to support to get a first TPC-H query round-tripped.