### PR TITLE
feat: implement `aggregation_phase` of `call` op

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -26,6 +26,23 @@ def AggregationInvocation
   let cppNamespace = "::mlir::substrait";
 }
 
+/// Represents the `AggregationPhase` protobuf enum.
+//
+/// The enum values correspond exactly to those in the `JoinRel.JoinType` enum,
+/// i.e., conversion through integers is possible.
+def AggregationPhase
+    : I32EnumAttr<"AggregationPhase", "aggregate invocation phase", [
+        // clang-format off
+        I32EnumAttrCase<"unspecified", 0>,
+        I32EnumAttrCase<"initial_to_intermediate", 1>,
+        I32EnumAttrCase<"intermediate_to_intermediate", 2>,
+        I32EnumAttrCase<"initial_to_result", 3>,
+        I32EnumAttrCase<"intermediate_to_result", 4>,
+        // clang-format on
+      ]> {
+  let cppNamespace = "::mlir::substrait";
+}
+
 /// Represents the `FailureBehavior` enum.
 ///
 /// The enum values correspond exactly to those in the `Cast.FailureBehavior`

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -371,6 +371,12 @@ def Substrait_LiteralOp : Substrait_ExpressionOp<"literal", [
 
 def Substrait_CallOp : Substrait_ExpressionOp<"call", [
     DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+    PredOpTrait<"'aggregation_phase' and 'aggregation_invocation' must either "
+                "both be set or both not be set",
+                CPred<[{ ::llvm::all_equal(
+                              {$aggregation_phase.has_value(),
+                               $aggregation_invocation.has_value()}) }]>
+    >,
   ]> {
   let summary = "Function call expression";
   let description = [{
@@ -378,9 +384,14 @@ def Substrait_CallOp : Substrait_ExpressionOp<"call", [
     future, a `WindowFunction` message) together with all messages it contains
     and, where applicable, the `Expression` message it is contained in. Which of
     the message types this op corresponds to depends on the presence of the
-    (otherwise optional) aggregate or window-related attributes. For aggregate
-    functions, the invocation type is omitted from the custom assembly if it is
-    set to `all`.
+    (otherwise optional) aggregate or window-related attributes.
+
+    For aggregate functions, the aggregation phase is ommitted if it is set to
+    `initial_to_result`; the invocation type is omitted from the custom assembly
+    if it is set to `all`. If only `unspecified` is provided, the aggregation
+    phase will be set to that value and the invocation type to `all`. The
+    printer avoids that case by always printing the attribute value of the other
+    one of these two is `unspecified`.
 
     Currently, the specification of the function, which is in an external YAML
     file, is not taken into account, for example, to verify whether a matching
@@ -403,12 +414,14 @@ def Substrait_CallOp : Substrait_ExpressionOp<"call", [
   let arguments = (ins
     FlatSymbolRefAttr:$callee,
     Variadic<Substrait_ExpressionType>:$args,
+    OptionalAttr<AggregationPhase>:$aggregation_phase,
     OptionalAttr<AggregationInvocation>:$aggregation_invocation
   );
   let results = (outs Substrait_ExpressionType:$result);
   let assemblyFormat = [{
     $callee `(` $args `)`
-    (`aggregate` `` custom<AggregationInvocation>($aggregation_invocation)^)?
+    (`aggregate` ``
+      custom<AggregationDetails>($aggregation_phase, $aggregation_invocation)^)?
     attr-dict `:` `(` type($args) `)` `->` type($result)
   }];
   let builders = [
@@ -416,11 +429,13 @@ def Substrait_CallOp : Substrait_ExpressionOp<"call", [
                      "::mlir::FlatSymbolRefAttr":$callee,
                      "::mlir::ValueRange":$args), [{
         build($_builder, $_state, result, callee, args,
+              AggregationPhaseAttr(),
               AggregationInvocationAttr());
       }]>,
       OpBuilder<(ins "::mlir::Type":$result, "::llvm::StringRef":$callee,
                      "::mlir::ValueRange":$args), [{
         build($_builder, $_state, result, callee, args,
+              AggregationPhaseAttr(),
               AggregationInvocationAttr());
       }]>
     ];

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -388,10 +388,10 @@ def Substrait_CallOp : Substrait_ExpressionOp<"call", [
 
     For aggregate functions, the aggregation phase is ommitted if it is set to
     `initial_to_result`; the invocation type is omitted from the custom assembly
-    if it is set to `all`. If only `unspecified` is provided, the aggregation
+    of it is set to `all`. If only `unspecified` is provided, the aggregation
     phase will be set to that value and the invocation type to `all`. The
     printer avoids that case by always printing the attribute value of the other
-    one of these two is `unspecified`.
+    if one of these two is `unspecified`.
 
     Currently, the specification of the function, which is in an external YAML
     file, is not taken into account, for example, to verify whether a matching

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1428,6 +1428,8 @@ FailureOr<std::unique_ptr<AggregateFunction>>
 SubstraitExporter::exportCallOpAggregate(CallOp op) {
   assert(op.isAggregate() && "expected aggregate function");
 
+  using AggregationPhase = ::mlir::substrait::AggregationPhase;
+
   // Export common fields.
   FailureOr<std::unique_ptr<AggregateFunction>> maybeAggregateFunction =
       exportCallOpCommon<AggregateFunction>(op);
@@ -1437,6 +1439,8 @@ SubstraitExporter::exportCallOpAggregate(CallOp op) {
       std::move(maybeAggregateFunction.value());
 
   // Add aggregation-specific fields.
+  AggregationPhase phase = op.getAggregationPhase().value();
+  aggregateFunction->set_phase(static_cast<proto::AggregationPhase>(phase));
   AggregationInvocation invocation = op.getAggregationInvocation().value();
   aggregateFunction->set_invocation(
       static_cast<AggregateFunction::AggregationInvocation>(invocation));

--- a/test/Dialect/Substrait/aggregate.mlir
+++ b/test/Dialect/Substrait/aggregate.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si32>
 // CHECK-NEXT:      groupings {
 // CHECK-NEXT:        ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:        %[[V2:.*]] = literal 0 : si1
@@ -16,10 +16,8 @@
 // CHECK-NEXT:      measures {
 // CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
 // CHECK-DAG:         %[[V3:.*]] = field_reference %[[ARG1]][0]
-// CHECK-DAG:         %[[V4:.*]] = literal 0
-// CHECK-DAG:         %[[V5:.*]] = call @function(%[[V3]]) aggregate :
-// CHECK-DAG:         %[[V6:.*]] = call @function(%[[V4]]) aggregate :
-// CHECK-NEXT:        yield %[[V5]], %[[V6]] : si32, si1
+// CHECK-DAG:         %[[V4:.*]] = call @function(%[[V3]]) aggregate :
+// CHECK-NEXT:        yield %[[V4]] : si32
 // CHECK-NEXT:      }
 // CHECK-NEXT:      yield %[[V1]]
 
@@ -28,7 +26,7 @@ substrait.plan version 0 : 42 : 1 {
   extension_function @function at @extension["somefunc"]
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -38,12 +36,10 @@ substrait.plan version 0 : 42 : 1 {
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
-        %3 = literal 0 : si1
-        %4 = call @function(%2) aggregate : (si32) -> si32
-        %5 = call @function(%3) aggregate all : (si1) -> si1
-        yield %4, %5 : si32, si1
+        %3 = call @function(%2) aggregate : (si32) -> si32
+        yield %3 : si32
       }
-    yield %1 : tuple<si1, si1, si32, si1, si32>
+    yield %1 : tuple<si1, si1, si32, si32>
   }
 }
 
@@ -61,10 +57,8 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      measures {
 // CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
 // CHECK-DAG:         %[[V3:.*]] = field_reference %[[ARG1]][0]
-// CHECK-DAG:         %[[V4:.*]] = literal 0
-// CHECK-DAG:         %[[V5:.*]] = call @function(%[[V3]]) aggregate unspecified :
-// CHECK-DAG:         %[[V6:.*]] = call @function(%[[V4]]) aggregate distinct :
-// CHECK-NEXT:        yield %[[V5]], %[[V6]] : si32, si1
+// CHECK-DAG:         %[[V4:.*]] = call @function(%[[V3]]) aggregate :
+// CHECK-NEXT:        yield %[[V4]] : si32
 // CHECK-NEXT:      }
 // CHECK-NEXT:      yield %[[V1]]
 
@@ -73,14 +67,12 @@ substrait.plan version 0 : 42 : 1 {
   extension_function @function at @extension["somefunc"]
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
-        %3 = literal 0 : si1
-        %4 = call @function(%2) aggregate unspecified : (si32) -> si32
-        %5 = call @function(%3) aggregate distinct : (si1) -> si1
-        yield %4, %5 : si32, si1
+        %3 = call @function(%2) aggregate : (si32) -> si32
+        yield %3 : si32
       }
       grouping_sets [[0], [0, 1], [1], []]
       groupings {
@@ -88,7 +80,7 @@ substrait.plan version 0 : 42 : 1 {
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
-    yield %1 : tuple<si1, si1, si32, si1, si32>
+    yield %1 : tuple<si1, si1, si32, si32>
   }
 }
 
@@ -254,5 +246,63 @@ substrait.plan version 0 : 42 : 1 {
         yield %3 : si32
       }
     yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// Check combinations of aggregation details.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
+// CHECK-NEXT:      measures {
+// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
+// CHECK-DAG:         %[[V2:.*]] = field_reference %[[ARG1]][0]
+// CHECK-DAG:         %[[V3:.*]] = call @function(%[[V2]]) aggregate :
+// CHECK-DAG:         %[[V4:.*]] = call @function(%[[V2]]) aggregate :
+// CHECK-DAG:         %[[V5:.*]] = call @function(%[[V2]]) aggregate :
+// CHECK-DAG:         %[[V6:.*]] = call @function(%[[V2]]) aggregate :
+// CHECK-DAG:         %[[V7:.*]] = call @function(%[[V2]]) aggregate unspecified all :
+// CHECK-DAG:         %[[V8:.*]] = call @function(%[[V2]]) aggregate initial_to_result unspecified :
+// CHECK-DAG:         %[[V9:.*]] = call @function(%[[V2]]) aggregate unspecified all :
+// CHECK-DAG:         %[[Va:.*]] = call @function(%[[V2]]) aggregate distinct :
+// CHECK-DAG:         %[[Vb:.*]] = call @function(%[[V2]]) aggregate distinct :
+// CHECK-DAG:         %[[Vc:.*]] = call @function(%[[V2]]) aggregate intermediate_to_result :
+// CHECK-DAG:         %[[Vd:.*]] = call @function(%[[V2]]) aggregate intermediate_to_result :
+// CHECK-DAG:         %[[Ve:.*]] = call @function(%[[V2]]) aggregate initial_to_intermediate :
+// CHECK-DAG:         %[[Vf:.*]] = call @function(%[[V2]]) aggregate intermediate_to_intermediate :
+// CHECK-NEXT:        yield %[[V3]], %[[V4]], %[[V5]], %[[V6]], %[[V7]], %[[V8]], %[[V9]], %[[Va]], %[[Vb]], %[[Vc]], %[[Vd]], %[[Ve]], %[[Vf]] :
+// CHECK-NEXT:      }
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0 : tuple<si32>
+          -> tuple<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
+      measures {
+      ^bb0(%arg : tuple<si32>):
+        %2 = field_reference %arg[0] : tuple<si32>
+        %3 = call @function(%2) aggregate : (si32) -> si32
+        %4 = call @function(%2) aggregate all : (si32) -> si32
+        %5 = call @function(%2) aggregate initial_to_result : (si32) -> si32
+        %6 = call @function(%2) aggregate initial_to_result all : (si32) -> si32
+        %7 = call @function(%2) aggregate unspecified all : (si32) -> si32
+        %8 = call @function(%2) aggregate initial_to_result unspecified : (si32) -> si32
+        %9 = call @function(%2) aggregate unspecified : (si32) -> si32
+        %a = call @function(%2) aggregate distinct : (si32) -> si32
+        %b = call @function(%2) aggregate initial_to_result distinct : (si32) -> si32
+        %c = call @function(%2) aggregate intermediate_to_result : (si32) -> si32
+        %d = call @function(%2) aggregate intermediate_to_result all : (si32) -> si32
+        %e = call @function(%2) aggregate initial_to_intermediate : (si32) -> si32
+        %f = call @function(%2) aggregate intermediate_to_intermediate : (si32) -> si32
+        yield %3, %4, %5, %6, %7, %8, %9, %a, %b, %c, %d, %e, %f
+              : si32, si32, si32, si32, si32, si32, si32,
+                si32, si32, si32, si32, si32, si32
+      }
+    yield %1 : tuple<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
   }
 }

--- a/test/Target/SubstraitPB/Import/aggregate.textpb
+++ b/test/Target/SubstraitPB/Import/aggregate.textpb
@@ -15,7 +15,7 @@
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si1, si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si32>
 # CHECK-NEXT:        groupings {
 # CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = literal -1 : si1
@@ -27,11 +27,9 @@
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V4:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
 # CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%[[V4]]) aggregate : (si32) -> si32
-# CHECK-DAG:           %[[V6:.*]] = literal 0 : si1
-# CHECK-DAG:           %[[V7:.*]] = call @[[F1]](%[[V6]]) aggregate : (si1) -> si1
-# CHECK-NEXT:          yield %[[V5]], %[[V7]] : si32, si1
+# CHECK-NEXT:          yield %[[V5]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si1, si1, si32, si1, si32>
+# CHECK-NEXT:      yield %[[V1]] : tuple<si1, si1, si32, si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -100,6 +98,7 @@ relations {
       }
       measures {
         measure {
+          phase: AGGREGATION_PHASE_INITIAL_TO_RESULT
           output_type {
             i32 {
               nullability: NULLABILITY_REQUIRED
@@ -120,23 +119,6 @@ relations {
           }
         }
       }
-      measures {
-        measure {
-          output_type {
-            bool {
-              nullability: NULLABILITY_REQUIRED
-            }
-          }
-          invocation: AGGREGATION_INVOCATION_ALL
-          arguments {
-            value {
-              literal {
-                boolean: false
-              }
-            }
-          }
-        }
-      }
     }
   }
 }
@@ -146,7 +128,6 @@ version {
 }
 
 # -----
-
 
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation
@@ -205,22 +186,19 @@ version {
 
 # -----
 
-
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32, si1>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32>
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
-# CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate unspecified : (si32) -> si32
-# CHECK-DAG:           %[[V4:.*]] = literal 0 : si1
-# CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%[[V4]]) aggregate distinct : (si1) -> si1
-# CHECK-NEXT:          yield %[[V3]], %[[V5]] : si32, si1
+# CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
+# CHECK-NEXT:          yield %[[V3]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si32, si1>
+# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -263,12 +241,13 @@ relations {
       }
       measures {
         measure {
+          phase: AGGREGATION_PHASE_INITIAL_TO_RESULT
           output_type {
             i32 {
               nullability: NULLABILITY_REQUIRED
             }
           }
-          invocation: AGGREGATION_INVOCATION_UNSPECIFIED
+          invocation: AGGREGATION_INVOCATION_ALL
           arguments {
             value {
               selection {
@@ -283,23 +262,6 @@ relations {
           }
         }
       }
-      measures {
-        measure {
-          output_type {
-            bool {
-              nullability: NULLABILITY_REQUIRED
-            }
-          }
-          invocation: AGGREGATION_INVOCATION_DISTINCT
-          arguments {
-            value {
-              literal {
-                boolean: false
-              }
-            }
-          }
-        }
-      }
     }
   }
 }
@@ -309,7 +271,6 @@ version {
 }
 
 # -----
-
 
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
@@ -365,6 +326,7 @@ relations {
       }
       measures {
         measure {
+          phase: AGGREGATION_PHASE_INITIAL_TO_RESULT
           output_type {
             i32 {
               nullability: NULLABILITY_REQUIRED
@@ -395,20 +357,24 @@ version {
 
 # -----
 
-
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> ->
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
-# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
-# CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
-# CHECK-NEXT:          yield %[[V3]] : si32
+# CHECK-DAG:           %[[V2:.*]] = call @[[F1]](%{{.*}}) aggregate initial_to_intermediate : (si32) -> si32
+# CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%{{.*}}) aggregate intermediate_to_intermediate : (si32) -> si32
+# CHECK-DAG:           %[[V4:.*]] = call @[[F1]](%{{.*}}) aggregate intermediate_to_result : (si32) -> si32
+# CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%{{.*}}) aggregate unspecified all : (si32) -> si32
+# CHECK-DAG:           %[[V6:.*]] = call @[[F1]](%{{.*}}) aggregate : (si32) -> si32
+# CHECK-DAG:           %[[V7:.*]] = call @[[F1]](%{{.*}}) aggregate initial_to_result unspecified : (si32) -> si32
+# CHECK-DAG:           %[[V8:.*]] = call @[[F1]](%{{.*}}) aggregate distinct : (si32) -> si32
+# CHECK-NEXT:          yield %[[V2]], %[[V3]], %[[V4]], %[[V5]], %[[V6]], %[[V7]], %[[V8]] :
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+# CHECK-NEXT:      yield %[[V1]] :
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -451,12 +417,149 @@ relations {
       }
       measures {
         measure {
+          phase: AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE
           output_type {
             i32 {
               nullability: NULLABILITY_REQUIRED
             }
           }
           invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          phase: AGGREGATION_PHASE_INTERMEDIATE_TO_INTERMEDIATE
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          phase: AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          phase: AGGREGATION_PHASE_INITIAL_TO_RESULT
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_ALL
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          phase: AGGREGATION_PHASE_INITIAL_TO_RESULT
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+      measures {
+        measure {
+          phase: AGGREGATION_PHASE_INITIAL_TO_RESULT
+          output_type {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          invocation: AGGREGATION_INVOCATION_DISTINCT
           arguments {
             value {
               selection {


### PR DESCRIPTION
~~This PR is based on and, therefor, includes #70.~~

This PR adds the `aggregation_phase` to the `call` op, which corresponds to the `phase` field of the `AggregationFunction` message. The PR also revisits the assembly format of the `aggregation_invocation` attribute of the `call` op and now handles the two jointly such that either of the two can be ommitted if it has the default value. Finally, the PR revisits the LIT tests such that both aggregation detauls are tested jointly and explicitly instead of being piggy-backed onto the remaining tests. This is the last non-type feature we need to run TPC-H Q6 as produced by Isthmus.