### PR TITLE
feat: implement real `relation` type

### DIFF
--- a/include/substrait-mlir-c/Dialects.h
+++ b/include/substrait-mlir-c/Dialects.h
@@ -22,6 +22,15 @@ extern "C" {
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Substrait, substrait);
 
+/// Checks whether the given type is a `RelationType`.
+MLIR_CAPI_EXPORTED
+bool mlirTypeIsASubstraitRelationType(MlirType type);
+
+/// Gets the `RelationType` with the given `fieldTypes`.
+MLIR_CAPI_EXPORTED
+MlirType mlirSubstraitRelationTypeGet(MlirContext context, intptr_t numFields,
+                                      MlirType *fieldTypes);
+
 /// Serialization/deserialization format for exporting/importing Substrait
 /// plans. This corresponds to `::mlir::substrait::SerdeFormat`.
 typedef enum MlirSubstraitSerdeFormat {

--- a/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
+++ b/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
@@ -16,6 +16,10 @@
 #include "mlir/Interfaces/CastInterfaces.h"       // IWYU: keep
 #include "mlir/Interfaces/InferTypeOpInterface.h" // IWYU: keep
 
+namespace mlir::substrait::detail {
+struct RelationTypeStorage;
+} // namespace mlir::substrait::detail
+
 //===----------------------------------------------------------------------===//
 // Substrait dialect
 //===----------------------------------------------------------------------===//

--- a/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
+++ b/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
@@ -16,10 +16,6 @@
 #include "mlir/Interfaces/CastInterfaces.h"       // IWYU: keep
 #include "mlir/Interfaces/InferTypeOpInterface.h" // IWYU: keep
 
-namespace mlir::substrait::detail {
-struct RelationTypeStorage;
-} // namespace mlir::substrait::detail
-
 //===----------------------------------------------------------------------===//
 // Substrait dialect
 //===----------------------------------------------------------------------===//

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitInterfaces.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitInterfaces.td
@@ -68,6 +68,11 @@ def Substrait_RelOpInterface : OpInterface<"RelOpInterface"> {
     turn, holds a more specialized message with the information specific to the
     concrete relational operation.
   }];
+  let methods = [InterfaceMethod<
+    "Get the result relation",
+    "::mlir::TypedValue<::mlir::substrait::RelationType>", "getResult",
+    /*args=*/(ins ), /*methodBody=*/ "return $_op.getResult();"
+  >];
   let cppNamespace = "::mlir::substrait";
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -493,8 +493,7 @@ def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
 
     ```mlir
     %0 = ...
-    // XXX: update example snippets, here and below
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32, si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -520,8 +519,9 @@ def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
     AnyRegion:$measures
   );
   let assemblyFormat = [{
-    $input (`advanced_extension` `` $advanced_extension^)?
-    attr-dict `:` type($input) `->` type($result)
+    $input (`advanced_extension` `` $advanced_extension^)? attr-dict
+    `:` custom<SubstraitType>(type($input))
+      `->` custom<SubstraitType>(type($result))
     custom<AggregateRegions>($groupings, $measures, $grouping_sets)
   }];
   let hasRegionVerifier = 1;
@@ -553,7 +553,7 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
     ```mlir
     %0 = ...
     %1 = ...
-    %2 = cross %0 x %1 : tuple<si32> x tuple<si32>
+    %2 = cross %0 x %1 : rel<si32> x rel<si32>
     ```
   }];
   let arguments = (ins
@@ -589,7 +589,7 @@ def Substrait_EmitOp : Substrait_RelOp<"emit", [
 
     ```mlir
     %0 = ...
-    %1 = emit [2, 1] from %0 : tuple<si32, s1, si32> -> tuple<si32, si1>
+    %1 = emit [2, 1] from %0 : rel<si32, s1, si32> -> rel<si32, si1>
     ```
   }];
   let arguments = (ins
@@ -598,7 +598,9 @@ def Substrait_EmitOp : Substrait_RelOp<"emit", [
   );
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $mapping `from` $input attr-dict `:` type($input) `->` type($result)
+    $mapping `from` $input attr-dict
+    `:` custom<SubstraitType>(type($input))
+      `->` custom<SubstraitType>(type($result))
   }];
   let hasFolder = 1;
   let extraClassDefinition = [{
@@ -622,7 +624,7 @@ def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table", [
     ```mlir
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-           as ["a"] : tuple<si32>
+           as ["a"] : rel<si32>
     ```
   }];
   let arguments = (ins
@@ -633,7 +635,7 @@ def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table", [
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     $detail `as` $field_names (`advanced_extension` `` $advanced_extension^)?
-    attr-dict `:` type($result)
+    attr-dict `:` custom<SubstraitType>(type($result))
   }];
   let hasVerifier = true;
   let builders = [
@@ -663,7 +665,8 @@ def Substrait_FetchOp : Substrait_RelOp<"fetch", [
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     custom<CountAsAll>($count) (`offset` $offset^)? `from` $input
-    (`advanced_extension` `` $advanced_extension^)? attr-dict `:` type($input)
+    (`advanced_extension` `` $advanced_extension^)? attr-dict
+    `:` custom<SubstraitType>(type($input))
   }];
   let builders = [
       OpBuilder<(ins "::mlir::Value":$input, "int64_t":$offset,
@@ -689,7 +692,7 @@ def Substrait_FilterOp : Substrait_RelOp<"filter", [
 
     ```mlir
     %0 = ...
-    %1 = filter %0 : tuple<si32> {
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %true = literal -1 : si1
       yield %true : si1
@@ -707,7 +710,7 @@ def Substrait_FilterOp : Substrait_RelOp<"filter", [
   //                    `scf.for` etc.
   let assemblyFormat = [{
     $input (`advanced_extension` `` $advanced_extension^)?
-    attr-dict `:` type($input) $condition
+    attr-dict `:` custom<SubstraitType>(type($input)) $condition
   }];
   let hasRegionVerifier = 1;
   let extraClassDefinition = [{
@@ -738,7 +741,10 @@ def Substrait_JoinOp : Substrait_RelOp<"join", [
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     $join_type $left `,` $right (`advanced_extension` `` $advanced_extension^)?
-    attr-dict `:` type($left) `,` type($right) `->` type($result)
+    attr-dict
+    `:` custom<SubstraitType>(type($left)) `,`
+        custom<SubstraitType>(type($right))
+      `->` custom<SubstraitType>(type($result))
   }];
   let builders = [
       OpBuilder<(ins "::mlir::Value":$left, "::mlir::Value":$right,
@@ -760,7 +766,7 @@ def Substrait_NamedTableOp : Substrait_RelOp<"named_table", [
     Example:
 
     ```mlir
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     ```
   }];
   // TODO(ingomueller): Maybe the result names should be part of a to-be-created
@@ -773,7 +779,8 @@ def Substrait_NamedTableOp : Substrait_RelOp<"named_table", [
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     $table_name `as` $field_names
-    (`advanced_extension` `` $advanced_extension^)? attr-dict `:` type($result)
+    (`advanced_extension` `` $advanced_extension^)? attr-dict
+    `:` custom<SubstraitType>(type($result))
   }];
   let hasVerifier = true;
   let builders = [
@@ -805,7 +812,7 @@ def Substrait_ProjectOp : Substrait_RelOp<"project", [
 
     ```mlir
     %0 = ...
-    %1 = project %0 : tuple<si32> -> tuple<si32, si1, si32> {
+    %1 = project %0 : rel<si32> -> rel<si32, si1, si32> {
     ^bb0(%arg : tuple<si32>):
       %true = literal -1 : si1
       %42 = literal 42 : si32
@@ -823,8 +830,10 @@ def Substrait_ProjectOp : Substrait_RelOp<"project", [
   //                    assembly by writing custom printers/parsers similar to
   //                    `scf.for` etc.
   let assemblyFormat = [{
-    $input (`advanced_extension` `` $advanced_extension^)?
-    attr-dict `:` type($input) `->` type($result) $expressions
+    $input (`advanced_extension` `` $advanced_extension^)? attr-dict
+    `:` custom<SubstraitType>(type($input))
+      `->` custom<SubstraitType>(type($result))
+    $expressions
   }];
   let hasRegionVerifier = 1;
   let hasFolder = 1;
@@ -858,7 +867,7 @@ def Substrait_SetOp : Substrait_RelOp<"set", [
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     $kind $inputs (`advanced_extension` `` $advanced_extension^)?
-    attr-dict `:` type($result)
+    attr-dict `:` custom<SubstraitType>(type($result))
   }];
   let builders = [
       OpBuilder<(ins "::mlir::ValueRange":$inputs, "SetOpKind":$kind), [{

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -564,7 +564,8 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     $left `x` $right (`advanced_extension` `` $advanced_extension^)?
-    attr-dict `:` type($left) `x` type($right)
+    attr-dict `:`
+    custom<SubstraitType>(type($left)) `x` custom<SubstraitType>(type($right))
   }];
   let builders = [
       OpBuilder<(ins "::mlir::Value":$left, "::mlir::Value":$right), [{

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -265,7 +265,9 @@ def Substrait_YieldOp : Substrait_Op<"yield", [
   ]> {
   let summary = "Yields the result of a `PlanRelOp`";
   let arguments = (ins Variadic<AnyType>:$value);
-  let assemblyFormat = "attr-dict ($value^ `:` type($value))?";
+  let assemblyFormat = [{
+    attr-dict ($value^ `:` custom<SubstraitType>(type($value)))?
+  }];
   let builders = [OpBuilder<(ins), [{ /* do nothing */ }]>];
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -493,6 +493,7 @@ def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
 
     ```mlir
     %0 = ...
+    // XXX: update example snippets, here and below
     %1 = aggregate %0 : tuple<si32> -> tuple<si32, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -207,7 +207,6 @@ def Substrait_Relation : Substrait_Type<"Relation", "relation"> {
   let summary = "Substrait relation, i.e., result of `RelOpInterface` ops";
   let description = [{
   }];
-  // XXX: decide if we want to restrict the types that can be used for fields
   let parameters = (ins AnyTuple:$structType);
   let builders = [
     TypeBuilder<(ins "TypeRange":$fieldTypes), [{
@@ -220,17 +219,18 @@ def Substrait_Relation : Substrait_Type<"Relation", "relation"> {
   let skipDefaultBuilders = 1;
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
-    // XXX: document
+    /// Get the field types of the relation.
     ArrayRef<Type> getFieldTypes() const {
       return getStructType().getTypes();
     }
 
+    /// Get the field types of the relation (for symmetry with `TupleType`).
     ArrayRef<Type> getTypes() const { return getFieldTypes(); }
 
-    /// Return the number of held types.
+    /// Return the number of fields.
     size_t size() const { return getFieldTypes().size(); }
 
-    /// Iterate over the held elements.
+    /// Iterate over the field types.
     using iterator = ArrayRef<Type>::iterator;
     iterator begin() const { return getFieldTypes().begin(); }
     iterator end() const { return getFieldTypes().end(); }

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -208,25 +208,24 @@ def Substrait_Relation : Substrait_Type<"Relation", "relation"> {
   let description = [{
   }];
   // XXX: decide if we want to restrict the types that can be used for fields
-  let parameters = (ins "ArrayRef<Type>":$fieldTypes);
+  let parameters = (ins AnyTuple:$structType);
   let builders = [
     TypeBuilder<(ins "TypeRange":$fieldTypes), [{
-      return $_get($_ctxt, fieldTypes);
+      return $_get($_ctxt, ::mlir::TupleType::get($_ctxt, fieldTypes));
     }]>,
     TypeBuilder<(ins), [{
-      return $_get($_ctxt, TypeRange());
+      return $_get($_ctxt, ::mlir::TupleType::get($_ctxt));
     }]>,
   ];
   let skipDefaultBuilders = 1;
-  let genStorageClass = 0;
   let hasCustomAssemblyFormat = 1;
   let extraClassDeclaration = [{
     // XXX: document
-    TupleType getStructType() {
-      return TupleType::get(getContext(), getFieldTypes());
+    ArrayRef<Type> getFieldTypes() const {
+      return getStructType().getTypes();
     }
 
-    ArrayRef<Type> getTypes() { return getFieldTypes(); }
+    ArrayRef<Type> getTypes() const { return getFieldTypes(); }
 
     /// Return the number of held types.
     size_t size() const { return getFieldTypes().size(); }
@@ -235,11 +234,6 @@ def Substrait_Relation : Substrait_Type<"Relation", "relation"> {
     using iterator = ArrayRef<Type>::iterator;
     iterator begin() const { return getFieldTypes().begin(); }
     iterator end() const { return getFieldTypes().end(); }
-  }];
-  let extraClassDefinition = [{
-    ArrayRef<Type> $cppClass::getFieldTypes() const {
-      return getImpl()->getTypes();
-    }
   }];
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -199,10 +199,48 @@ def Substrait_ExpressionType : AnyTypeOf<[
   Substrait_ContainerType,
 ]>;
 
-/// Placeholder for a proper relation type, the result of any `RelOpInterface`
-/// op.
-// TODO(ingomueller): Transform this into a proper relation type.
-def Substrait_Relation :
-  NestedTupleOf<Substrait_ExpressionTypes.types>;
+//===----------------------------------------------------------------------===//
+// RelationType
+//===----------------------------------------------------------------------===//
+
+def Substrait_Relation : Substrait_Type<"Relation", "relation"> {
+  let summary = "Substrait relation, i.e., result of `RelOpInterface` ops";
+  let description = [{
+  }];
+  // XXX: decide if we want to restrict the types that can be used for fields
+  let parameters = (ins "ArrayRef<Type>":$fieldTypes);
+  let builders = [
+    TypeBuilder<(ins "TypeRange":$fieldTypes), [{
+      return $_get($_ctxt, fieldTypes);
+    }]>,
+    TypeBuilder<(ins), [{
+      return $_get($_ctxt, TypeRange());
+    }]>,
+  ];
+  let skipDefaultBuilders = 1;
+  let genStorageClass = 0;
+  let hasCustomAssemblyFormat = 1;
+  let extraClassDeclaration = [{
+    // XXX: document
+    TupleType getStructType() {
+      return TupleType::get(getContext(), getFieldTypes());
+    }
+
+    ArrayRef<Type> getTypes() { return getFieldTypes(); }
+
+    /// Return the number of held types.
+    size_t size() const { return getFieldTypes().size(); }
+
+    /// Iterate over the held elements.
+    using iterator = ArrayRef<Type>::iterator;
+    iterator begin() const { return getFieldTypes().begin(); }
+    iterator end() const { return getFieldTypes().end(); }
+  }];
+  let extraClassDefinition = [{
+    ArrayRef<Type> $cppClass::getFieldTypes() const {
+      return getImpl()->getTypes();
+    }
+  }];
+}
 
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITTYPES

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -29,6 +29,17 @@ using namespace mlir::substrait;
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Substrait, substrait, SubstraitDialect)
 
+bool mlirTypeIsASubstraitRelationType(MlirType type) {
+  return mlir::isa<RelationType>(unwrap(type));
+}
+
+MlirType mlirSubstraitRelationTypeGet(MlirContext context, intptr_t numFields,
+                                      MlirType *fieldTypes) {
+  SmallVector<Type, 4> types;
+  ArrayRef<Type> typesRef = unwrapList(numFields, fieldTypes, types);
+  return wrap(RelationType::get(unwrap(context), typesRef));
+}
+
 /// Converts the provided enum value into the equivalent value from
 /// `::mlir::substrait::SerdeFormat`.
 SerdeFormat convertSerdeFormat(MlirSubstraitSerdeFormat format) {

--- a/python/SubstraitDialects.cpp
+++ b/python/SubstraitDialects.cpp
@@ -16,6 +16,7 @@
 #include "llvm/Support/Signals.h"
 
 namespace nb = nanobind;
+using namespace mlir::python::nanobind_adaptors;
 
 NB_MODULE(_substraitDialects, mainModule) {
 #ifndef NDEBUG
@@ -46,6 +47,26 @@ NB_MODULE(_substraitDialects, mainModule) {
               "context: Optional[substrait_mlir.ir.Context] = None,"
               "load: bool = True) -> None"),
       "Register and optionally load the dialect with the given context");
+
+  //
+  // Types
+  //
+
+  mlir_type_subclass(substraitModule, "RelationType",
+                     mlirTypeIsASubstraitRelationType)
+      .def_classmethod(
+          "get",
+          [](const nb::object &cls, std::vector<MlirType> fieldTypes,
+             MlirContext context) {
+            return cls(mlirSubstraitRelationTypeGet(context, fieldTypes.size(),
+                                                    fieldTypes.data()));
+          },
+          nb::arg("cls"), nb::arg("element_type"),
+          nb::arg("context").none() = nb::none(),
+          nb::sig("def get(cls: object, "
+                  "element_type: typing.Sequence[substrait_mlir.ir.Type], "
+                  "context: typing.Optional[substrait_mlir.ir.Context] = None) "
+                  "-> RelationType"));
 
   //
   // Import

--- a/test/Dialect/Substrait/aggregate-invalid.mlir
+++ b/test/Dialect/Substrait/aggregate-invalid.mlir
@@ -4,15 +4,15 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #0 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+    %1 = aggregate %0 : <si32> -> <si1>
       groupings {
       ^bb0(%arg : tuple<si1>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
-    yield %1 : tuple<si1>
+    yield %1 : !substrait.relation<si1>
   }
 }
 
@@ -22,16 +22,16 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #1 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+    %1 = aggregate %0 : <si32> -> <si1>
       measures {
       ^bb0(%arg : tuple<si1>):
         %2 = literal 0 : si1
         %3 = call @function(%2) aggregate : (si1) -> si1
         yield %3 : si1
       }
-    yield %1 : tuple<si1>
+    yield %1 : !substrait.relation<si1>
   }
 }
 
@@ -41,16 +41,16 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op has invalid grouping set #0: column reference 1 (column #0) is out of bounds}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+    %1 = aggregate %0 : <si32> -> <si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
       grouping_sets [[1]]
-    yield %1 : tuple<si1>
+    yield %1 : !substrait.relation<si1>
   }
 }
 
@@ -61,16 +61,16 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op has invalid grouping sets: the first occerrences of the column references must be densely increasing}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+    %1 = aggregate %0 : <si32> -> <si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
       grouping_sets [[1, 0]]
-    yield %1 : tuple<si1, si1>
+    yield %1 : !substrait.relation<si1, si1>
   }
 }
 
@@ -80,16 +80,16 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op has 'groupings' region whose operand #1 is not contained in any 'grouping_set'}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+    %1 = aggregate %0 : <si32> -> <si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
       grouping_sets [[0]]
-    yield %1 : tuple<si1, si1>
+    yield %1 : !substrait.relation<si1, si1>
   }
 }
 
@@ -99,11 +99,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{one of 'groupings' or 'measures' must be specified}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<>
+    %1 = aggregate %0 : <si32> -> <>
       grouping_sets [[]]
-    yield %1 : tuple<>
+    yield %1 : !substrait.relation<>
   }
 }
 
@@ -113,16 +113,16 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error-re@+1 {{'substrait.aggregate' op yields value from 'measures' region that was not produced by an aggregate function: {{.*}}substrait.call{{.*}}}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+    %1 = aggregate %0 : <si32> -> <si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si32
         %3 = call @function(%2) : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -132,8 +132,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si32
@@ -141,7 +141,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate foo : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -149,14 +149,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #1 that yields no values (use empty region instead)}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<>
+    %1 = aggregate %0 : <si32> -> <>
       measures {
       ^bb0(%arg : tuple<si32>):
         yield
       }
-    yield %1 : tuple<>
+    yield %1 : !substrait.relation<>
   }
 }
 
@@ -164,13 +164,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #0 that yields no values (use empty region instead)}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<>
+    %1 = aggregate %0 : <si32> -> <>
       groupings {
       ^bb0(%arg : tuple<si32>):
         yield
       }
-    yield %1 : tuple<>
+    yield %1 : !substrait.relation<>
   }
 }

--- a/test/Dialect/Substrait/aggregate-invalid.mlir
+++ b/test/Dialect/Substrait/aggregate-invalid.mlir
@@ -4,9 +4,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #0 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
-    %1 = aggregate %0 : <si32> -> <si1>
+    %1 = aggregate %0 : rel<si32> -> rel<si1>
       groupings {
       ^bb0(%arg : tuple<si1>):
         %2 = literal 0 : si1
@@ -22,9 +22,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #1 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
-    %1 = aggregate %0 : <si32> -> <si1>
+    %1 = aggregate %0 : rel<si32> -> rel<si1>
       measures {
       ^bb0(%arg : tuple<si1>):
         %2 = literal 0 : si1
@@ -41,9 +41,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op has invalid grouping set #0: column reference 1 (column #0) is out of bounds}}
-    %1 = aggregate %0 : <si32> -> <si1>
+    %1 = aggregate %0 : rel<si32> -> rel<si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -61,9 +61,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op has invalid grouping sets: the first occerrences of the column references must be densely increasing}}
-    %1 = aggregate %0 : <si32> -> <si1, si1>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -80,9 +80,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op has 'groupings' region whose operand #1 is not contained in any 'grouping_set'}}
-    %1 = aggregate %0 : <si32> -> <si1, si1>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -99,9 +99,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{one of 'groupings' or 'measures' must be specified}}
-    %1 = aggregate %0 : <si32> -> <>
+    %1 = aggregate %0 : rel<si32> -> rel<>
       grouping_sets [[]]
     yield %1 : !substrait.relation<>
   }
@@ -113,9 +113,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error-re@+1 {{'substrait.aggregate' op yields value from 'measures' region that was not produced by an aggregate function: {{.*}}substrait.call{{.*}}}}
-    %1 = aggregate %0 : <si32> -> <si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si32
@@ -132,8 +132,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si32
@@ -149,9 +149,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #1 that yields no values (use empty region instead)}}
-    %1 = aggregate %0 : <si32> -> <>
+    %1 = aggregate %0 : rel<si32> -> rel<>
       measures {
       ^bb0(%arg : tuple<si32>):
         yield
@@ -164,9 +164,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op has region #0 that yields no values (use empty region instead)}}
-    %1 = aggregate %0 : <si32> -> <>
+    %1 = aggregate %0 : rel<si32> -> rel<>
       groupings {
       ^bb0(%arg : tuple<si32>):
         yield

--- a/test/Dialect/Substrait/aggregate-invalid.mlir
+++ b/test/Dialect/Substrait/aggregate-invalid.mlir
@@ -12,7 +12,7 @@ substrait.plan version 0 : 42 : 1 {
         %2 = literal 0 : si1
         yield %2 : si1
       }
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }
 
@@ -31,7 +31,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si1) -> si1
         yield %3 : si1
       }
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }
 
@@ -50,7 +50,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %2 : si1
       }
       grouping_sets [[1]]
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }
 
@@ -70,7 +70,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %2, %2 : si1, si1
       }
       grouping_sets [[1, 0]]
-    yield %1 : !substrait.relation<si1, si1>
+    yield %1 : rel<si1, si1>
   }
 }
 
@@ -89,7 +89,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %2, %2 : si1, si1
       }
       grouping_sets [[0]]
-    yield %1 : !substrait.relation<si1, si1>
+    yield %1 : rel<si1, si1>
   }
 }
 
@@ -103,7 +103,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+1 {{one of 'groupings' or 'measures' must be specified}}
     %1 = aggregate %0 : rel<si32> -> rel<>
       grouping_sets [[]]
-    yield %1 : !substrait.relation<>
+    yield %1 : rel<>
   }
 }
 
@@ -122,7 +122,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -141,7 +141,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate foo : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -156,7 +156,7 @@ substrait.plan version 0 : 42 : 1 {
       ^bb0(%arg : tuple<si32>):
         yield
       }
-    yield %1 : !substrait.relation<>
+    yield %1 : rel<>
   }
 }
 
@@ -171,6 +171,6 @@ substrait.plan version 0 : 42 : 1 {
       ^bb0(%arg : tuple<si32>):
         yield
       }
-    yield %1 : !substrait.relation<>
+    yield %1 : rel<>
   }
 }

--- a/test/Dialect/Substrait/aggregate.mlir
+++ b/test/Dialect/Substrait/aggregate.mlir
@@ -39,7 +39,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : !substrait.relation<si1, si1, si32, si32>
+    yield %1 : rel<si1, si1, si32, si32>
   }
 }
 
@@ -80,7 +80,7 @@ substrait.plan version 0 : 42 : 1 {
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
-    yield %1 : !substrait.relation<si1, si1, si32, si32>
+    yield %1 : rel<si1, si1, si32, si32>
   }
 }
 
@@ -107,7 +107,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %2, %2 : si1, si1
       }
       grouping_sets [[0], [0, 1], [1], []]
-    yield %1 : !substrait.relation<si1, si1, si32>
+    yield %1 : rel<si1, si1, si32>
   }
 }
 
@@ -133,7 +133,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %2, %2 : si1, si1
       }
       grouping_sets [[0, 1]]
-    yield %1 : !substrait.relation<si1, si1>
+    yield %1 : rel<si1, si1>
   }
 }
 
@@ -158,7 +158,7 @@ substrait.plan version 0 : 42 : 1 {
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
-    yield %1 : !substrait.relation<si1, si1>
+    yield %1 : rel<si1, si1>
   }
 }
 
@@ -188,7 +188,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -216,7 +216,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -245,7 +245,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -303,7 +303,7 @@ substrait.plan version 0 : 42 : 1 {
               : si32, si32, si32, si32, si32, si32, si32,
                 si32, si32, si32, si32, si32, si32
       }
-    yield %1 : !substrait.relation<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
+    yield %1 : rel<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
   }
 }
 
@@ -328,6 +328,6 @@ substrait.plan version 0 : 42 : 1 {
         %2 = literal 0 : si1
         yield %2 : si1
       }
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }

--- a/test/Dialect/Substrait/aggregate.mlir
+++ b/test/Dialect/Substrait/aggregate.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si32>
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si1, si1, si32, si32>
 // CHECK-NEXT:      groupings {
 // CHECK-NEXT:        ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:        %[[V2:.*]] = literal 0 : si1
@@ -19,14 +19,14 @@
 // CHECK-DAG:         %[[V4:.*]] = call @function(%[[V3]]) aggregate :
 // CHECK-NEXT:        yield %[[V4]] : si32
 // CHECK-NEXT:      }
-// CHECK-NEXT:      yield %[[V1]]
+// CHECK-NEXT:      yield %[[V1]] :
 
 substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si1, si1, si32, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -39,7 +39,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : tuple<si1, si1, si32, si32>
+    yield %1 : !substrait.relation<si1, si1, si32, si32>
   }
 }
 
@@ -66,8 +66,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si1, si1, si32, si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -80,7 +80,7 @@ substrait.plan version 0 : 42 : 1 {
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
-    yield %1 : tuple<si1, si1, si32, si32>
+    yield %1 : !substrait.relation<si1, si1, si32, si32>
   }
 }
 
@@ -99,15 +99,15 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si1, si1, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
       grouping_sets [[0], [0, 1], [1], []]
-    yield %1 : tuple<si1, si1, si32>
+    yield %1 : !substrait.relation<si1, si1, si32>
   }
 }
 
@@ -125,15 +125,15 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
       grouping_sets [[0, 1]]
-    yield %1 : tuple<si1, si1>
+    yield %1 : !substrait.relation<si1, si1>
   }
 }
 
@@ -151,14 +151,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
-    yield %1 : tuple<si1, si1>
+    yield %1 : !substrait.relation<si1, si1>
   }
 }
 
@@ -179,8 +179,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si32>
       grouping_sets []
       measures {
       ^bb0(%arg : tuple<si32>):
@@ -188,7 +188,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -208,15 +208,15 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -236,8 +236,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si32>
       grouping_sets [[]]
       measures {
       ^bb0(%arg : tuple<si32>):
@@ -245,7 +245,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -280,9 +280,9 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32>
-          -> tuple<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32>
+          -> <si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -303,7 +303,7 @@ substrait.plan version 0 : 42 : 1 {
               : si32, si32, si32, si32, si32, si32, si32,
                 si32, si32, si32, si32, si32, si32
       }
-    yield %1 : tuple<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
+    yield %1 : !substrait.relation<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
   }
 }
 
@@ -314,20 +314,20 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:           aggregate %{{.*}} advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : tuple
+// CHECK-SAME:        : <si32> -> <si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = aggregate %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> -> tuple<si1>
+            : <si32> -> <si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
-    yield %1 : tuple<si1>
+    yield %1 : !substrait.relation<si1>
   }
 }

--- a/test/Dialect/Substrait/aggregate.mlir
+++ b/test/Dialect/Substrait/aggregate.mlir
@@ -6,7 +6,7 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si1, si1, si32, si32>
+// CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si1, si1, si32, si32>
 // CHECK-NEXT:      groupings {
 // CHECK-NEXT:        ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:        %[[V2:.*]] = literal 0 : si1
@@ -25,8 +25,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si1, si1, si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -66,8 +66,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si1, si1, si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32, si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -99,8 +99,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si1, si1, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -125,8 +125,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si1, si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -151,8 +151,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si1, si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -179,8 +179,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32>
       grouping_sets []
       measures {
       ^bb0(%arg : tuple<si32>):
@@ -208,8 +208,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -236,8 +236,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32>
       grouping_sets [[]]
       measures {
       ^bb0(%arg : tuple<si32>):
@@ -280,9 +280,9 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32>
-          -> <si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32>
+          -> rel<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -314,15 +314,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:           aggregate %{{.*}} advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : <si32> -> <si1>
+// CHECK-SAME:        : rel<si32> -> rel<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> -> <si1>
+            : rel<si32> -> rel<si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1

--- a/test/Dialect/Substrait/call.mlir
+++ b/test/Dialect/Substrait/call.mlir
@@ -22,6 +22,6 @@ substrait.plan version 0 : 42 : 1 {
       %3 = call @function(%2) : (si32) -> si1
       yield %3 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/call.mlir
+++ b/test/Dialect/Substrait/call.mlir
@@ -15,13 +15,13 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = filter %0 : tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = field_reference %arg[0] : tuple<si32>
       %3 = call @function(%2) : (si32) -> si1
       yield %3 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/call.mlir
+++ b/test/Dialect/Substrait/call.mlir
@@ -15,8 +15,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = filter %0 : <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = field_reference %arg[0] : tuple<si32>
       %3 = call @function(%2) : (si32) -> si1

--- a/test/Dialect/Substrait/canonicalize.mlir
+++ b/test/Dialect/Substrait/canonicalize.mlir
@@ -10,9 +10,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [0, 1] from %0 : tuple<si1, si32> -> tuple<si1, si32>
-    yield %1 : tuple<si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [0, 1] from %0 : <si1, si32> -> <si1, si32>
+    yield %1 : !substrait.relation<si1, si32>
   }
 }
 
@@ -28,9 +28,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    yield %1 : tuple<si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    yield %1 : !substrait.relation<si32, si1>
   }
 }
 
@@ -46,9 +46,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [0] from %0 : tuple<si1, si32> -> tuple<si1>
-    yield %1 : tuple<si1>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [0] from %0 : <si1, si32> -> <si1>
+    yield %1 : !substrait.relation<si1>
   }
 }
 
@@ -63,13 +63,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    %2 = emit [1, 0] from %1 : tuple<si32, si1> -> tuple<si1, si32>
-    %3 = emit [0, 0, 1, 1] from %2 : tuple<si1, si32> -> tuple<si1, si1, si32, si32>
-    %4 = emit [3, 0, 1] from %3 : tuple<si1, si1, si32, si32> -> tuple<si32, si1, si1>
-    %5 = emit [1, 0] from %4 : tuple<si32, si1, si1> -> tuple<si1, si32>
-    yield %5 : tuple<si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %2 = emit [1, 0] from %1 : <si32, si1> -> <si1, si32>
+    %3 = emit [0, 0, 1, 1] from %2 : <si1, si32> -> <si1, si1, si32, si32>
+    %4 = emit [3, 0, 1] from %3 : <si1, si1, si32, si32> -> <si32, si1, si1>
+    %5 = emit [1, 0] from %4 : <si32, si1, si1> -> <si1, si32>
+    yield %5 : !substrait.relation<si1, si32>
   }
 }
 
@@ -84,10 +84,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = project %0 : tuple<si32> -> tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = project %0 : <si32> -> <si32> {
     ^bb0(%arg0: tuple<si32>):
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/canonicalize.mlir
+++ b/test/Dialect/Substrait/canonicalize.mlir
@@ -12,7 +12,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [0, 1] from %0 : rel<si1, si32> -> rel<si1, si32>
-    yield %1 : !substrait.relation<si1, si32>
+    yield %1 : rel<si1, si32>
   }
 }
 
@@ -30,7 +30,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
-    yield %1 : !substrait.relation<si32, si1>
+    yield %1 : rel<si32, si1>
   }
 }
 
@@ -48,7 +48,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [0] from %0 : rel<si1, si32> -> rel<si1>
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }
 
@@ -69,7 +69,7 @@ substrait.plan version 0 : 42 : 1 {
     %3 = emit [0, 0, 1, 1] from %2 : rel<si1, si32> -> rel<si1, si1, si32, si32>
     %4 = emit [3, 0, 1] from %3 : rel<si1, si1, si32, si32> -> rel<si32, si1, si1>
     %5 = emit [1, 0] from %4 : rel<si32, si1, si1> -> rel<si1, si32>
-    yield %5 : !substrait.relation<si1, si32>
+    yield %5 : rel<si1, si32>
   }
 }
 
@@ -88,6 +88,6 @@ substrait.plan version 0 : 42 : 1 {
     %1 = project %0 : rel<si32> -> rel<si32> {
     ^bb0(%arg0: tuple<si32>):
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/canonicalize.mlir
+++ b/test/Dialect/Substrait/canonicalize.mlir
@@ -10,8 +10,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [0, 1] from %0 : <si1, si32> -> <si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [0, 1] from %0 : rel<si1, si32> -> rel<si1, si32>
     yield %1 : !substrait.relation<si1, si32>
   }
 }
@@ -28,8 +28,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     yield %1 : !substrait.relation<si32, si1>
   }
 }
@@ -46,8 +46,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [0] from %0 : <si1, si32> -> <si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [0] from %0 : rel<si1, si32> -> rel<si1>
     yield %1 : !substrait.relation<si1>
   }
 }
@@ -63,12 +63,12 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
-    %2 = emit [1, 0] from %1 : <si32, si1> -> <si1, si32>
-    %3 = emit [0, 0, 1, 1] from %2 : <si1, si32> -> <si1, si1, si32, si32>
-    %4 = emit [3, 0, 1] from %3 : <si1, si1, si32, si32> -> <si32, si1, si1>
-    %5 = emit [1, 0] from %4 : <si32, si1, si1> -> <si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
+    %2 = emit [1, 0] from %1 : rel<si32, si1> -> rel<si1, si32>
+    %3 = emit [0, 0, 1, 1] from %2 : rel<si1, si32> -> rel<si1, si1, si32, si32>
+    %4 = emit [3, 0, 1] from %3 : rel<si1, si1, si32, si32> -> rel<si32, si1, si1>
+    %5 = emit [1, 0] from %4 : rel<si32, si1, si1> -> rel<si1, si32>
     yield %5 : !substrait.relation<si1, si32>
   }
 }
@@ -84,8 +84,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = project %0 : <si32> -> <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = project %0 : rel<si32> -> rel<si32> {
     ^bb0(%arg0: tuple<si32>):
     }
     yield %1 : !substrait.relation<si32>

--- a/test/Dialect/Substrait/cast.mlir
+++ b/test/Dialect/Substrait/cast.mlir
@@ -25,6 +25,6 @@ substrait.plan version 0 : 42 : 1 {
       %5 = cast %2 or unspecified : si32 to si64
       yield %3, %4, %5 : si64, si64, si64
     }
-    yield %1 : !substrait.relation<si32, si64, si64, si64>
+    yield %1 : rel<si32, si64, si64, si64>
   }
 }

--- a/test/Dialect/Substrait/cast.mlir
+++ b/test/Dialect/Substrait/cast.mlir
@@ -16,8 +16,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = project %0 : tuple<si32> -> tuple<si32, si64, si64, si64> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = project %0 : <si32> -> <si32, si64, si64, si64> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si64
@@ -25,6 +25,6 @@ substrait.plan version 0 : 42 : 1 {
       %5 = cast %2 or unspecified : si32 to si64
       yield %3, %4, %5 : si64, si64, si64
     }
-    yield %1 : tuple<si32, si64, si64, si64>
+    yield %1 : !substrait.relation<si32, si64, si64, si64>
   }
 }

--- a/test/Dialect/Substrait/cast.mlir
+++ b/test/Dialect/Substrait/cast.mlir
@@ -16,8 +16,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = project %0 : <si32> -> <si32, si64, si64, si64> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = project %0 : rel<si32> -> rel<si32, si64, si64, si64> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si64

--- a/test/Dialect/Substrait/cross.mlir
+++ b/test/Dialect/Substrait/cross.mlir
@@ -5,14 +5,14 @@
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : <si32> x <si1>
+// CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : rel<si32> x rel<si1>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : <si32>
     %1 = named_table @t2 as ["b"] : <si1>
-    %2 = cross %0 x %1 : <si32> x <si1>
+    %2 = cross %0 x %1 : rel<si32> x rel<si1>
     yield %2 : !substrait.relation<si32, si1>
   }
 }
@@ -24,7 +24,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           cross %{{.*}} x %{{[^ ]*}}
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : <si32> x <si1>
+// CHECK-SAME:        : rel<si32> x rel<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -33,7 +33,7 @@ substrait.plan version 0 : 42 : 1 {
     %2 = cross %0 x %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> x <si1>
+            : rel<si32> x rel<si1>
     yield %2 : !substrait.relation<si32, si1>
   }
 }

--- a/test/Dialect/Substrait/cross.mlir
+++ b/test/Dialect/Substrait/cross.mlir
@@ -10,8 +10,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = cross %0 x %1 : rel<si32> x rel<si1>
     yield %2 : !substrait.relation<si32, si1>
   }
@@ -28,8 +28,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = cross %0 x %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">

--- a/test/Dialect/Substrait/cross.mlir
+++ b/test/Dialect/Substrait/cross.mlir
@@ -6,14 +6,14 @@
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : rel<si32> x rel<si1>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si1>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32, si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = cross %0 x %1 : rel<si32> x rel<si1>
-    yield %2 : !substrait.relation<si32, si1>
+    yield %2 : rel<si32, si1>
   }
 }
 
@@ -34,6 +34,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> x rel<si1>
-    yield %2 : !substrait.relation<si32, si1>
+    yield %2 : rel<si32, si1>
   }
 }

--- a/test/Dialect/Substrait/cross.mlir
+++ b/test/Dialect/Substrait/cross.mlir
@@ -5,16 +5,15 @@
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
-// CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]]
-// CHECK-SAME:        : tuple<si32> x tuple<si1>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32, si1>
+// CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : <si32> x <si1>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si1>
-    %2 = cross %0 x %1 : tuple<si32> x tuple<si1>
-    yield %2 : tuple<si32, si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si1>
+    %2 = cross %0 x %1 : <si32> x <si1>
+    yield %2 : !substrait.relation<si32, si1>
   }
 }
 
@@ -25,16 +24,16 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           cross %{{.*}} x %{{[^ ]*}}
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : tuple<si32> x tuple<si1>
+// CHECK-SAME:        : <si32> x <si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si1>
     %2 = cross %0 x %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> x tuple<si1>
-    yield %2 : tuple<si32, si1>
+            : <si32> x <si1>
+    yield %2 : !substrait.relation<si32, si1>
   }
 }

--- a/test/Dialect/Substrait/emit-invalid.mlir
+++ b/test/Dialect/Substrait/emit-invalid.mlir
@@ -6,7 +6,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
     // expected-error@+1 {{1 is not a valid index into '!substrait.relation<si32>'}}
     %1 = emit [1] from %0 : rel<si32> -> rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -18,6 +18,6 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
     // expected-error@+1 {{-1 is not a valid index into '!substrait.relation<si32>'}}
     %1 = emit [-1] from %0 : rel<si32> -> rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/emit-invalid.mlir
+++ b/test/Dialect/Substrait/emit-invalid.mlir
@@ -2,11 +2,11 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
-    // expected-error@+1 {{1 is not a valid index into 'tuple<si32>'}}
-    %1 = emit [1] from %0 : tuple<si32> -> tuple<si32>
-    yield %1 : tuple<si32>
+    // expected-error@+1 {{1 is not a valid index into '!substrait.relation<si32>'}}
+    %1 = emit [1] from %0 : <si32> -> <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -14,10 +14,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
-    // expected-error@+1 {{-1 is not a valid index into 'tuple<si32>'}}
-    %1 = emit [-1] from %0 : tuple<si32> -> tuple<si32>
-    yield %1 : tuple<si32>
+    // expected-error@+1 {{-1 is not a valid index into '!substrait.relation<si32>'}}
+    %1 = emit [-1] from %0 : <si32> -> <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/emit-invalid.mlir
+++ b/test/Dialect/Substrait/emit-invalid.mlir
@@ -2,10 +2,10 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
     // expected-error@+1 {{1 is not a valid index into '!substrait.relation<si32>'}}
-    %1 = emit [1] from %0 : <si32> -> <si32>
+    %1 = emit [1] from %0 : rel<si32> -> rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }
@@ -14,10 +14,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
     // expected-error@+1 {{-1 is not a valid index into '!substrait.relation<si32>'}}
-    %1 = emit [-1] from %0 : <si32> -> <si32>
+    %1 = emit [-1] from %0 : rel<si32> -> rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/emit.mlir
+++ b/test/Dialect/Substrait/emit.mlir
@@ -5,12 +5,12 @@
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
-// CHECK-SAME:          <si1, si32> -> <si32, si1>
+// CHECK-SAME:          rel<si1, si32> -> rel<si32, si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     yield %1 : !substrait.relation<si32, si1>
   }
 }
@@ -21,12 +21,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [0, 0] from %[[V0]] :
-// CHECK-SAME:          <si32> -> <si32, si32>
+// CHECK-SAME:          rel<si32> -> rel<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = emit [0, 0] from %0 : <si32> -> <si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = emit [0, 0] from %0 : rel<si32> -> rel<si32, si32>
     yield %1 : !substrait.relation<si32, si32>
   }
 }
@@ -36,12 +36,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]] : <si32, si1> -> <si1>
+// CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]] : rel<si32, si1> -> rel<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
-    %1 = emit [1] from %0 : <si32, si1> -> <si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
+    %1 = emit [1] from %0 : rel<si32, si1> -> rel<si1>
     yield %1 : !substrait.relation<si1>
   }
 }

--- a/test/Dialect/Substrait/emit.mlir
+++ b/test/Dialect/Substrait/emit.mlir
@@ -5,13 +5,13 @@
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
-// CHECK-SAME:          tuple<si1, si32> -> tuple<si32, si1>
+// CHECK-SAME:          <si1, si32> -> <si32, si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    yield %1 : tuple<si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    yield %1 : !substrait.relation<si32, si1>
   }
 }
 
@@ -21,13 +21,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [0, 0] from %[[V0]] :
-// CHECK-SAME:          tuple<si32> -> tuple<si32, si32>
+// CHECK-SAME:          <si32> -> <si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = emit [0, 0] from %0 : tuple<si32> -> tuple<si32, si32>
-    yield %1 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = emit [0, 0] from %0 : <si32> -> <si32, si32>
+    yield %1 : !substrait.relation<si32, si32>
   }
 }
 
@@ -36,13 +36,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]] :
-// CHECK-SAME:          tuple<si32, si1> -> tuple<si1>
+// CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]] : <si32, si1> -> <si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si1>
-    %1 = emit [1] from %0 : tuple<si32, si1> -> tuple<si1>
-    yield %1 : tuple<si1>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
+    %1 = emit [1] from %0 : <si32, si1> -> <si1>
+    yield %1 : !substrait.relation<si1>
   }
 }

--- a/test/Dialect/Substrait/emit.mlir
+++ b/test/Dialect/Substrait/emit.mlir
@@ -11,7 +11,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
-    yield %1 : !substrait.relation<si32, si1>
+    yield %1 : rel<si32, si1>
   }
 }
 
@@ -27,7 +27,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = emit [0, 0] from %0 : rel<si32> -> rel<si32, si32>
-    yield %1 : !substrait.relation<si32, si32>
+    yield %1 : rel<si32, si32>
   }
 }
 
@@ -42,6 +42,6 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
     %1 = emit [1] from %0 : rel<si32, si1> -> rel<si1>
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }

--- a/test/Dialect/Substrait/extension-table.mlir
+++ b/test/Dialect/Substrait/extension-table.mlir
@@ -5,15 +5,15 @@
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = extension_table
 // CHECK-SAME:         "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        as ["a"] : tuple<si32>
-// CHECK-NEXT:      yield %[[V0]] : tuple<si32>
+// CHECK-SAME:        as ["a"] : <si32>
+// CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-           as ["a"] : tuple<si32>
-    yield %0 : tuple<si32>
+           as ["a"] : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }
 
@@ -24,7 +24,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-SAME:        "some detail" : !substrait.any<"some url"> as ["a"]
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : tuple<si32>
+// CHECK-SAME:        : <si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -32,7 +32,7 @@ substrait.plan version 0 : 42 : 1 {
            "some detail" : !substrait.any<"some url"> as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %0 : tuple<si32>
+            : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/extension-table.mlir
+++ b/test/Dialect/Substrait/extension-table.mlir
@@ -5,14 +5,14 @@
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = extension_table
 // CHECK-SAME:         "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        as ["a"] : <si32>
+// CHECK-SAME:        as ["a"] : rel<si32>
 // CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-           as ["a"] : <si32>
+           as ["a"] : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }
@@ -24,7 +24,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-SAME:        "some detail" : !substrait.any<"some url"> as ["a"]
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -32,7 +32,7 @@ substrait.plan version 0 : 42 : 1 {
            "some detail" : !substrait.any<"some url"> as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/extension-table.mlir
+++ b/test/Dialect/Substrait/extension-table.mlir
@@ -6,14 +6,14 @@
 // CHECK:           %[[V0:.*]] = extension_table
 // CHECK-SAME:         "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 // CHECK-SAME:        as ["a"] : rel<si32>
-// CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V0]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
            as ["a"] : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }
 
@@ -33,6 +33,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/fetch.mlir
+++ b/test/Dialect/Substrait/fetch.mlir
@@ -5,13 +5,13 @@
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : rel<si32>
-// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch 5 offset 3 from %0 : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -21,13 +21,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : rel<si32>
-// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch -1 offset 3 from %0 : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -37,13 +37,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : rel<si32>
-// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch all offset 3 from %0 : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -53,13 +53,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : rel<si32>
-// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch 3 from %0 : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -69,13 +69,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : rel<si32>
-// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch 3 offset 0 from %0 : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -94,6 +94,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/fetch.mlir
+++ b/test/Dialect/Substrait/fetch.mlir
@@ -4,13 +4,13 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : rel<si32>
 // CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = fetch 5 offset 3 from %0 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = fetch 5 offset 3 from %0 : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }
@@ -20,13 +20,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : rel<si32>
 // CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = fetch -1 offset 3 from %0 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = fetch -1 offset 3 from %0 : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }
@@ -36,13 +36,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : rel<si32>
 // CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = fetch all offset 3 from %0 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = fetch all offset 3 from %0 : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }
@@ -52,13 +52,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : rel<si32>
 // CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = fetch 3 from %0 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = fetch 3 from %0 : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }
@@ -68,13 +68,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : rel<si32>
 // CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = fetch 3 offset 0 from %0 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = fetch 3 offset 0 from %0 : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }
@@ -85,15 +85,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           fetch 3 from %{{[^ ]*}}
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch 3 from %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/fetch.mlir
+++ b/test/Dialect/Substrait/fetch.mlir
@@ -4,15 +4,14 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = fetch 5 offset 3 from %0 : tuple<si32>
-    yield %1 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = fetch 5 offset 3 from %0 : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -21,15 +20,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = fetch -1 offset 3 from %0 : tuple<si32>
-    yield %1 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = fetch -1 offset 3 from %0 : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -38,15 +36,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch all offset 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = fetch all offset 3 from %0 : tuple<si32>
-    yield %1 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = fetch all offset 3 from %0 : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -55,15 +52,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = fetch 3 from %0 : tuple<si32>
-    yield %1 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = fetch 3 from %0 : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -72,15 +68,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = named_table
-// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+// CHECK-NEXT:      %[[V1:.*]] = fetch 3 from %[[V0]] : <si32>
+// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = fetch 3 offset 0 from %0 : tuple<si32>
-    yield %1 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = fetch 3 offset 0 from %0 : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -90,15 +85,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           fetch 3 from %{{[^ ]*}}
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : tuple<si32>
+// CHECK-SAME:        : <si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = fetch 3 from %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %1 : tuple<si32>
+            : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/field-reference-invalid.mlir
+++ b/test/Dialect/Substrait/field-reference-invalid.mlir
@@ -11,7 +11,7 @@ substrait.plan version 0 : 42 : 1 {
       %3 = literal 0 : si1
       yield %3 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -28,6 +28,6 @@ substrait.plan version 0 : 42 : 1 {
       %3 = literal 0 : si1
       yield %3 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/field-reference-invalid.mlir
+++ b/test/Dialect/Substrait/field-reference-invalid.mlir
@@ -2,8 +2,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = filter %0 : tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       // expected-error@+2 {{can't extract element from type 'si32'}}
       // expected-error@+1 {{mismatching position and type (position: array<i64: 0, 0>, type: 'tuple<si32>')}}
@@ -11,7 +11,7 @@ substrait.plan version 0 : 42 : 1 {
       %3 = literal 0 : si1
       yield %3 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -19,8 +19,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = filter %0 : tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       // expected-error@+2 {{2 is not a valid index for 'tuple<si32>'}}
       // expected-error@+1 {{mismatching position and type (position: array<i64: 2>, type: 'tuple<si32>')}}
@@ -28,6 +28,6 @@ substrait.plan version 0 : 42 : 1 {
       %3 = literal 0 : si1
       yield %3 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/field-reference-invalid.mlir
+++ b/test/Dialect/Substrait/field-reference-invalid.mlir
@@ -2,8 +2,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = filter %0 : <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       // expected-error@+2 {{can't extract element from type 'si32'}}
       // expected-error@+1 {{mismatching position and type (position: array<i64: 0, 0>, type: 'tuple<si32>')}}
@@ -19,8 +19,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = filter %0 : <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       // expected-error@+2 {{2 is not a valid index for 'tuple<si32>'}}
       // expected-error@+1 {{mismatching position and type (position: array<i64: 2>, type: 'tuple<si32>')}}

--- a/test/Dialect/Substrait/field-reference.mlir
+++ b/test/Dialect/Substrait/field-reference.mlir
@@ -11,8 +11,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = filter %0 : <si1> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = filter %0 : rel<si1> {
     ^bb0(%arg : tuple<si1>):
       %2 = field_reference %arg[0] : tuple<si1>
       yield %2 : si1
@@ -33,8 +33,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
-    %1 = filter %0 : <si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
+    %1 = filter %0 : rel<si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
       yield %2 : si1
@@ -56,8 +56,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
-    %1 = filter %0 : <si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
+    %1 = filter %0 : rel<si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1] : tuple<si1, tuple<si1>>
       %3 = field_reference %2[0] : tuple<si1>

--- a/test/Dialect/Substrait/field-reference.mlir
+++ b/test/Dialect/Substrait/field-reference.mlir
@@ -17,7 +17,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = field_reference %arg[0] : tuple<si1>
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }
 
@@ -39,7 +39,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si1, tuple<si1>>
+    yield %1 : rel<si1, tuple<si1>>
   }
 }
 
@@ -63,6 +63,6 @@ substrait.plan version 0 : 42 : 1 {
       %3 = field_reference %2[0] : tuple<si1>
       yield %3 : si1
     }
-    yield %1 : !substrait.relation<si1, tuple<si1>>
+    yield %1 : rel<si1, tuple<si1>>
   }
 }

--- a/test/Dialect/Substrait/field-reference.mlir
+++ b/test/Dialect/Substrait/field-reference.mlir
@@ -11,13 +11,13 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = filter %0 : tuple<si1> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = filter %0 : <si1> {
     ^bb0(%arg : tuple<si1>):
       %2 = field_reference %arg[0] : tuple<si1>
       yield %2 : si1
     }
-    yield %1 : tuple<si1>
+    yield %1 : !substrait.relation<si1>
   }
 }
 
@@ -33,13 +33,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
-    %1 = filter %0 : tuple<si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    %1 = filter %0 : <si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
       yield %2 : si1
     }
-    yield %1 : tuple<si1, tuple<si1>>
+    yield %1 : !substrait.relation<si1, tuple<si1>>
   }
 }
 
@@ -56,13 +56,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
-    %1 = filter %0 : tuple<si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    %1 = filter %0 : <si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1] : tuple<si1, tuple<si1>>
       %3 = field_reference %2[0] : tuple<si1>
       yield %3 : si1
     }
-    yield %1 : tuple<si1, tuple<si1>>
+    yield %1 : !substrait.relation<si1, tuple<si1>>
   }
 }

--- a/test/Dialect/Substrait/filter-invalid.mlir
+++ b/test/Dialect/Substrait/filter-invalid.mlir
@@ -2,14 +2,14 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding one value (yields 2)}}
-    %1 = filter %0 : tuple<si32> {
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 0 : si1
       yield %2, %2 : si1, si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -17,14 +17,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding 'si1' (yields 'si32')}}
-    %1 = filter %0 : tuple<si32> {
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 42 : si32
       yield %2 : si32
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -32,13 +32,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes no arguments)}}
-    %1 = filter %0 : tuple<si32> {
+    %1 = filter %0 : <si32> {
       %2 = literal 0 : si1
       yield %2 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -46,13 +46,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes 'tuple<>')}}
-    %1 = filter %0 : tuple<si32> {
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<>):
       %2 = literal 0 : si1
       yield %2 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/filter-invalid.mlir
+++ b/test/Dialect/Substrait/filter-invalid.mlir
@@ -2,9 +2,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding one value (yields 2)}}
-    %1 = filter %0 : <si32> {
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 0 : si1
       yield %2, %2 : si1, si1
@@ -17,9 +17,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding 'si1' (yields 'si32')}}
-    %1 = filter %0 : <si32> {
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 42 : si32
       yield %2 : si32
@@ -32,9 +32,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes no arguments)}}
-    %1 = filter %0 : <si32> {
+    %1 = filter %0 : rel<si32> {
       %2 = literal 0 : si1
       yield %2 : si1
     }
@@ -46,9 +46,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes 'tuple<>')}}
-    %1 = filter %0 : <si32> {
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<>):
       %2 = literal 0 : si1
       yield %2 : si1

--- a/test/Dialect/Substrait/filter-invalid.mlir
+++ b/test/Dialect/Substrait/filter-invalid.mlir
@@ -9,7 +9,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal 0 : si1
       yield %2, %2 : si1, si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -24,7 +24,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal 42 : si32
       yield %2 : si32
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -38,7 +38,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal 0 : si1
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -53,6 +53,6 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal 0 : si1
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/filter.mlir
+++ b/test/Dialect/Substrait/filter.mlir
@@ -4,7 +4,7 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = filter %[[V0]] : tuple<si32> {
+// CHECK-NEXT:    %[[V1:.*]] = filter %[[V0]] : <si32> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 // CHECK-NEXT:      yield %[[V2]] : si1
@@ -13,13 +13,13 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = filter %0 : tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -28,19 +28,19 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         filter %{{.*}} advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : tuple<si32> {
+// CHECK-SAME:        : <si32> {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = filter %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> {
+            : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/filter.mlir
+++ b/test/Dialect/Substrait/filter.mlir
@@ -19,7 +19,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -41,6 +41,6 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/filter.mlir
+++ b/test/Dialect/Substrait/filter.mlir
@@ -4,7 +4,7 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = filter %[[V0]] : <si32> {
+// CHECK-NEXT:    %[[V1:.*]] = filter %[[V0]] : rel<si32> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 // CHECK-NEXT:      yield %[[V2]] : si1
@@ -13,8 +13,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = filter %0 : <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
@@ -28,15 +28,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         filter %{{.*}} advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : <si32> {
+// CHECK-SAME:        : rel<si32> {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> {
+            : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1

--- a/test/Dialect/Substrait/join.mlir
+++ b/test/Dialect/Substrait/join.mlir
@@ -6,14 +6,14 @@
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join unspecified %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join unspecified %0, %1 : <si32>, <si32> -> <si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join unspecified %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -25,14 +25,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join inner %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join inner %0, %1 : <si32>, <si32> -> <si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join inner %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -44,14 +44,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join outer %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join outer %0, %1 : <si32>, <si32> -> <si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join outer %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -63,14 +63,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join left %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join left %0, %1 : <si32>, <si32> -> <si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join left %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -82,14 +82,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join right %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join right %0, %1 : <si32>, <si32> -> <si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join right %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -101,14 +101,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join semi %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si1>, <si32> -> <si1>
+// CHECK-SAME:        : rel<si1>, rel<si32> -> rel<si1>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join semi %0, %1 : <si1>, <si32> -> <si1>
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join semi %0, %1 : rel<si1>, rel<si32> -> rel<si1>
     yield %2 : !substrait.relation<si1>
   }
 }
@@ -120,14 +120,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join anti %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si1>, <si32> -> <si1>
+// CHECK-SAME:        : rel<si1>, rel<si32> -> rel<si1>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join anti %0, %1 : <si1>, <si32> -> <si1>
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join anti %0, %1 : rel<si1>, rel<si32> -> rel<si1>
     yield %2 : !substrait.relation<si1>
   }
 }
@@ -139,14 +139,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join single %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>, <si1> -> <si1>
+// CHECK-SAME:        : rel<si32>, rel<si1> -> rel<si1>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si1>
-    %2 = join single %0, %1 : <si32>, <si1> -> <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si1>
+    %2 = join single %0, %1 : rel<si32>, rel<si1> -> rel<si1>
     yield %2 : !substrait.relation<si1>
   }
 }
@@ -157,16 +157,16 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           join inner %{{.*}}, %{{[^ ]*}}
 // CHECK-SAME:          advanced_extension optimization = "\08*"
 // CHECK-SAME:            : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:          : <si32>, <si32> -> <si32, si32>
+// CHECK-SAME:          : rel<si32>, rel<si32> -> rel<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join inner %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>, <si32> -> <si32, si32>
+            : rel<si32>, rel<si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/join.mlir
+++ b/test/Dialect/Substrait/join.mlir
@@ -6,15 +6,15 @@
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join unspecified %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join unspecified %0, %1 : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join unspecified %0, %1 : <si32>, <si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -25,15 +25,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join inner %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join inner %0, %1 : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join inner %0, %1 : <si32>, <si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -44,15 +44,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join outer %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join outer %0, %1 : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join outer %0, %1 : <si32>, <si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -63,15 +63,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join left %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join left %0, %1 : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join left %0, %1 : <si32>, <si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -82,15 +82,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join right %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+// CHECK-SAME:        : <si32>, <si32> -> <si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join right %0, %1 : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join right %0, %1 : <si32>, <si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -101,15 +101,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join semi %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si1>, tuple<si32> -> tuple<si1>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si1>
+// CHECK-SAME:        : <si1>, <si32> -> <si1>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join semi %0, %1 : tuple<si1>, tuple<si32> -> tuple<si1>
-    yield %2 : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join semi %0, %1 : <si1>, <si32> -> <si1>
+    yield %2 : !substrait.relation<si1>
   }
 }
 
@@ -120,15 +120,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join anti %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si1>, tuple<si32> -> tuple<si1>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si1>
+// CHECK-SAME:        : <si1>, <si32> -> <si1>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join anti %0, %1 : tuple<si1>, tuple<si32> -> tuple<si1>
-    yield %2 : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join anti %0, %1 : <si1>, <si32> -> <si1>
+    yield %2 : !substrait.relation<si1>
   }
 }
 
@@ -139,15 +139,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join single %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>, tuple<si1> -> tuple<si1>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si1>
+// CHECK-SAME:        : <si32>, <si1> -> <si1>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si1>
-    %2 = join single %0, %1 : tuple<si32>, tuple<si1> -> tuple<si1>
-    yield %2 : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si1>
+    %2 = join single %0, %1 : <si32>, <si1> -> <si1>
+    yield %2 : !substrait.relation<si1>
   }
 }
 
@@ -157,16 +157,16 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           join inner %{{.*}}, %{{[^ ]*}}
 // CHECK-SAME:          advanced_extension optimization = "\08*"
 // CHECK-SAME:            : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:          : tuple<si32>, tuple<si32> -> tuple<si32, si32>
+// CHECK-SAME:          : <si32>, <si32> -> <si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
     %2 = join inner %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+            : <si32>, <si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/join.mlir
+++ b/test/Dialect/Substrait/join.mlir
@@ -7,14 +7,14 @@
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join unspecified %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join unspecified %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -26,14 +26,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join inner %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join inner %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -45,14 +45,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join outer %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join outer %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -64,14 +64,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join left %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join left %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -83,14 +83,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join right %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>, rel<si32> -> rel<si32, si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join right %0, %1 : rel<si32>, rel<si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -102,14 +102,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join semi %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si1>, rel<si32> -> rel<si1>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
+// CHECK-NEXT:      yield %[[V2]] : rel<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join semi %0, %1 : rel<si1>, rel<si32> -> rel<si1>
-    yield %2 : !substrait.relation<si1>
+    yield %2 : rel<si1>
   }
 }
 
@@ -121,14 +121,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join anti %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si1>, rel<si32> -> rel<si1>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
+// CHECK-NEXT:      yield %[[V2]] : rel<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join anti %0, %1 : rel<si1>, rel<si32> -> rel<si1>
-    yield %2 : !substrait.relation<si1>
+    yield %2 : rel<si1>
   }
 }
 
@@ -140,14 +140,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = join single %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>, rel<si1> -> rel<si1>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
+// CHECK-NEXT:      yield %[[V2]] : rel<si1>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = join single %0, %1 : rel<si32>, rel<si1> -> rel<si1>
-    yield %2 : !substrait.relation<si1>
+    yield %2 : rel<si1>
   }
 }
 
@@ -167,6 +167,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>, rel<si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -39,7 +39,7 @@
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_binary<10>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_binary<10>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -49,7 +49,7 @@ substrait.plan version 0 : 42 : 1 {
       %bytes = literal #substrait.fixed_binary<"8181818181">
       yield %bytes : !substrait.fixed_binary<10>
     }
-    yield %1 : !substrait.relation<si1, !substrait.fixed_binary<10>>
+    yield %1 : rel<si1, !substrait.fixed_binary<10>>
   }
 }
 
@@ -63,7 +63,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<6>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.var_char<6>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.var_char<6>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -73,7 +73,7 @@ substrait.plan version 0 : 42 : 1 {
       %var_char = literal #substrait.var_char<"hello", 6>
       yield %var_char : !substrait.var_char<6>
     }
-    yield %1 : !substrait.relation<si1, !substrait.var_char<6>>
+    yield %1 : rel<si1, !substrait.var_char<6>>
   }
 }
 
@@ -87,7 +87,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_char<5>>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_char<5>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -97,7 +97,7 @@ substrait.plan version 0 : 42 : 1 {
       %fixed_char = literal #substrait.fixed_char<"hello">
       yield %fixed_char : !substrait.fixed_char<5>
     }
-    yield %1 : !substrait.relation<si1, !substrait.fixed_char<5>>
+    yield %1 : rel<si1, !substrait.fixed_char<5>>
   }
 }
 
@@ -111,7 +111,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.uuid>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.uuid>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -121,7 +121,7 @@ substrait.plan version 0 : 42 : 1 {
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : !substrait.uuid
     }
-    yield %1 : !substrait.relation<si1, !substrait.uuid>
+    yield %1 : rel<si1, !substrait.uuid>
   }
 }
 
@@ -135,7 +135,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>{{$}}
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -146,7 +146,7 @@ substrait.plan version 0 : 42 : 1 {
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
       yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
     }
-    yield %1 : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+    yield %1 : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -160,7 +160,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : !substrait.time
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.time>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.time>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -170,7 +170,7 @@ substrait.plan version 0 : 42 : 1 {
       %time = literal #substrait.time<200000000us>
       yield %time : !substrait.time
     }
-    yield %1 : !substrait.relation<si1, !substrait.time>
+    yield %1 : rel<si1, !substrait.time>
   }
 }
 
@@ -184,7 +184,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : !substrait.date
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.date>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.date>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -194,7 +194,7 @@ substrait.plan version 0 : 42 : 1 {
       %date = literal #substrait.date<200000000>
       yield %date : !substrait.date
     }
-    yield %1 : !substrait.relation<si1, !substrait.date>
+    yield %1 : rel<si1, !substrait.date>
   }
 }
 
@@ -209,7 +209,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>{{$}}
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -220,7 +220,7 @@ substrait.plan version 0 : 42 : 1 {
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
       yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
     }
-    yield %1 : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
+    yield %1 : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -234,7 +234,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 // CHECK-NEXT:      yield %[[V2]] : !substrait.binary
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.binary>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -244,7 +244,7 @@ substrait.plan version 0 : 42 : 1 {
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : !substrait.binary
     }
-    yield %1 : !substrait.relation<si1, !substrait.binary>
+    yield %1 : rel<si1, !substrait.binary>
   }
 }
 
@@ -258,7 +258,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 // CHECK-NEXT:      yield %[[V2]] : !substrait.string
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.string>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.string>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -268,7 +268,7 @@ substrait.plan version 0 : 42 : 1 {
       %hi = literal "hi" : !substrait.string
       yield %hi : !substrait.string
     }
-    yield %1 : !substrait.relation<si1, !substrait.string>
+    yield %1 : rel<si1, !substrait.string>
   }
 }
 
@@ -283,7 +283,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : f32, f64
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<f32, f32, f64>
+// CHECK-NEXT:    yield %[[V1]] : rel<f32, f32, f64>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -294,7 +294,7 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42.42 : f64
       yield %35, %42 : f32, f64
     }
-    yield %1 : !substrait.relation<f32, f32, f64>
+    yield %1 : rel<f32, f32, f64>
   }
 }
 
@@ -312,7 +312,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V6:.*]] = literal 42 : si64
 // CHECK-NEXT:      yield %[[V2]], %[[V3]], %[[V4]], %[[V5]], %[[V6]] : si1, si8, si16, si32, si64
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, si1, si8, si16, si32, si64>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, si1, si8, si16, si32, si64>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -326,6 +326,6 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si64
       yield %false, %2, %-1, %35, %42 : si1, si8, si16, si32, si64
     }
-    yield %1 : !substrait.relation<si1, si1, si8, si16, si32, si64>
+    yield %1 : rel<si1, si1, si8, si16, si32, si64>
   }
 }

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -34,22 +34,22 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_binary<10>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_binary<10>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal #substrait.fixed_binary<"8181818181">
       yield %bytes : !substrait.fixed_binary<10>
     }
-    yield %1 : tuple<si1, !substrait.fixed_binary<10>>
+    yield %1 : !substrait.relation<si1, !substrait.fixed_binary<10>>
   }
 }
 
@@ -58,22 +58,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.var_char<6>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<6>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<6>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.var_char<6>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.var_char<6>> {
     ^bb0(%arg : tuple<si1>):
       %var_char = literal #substrait.var_char<"hello", 6>
       yield %var_char : !substrait.var_char<6>
     }
-    yield %1 : tuple<si1, !substrait.var_char<6>>
+    yield %1 : !substrait.relation<si1, !substrait.var_char<6>>
   }
 }
 
@@ -82,22 +82,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_char<5>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_char<5>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_char<5>>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_char<5>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_char<5>> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.fixed_char<5>> {
     ^bb0(%arg : tuple<si1>):
       %fixed_char = literal #substrait.fixed_char<"hello">
       yield %fixed_char : !substrait.fixed_char<5>
     }
-    yield %1 : tuple<si1, !substrait.fixed_char<5>>
+    yield %1 : !substrait.relation<si1, !substrait.fixed_char<5>>
   }
 }
 
@@ -106,22 +106,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.uuid> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.uuid> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.uuid>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.uuid>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.uuid> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.uuid> {
     ^bb0(%arg : tuple<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : !substrait.uuid
     }
-    yield %1 : tuple<si1, !substrait.uuid>
+    yield %1 : !substrait.relation<si1, !substrait.uuid>
   }
 }
 
@@ -129,24 +129,24 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>{{$}}
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
     ^bb0(%arg : tuple<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
       yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
     }
-    yield %1 : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+    yield %1 : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -155,22 +155,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.time> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.time> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : !substrait.time
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.time>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.time>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.time> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.time> {
     ^bb0(%arg : tuple<si1>):
       %time = literal #substrait.time<200000000us>
       yield %time : !substrait.time
     }
-    yield %1 : tuple<si1, !substrait.time>
+    yield %1 : !substrait.relation<si1, !substrait.time>
   }
 }
 
@@ -179,22 +179,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.date> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.date> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : !substrait.date
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.date>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.date>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.date> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.date> {
     ^bb0(%arg : tuple<si1>):
       %date = literal #substrait.date<200000000>
       yield %date : !substrait.date
     }
-    yield %1 : tuple<si1, !substrait.date>
+    yield %1 : !substrait.relation<si1, !substrait.date>
   }
 }
 
@@ -203,24 +203,24 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>{{$}}
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
       yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
     }
-    yield %1 : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+    yield %1 : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -229,22 +229,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.binary> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.binary> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 // CHECK-NEXT:      yield %[[V2]] : !substrait.binary
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.binary>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.binary> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.binary> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : !substrait.binary
     }
-    yield %1 : tuple<si1, !substrait.binary>
+    yield %1 : !substrait.relation<si1, !substrait.binary>
   }
 }
 
@@ -253,22 +253,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.string> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.string> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 // CHECK-NEXT:      yield %[[V2]] : !substrait.string
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.string>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.string>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.string> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.string> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal "hi" : !substrait.string
       yield %hi : !substrait.string
     }
-    yield %1 : tuple<si1, !substrait.string>
+    yield %1 : !substrait.relation<si1, !substrait.string>
   }
 }
 
@@ -277,24 +277,24 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<f32> -> tuple<f32, f32, f64> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <f32> -> <f32, f32, f64> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<f32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal 3.535000e+01 : f32
 // CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : f32, f64
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<f32, f32, f64>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<f32, f32, f64>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<f32>
-    %1 = project %0 : tuple<f32> -> tuple<f32, f32, f64> {
+    %0 = named_table @t1 as ["a"] : <f32>
+    %1 = project %0 : <f32> -> <f32, f32, f64> {
     ^bb0(%arg : tuple<f32>):
       %35 = literal 35.35 : f32
       %42 = literal 42.42 : f64
       yield %35, %42 : f32, f64
     }
-    yield %1 : tuple<f32, f32, f64>
+    yield %1 : !substrait.relation<f32, f32, f64>
   }
 }
 
@@ -303,7 +303,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, si1, si8, si16, si32, si64> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, si1, si8, si16, si32, si64> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal 0 : si1
 // CHECK-NEXT:      %[[V3:.*]] = literal 2 : si8
@@ -312,12 +312,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V6:.*]] = literal 42 : si64
 // CHECK-NEXT:      yield %[[V2]], %[[V3]], %[[V4]], %[[V5]], %[[V6]] : si1, si8, si16, si32, si64
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, si1, si8, si16, si32, si64>
+// CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, si1, si8, si16, si32, si64>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, si1, si8, si16, si32, si64> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, si1, si8, si16, si32, si64> {
     ^bb0(%arg : tuple<si1>):
       %false = literal 0 : si1
       %2 = literal 2 : si8
@@ -326,6 +326,6 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si64
       yield %false, %2, %-1, %35, %42 : si1, si8, si16, si32, si64
     }
-    yield %1 : tuple<si1, si1, si8, si16, si32, si64>
+    yield %1 : !substrait.relation<si1, si1, si8, si16, si32, si64>
   }
 }

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -34,7 +34,7 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_binary<10>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
@@ -43,8 +43,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.fixed_binary<10>> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal #substrait.fixed_binary<"8181818181">
       yield %bytes : !substrait.fixed_binary<10>
@@ -58,7 +58,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.var_char<6>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.var_char<6>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<6>
@@ -67,8 +67,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.var_char<6>> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.var_char<6>> {
     ^bb0(%arg : tuple<si1>):
       %var_char = literal #substrait.var_char<"hello", 6>
       yield %var_char : !substrait.var_char<6>
@@ -82,7 +82,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_char<5>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
@@ -91,8 +91,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.fixed_char<5>> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
     ^bb0(%arg : tuple<si1>):
       %fixed_char = literal #substrait.fixed_char<"hello">
       yield %fixed_char : !substrait.fixed_char<5>
@@ -106,7 +106,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.uuid> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.uuid> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
@@ -115,8 +115,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.uuid> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.uuid> {
     ^bb0(%arg : tuple<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : !substrait.uuid
@@ -129,7 +129,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>{{$}}
@@ -139,8 +139,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
     ^bb0(%arg : tuple<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
@@ -155,7 +155,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.time> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.time> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : !substrait.time
@@ -164,8 +164,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.time> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.time> {
     ^bb0(%arg : tuple<si1>):
       %time = literal #substrait.time<200000000us>
       yield %time : !substrait.time
@@ -179,7 +179,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.date> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.date> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : !substrait.date
@@ -188,8 +188,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.date> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.date> {
     ^bb0(%arg : tuple<si1>):
       %date = literal #substrait.date<200000000>
       yield %date : !substrait.date
@@ -203,7 +203,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>{{$}}
@@ -213,8 +213,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
@@ -229,7 +229,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.binary> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.binary> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 // CHECK-NEXT:      yield %[[V2]] : !substrait.binary
@@ -238,8 +238,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.binary> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.binary> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : !substrait.binary
@@ -253,7 +253,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.string> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.string> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 // CHECK-NEXT:      yield %[[V2]] : !substrait.string
@@ -262,8 +262,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.string> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.string> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal "hi" : !substrait.string
       yield %hi : !substrait.string
@@ -277,7 +277,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <f32> -> <f32, f32, f64> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<f32> -> rel<f32, f32, f64> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<f32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal 3.535000e+01 : f32
 // CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
@@ -287,8 +287,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <f32>
-    %1 = project %0 : <f32> -> <f32, f32, f64> {
+    %0 = named_table @t1 as ["a"] : rel<f32>
+    %1 = project %0 : rel<f32> -> rel<f32, f32, f64> {
     ^bb0(%arg : tuple<f32>):
       %35 = literal 35.35 : f32
       %42 = literal 42.42 : f64
@@ -303,7 +303,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, si1, si8, si16, si32, si64> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal 0 : si1
 // CHECK-NEXT:      %[[V3:.*]] = literal 2 : si8
@@ -316,8 +316,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, si1, si8, si16, si32, si64> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
     ^bb0(%arg : tuple<si1>):
       %false = literal 0 : si1
       %2 = literal 2 : si8

--- a/test/Dialect/Substrait/named-table-invalid.mlir
+++ b/test/Dialect/Substrait/named-table-invalid.mlir
@@ -6,7 +6,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a"]) and result type ('tuple<>')}}
     // expected-note@+1 {{too many field names provided}}
     %0 = named_table @t1 as ["a"] : rel<>
-    yield %0 : !substrait.relation<>
+    yield %0 : rel<>
   }
 }
 
@@ -18,7 +18,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' ([]) and result type ('tuple<si32>')}}
     // expected-error@+1 {{not enough field names provided}}
     %0 = named_table @t1 as [] : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }
 
@@ -30,6 +30,6 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a", "a"]) and result type ('tuple<si32, si32>')}}
     // expected-error@+1 {{duplicate field name: 'a'}}
     %0 = named_table @t1 as ["a", "a"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/named-table-invalid.mlir
+++ b/test/Dialect/Substrait/named-table-invalid.mlir
@@ -5,8 +5,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a"]) and result type ('tuple<>')}}
     // expected-note@+1 {{too many field names provided}}
-    %0 = named_table @t1 as ["a"] : tuple<>
-    yield %0 : tuple<>
+    %0 = named_table @t1 as ["a"] : <>
+    yield %0 : !substrait.relation<>
   }
 }
 
@@ -17,8 +17,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' ([]) and result type ('tuple<si32>')}}
     // expected-error@+1 {{not enough field names provided}}
-    %0 = named_table @t1 as [] : tuple<si32>
-    yield %0 : tuple<si32>
+    %0 = named_table @t1 as [] : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }
 
@@ -29,7 +29,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a", "a"]) and result type ('tuple<si32, si32>')}}
     // expected-error@+1 {{duplicate field name: 'a'}}
-    %0 = named_table @t1 as ["a", "a"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a", "a"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/named-table-invalid.mlir
+++ b/test/Dialect/Substrait/named-table-invalid.mlir
@@ -5,7 +5,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a"]) and result type ('tuple<>')}}
     // expected-note@+1 {{too many field names provided}}
-    %0 = named_table @t1 as ["a"] : <>
+    %0 = named_table @t1 as ["a"] : rel<>
     yield %0 : !substrait.relation<>
   }
 }
@@ -17,7 +17,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' ([]) and result type ('tuple<si32>')}}
     // expected-error@+1 {{not enough field names provided}}
-    %0 = named_table @t1 as [] : <si32>
+    %0 = named_table @t1 as [] : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }
@@ -29,7 +29,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a", "a"]) and result type ('tuple<si32, si32>')}}
     // expected-error@+1 {{duplicate field name: 'a'}}
-    %0 = named_table @t1 as ["a", "a"] : <si32, si32>
+    %0 = named_table @t1 as ["a", "a"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/named-table.mlir
+++ b/test/Dialect/Substrait/named-table.mlir
@@ -9,7 +9,7 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as [] : rel<>
-    yield %0 : !substrait.relation<>
+    yield %0 : rel<>
   }
 }
 
@@ -23,7 +23,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }
 
@@ -37,7 +37,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
 }
 
@@ -52,7 +52,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["outer", "inner"] : rel<tuple<si32>>
-    yield %0 : !substrait.relation<tuple<si32>>
+    yield %0 : rel<tuple<si32>>
   }
 }
 
@@ -67,7 +67,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "a"] : rel<tuple<si32>>
-    yield %0 : !substrait.relation<tuple<si32>>
+    yield %0 : rel<tuple<si32>>
   }
 }
 
@@ -85,6 +85,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/named-table.mlir
+++ b/test/Dialect/Substrait/named-table.mlir
@@ -3,13 +3,13 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as [] : tuple<>
+// CHECK:         %[[V0:.*]] = named_table @t1 as [] : <>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as [] : tuple<>
-    yield %0 : tuple<>
+    %0 = named_table @t1 as [] : <>
+    yield %0 : !substrait.relation<>
   }
 }
 
@@ -17,13 +17,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<si32>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <si32>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    yield %0 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }
 
@@ -31,28 +31,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<si32, si32>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <si32, si32>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: substrait.plan
-// CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1
-// CHECK-SAME:      as ["outer", "inner"] : tuple<tuple<si32>>
-// CHECK-NEXT:    yield %[[V0]] :
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["outer", "inner"] : tuple<tuple<si32>>
-    yield %0 : tuple<tuple<si32>>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
 }
 
@@ -61,13 +46,28 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1
-// CHECK-SAME:      as ["a", "a"] : tuple<tuple<si32>>
+// CHECK-SAME:      as ["outer", "inner"] : <tuple<si32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "a"] : tuple<tuple<si32>>
-    yield %0 : tuple<tuple<si32>>
+    %0 = named_table @t1 as ["outer", "inner"] : <tuple<si32>>
+    yield %0 : !substrait.relation<tuple<si32>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1
+// CHECK-SAME:      as ["a", "a"] : <tuple<si32>>
+// CHECK-NEXT:    yield %[[V0]] :
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "a"] : <tuple<si32>>
+    yield %0 : !substrait.relation<tuple<si32>>
   }
 }
 
@@ -77,14 +77,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         named_table @t1 as ["a"]
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : tuple<si32>
+// CHECK-SAME:        : <si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %0 : tuple<si32>
+            : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/named-table.mlir
+++ b/test/Dialect/Substrait/named-table.mlir
@@ -3,12 +3,12 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as [] : <>
+// CHECK:         %[[V0:.*]] = named_table @t1 as [] : rel<>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as [] : <>
+    %0 = named_table @t1 as [] : rel<>
     yield %0 : !substrait.relation<>
   }
 }
@@ -17,12 +17,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <si32>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<si32>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }
@@ -31,12 +31,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <si32, si32>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<si32, si32>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
 }
@@ -46,12 +46,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1
-// CHECK-SAME:      as ["outer", "inner"] : <tuple<si32>>
+// CHECK-SAME:      as ["outer", "inner"] : rel<tuple<si32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["outer", "inner"] : <tuple<si32>>
+    %0 = named_table @t1 as ["outer", "inner"] : rel<tuple<si32>>
     yield %0 : !substrait.relation<tuple<si32>>
   }
 }
@@ -61,12 +61,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1
-// CHECK-SAME:      as ["a", "a"] : <tuple<si32>>
+// CHECK-SAME:      as ["a", "a"] : rel<tuple<si32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "a"] : <tuple<si32>>
+    %0 = named_table @t1 as ["a", "a"] : rel<tuple<si32>>
     yield %0 : !substrait.relation<tuple<si32>>
   }
 }
@@ -77,14 +77,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         named_table @t1 as ["a"]
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/plan.mlir
+++ b/test/Dialect/Substrait/plan.mlir
@@ -22,8 +22,8 @@ substrait.plan
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @foo::@bar as ["a", "b"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
+    %0 = named_table @foo::@bar as ["a", "b"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
 }
 
@@ -42,12 +42,12 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @foo::@bar as ["a", "b"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
+    %0 = named_table @foo::@bar as ["a", "b"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
   relation {
-    %0 = named_table @foo::@bar as ["a", "b"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
+    %0 = named_table @foo::@bar as ["a", "b"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
 }
 
@@ -62,8 +62,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
-    %0 = named_table @t as ["a", "b", "c"] : tuple<si32, tuple<si32>>
-    yield %0 : tuple<si32, tuple<si32>>
+    %0 = named_table @t as ["a", "b", "c"] : <si32, tuple<si32>>
+    yield %0 : !substrait.relation<si32, tuple<si32>>
   }
 }
 

--- a/test/Dialect/Substrait/plan.mlir
+++ b/test/Dialect/Substrait/plan.mlir
@@ -22,7 +22,7 @@ substrait.plan
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @foo::@bar as ["a", "b"] : <si32, si32>
+    %0 = named_table @foo::@bar as ["a", "b"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
 }
@@ -42,11 +42,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @foo::@bar as ["a", "b"] : <si32, si32>
+    %0 = named_table @foo::@bar as ["a", "b"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
   relation {
-    %0 = named_table @foo::@bar as ["a", "b"] : <si32, si32>
+    %0 = named_table @foo::@bar as ["a", "b"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
 }
@@ -62,7 +62,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
-    %0 = named_table @t as ["a", "b", "c"] : <si32, tuple<si32>>
+    %0 = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
     yield %0 : !substrait.relation<si32, tuple<si32>>
   }
 }

--- a/test/Dialect/Substrait/plan.mlir
+++ b/test/Dialect/Substrait/plan.mlir
@@ -23,7 +23,7 @@ substrait.plan
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @foo::@bar as ["a", "b"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
 }
 
@@ -43,11 +43,11 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @foo::@bar as ["a", "b"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
   relation {
     %0 = named_table @foo::@bar as ["a", "b"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
 }
 
@@ -63,7 +63,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
     %0 = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
-    yield %0 : !substrait.relation<si32, tuple<si32>>
+    yield %0 : rel<si32, tuple<si32>>
   }
 }
 

--- a/test/Dialect/Substrait/project-invalid.mlir
+++ b/test/Dialect/Substrait/project-invalid.mlir
@@ -9,7 +9,7 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si32
       yield %42 : si32
     }
-    yield %1 : !substrait.relation<si1, si32>
+    yield %1 : rel<si1, si32>
   }
 }
 
@@ -24,7 +24,7 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si32
       yield %42 : si32
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -39,7 +39,7 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si32
       yield %42 : si32
     }
-    yield %1 : !substrait.relation<si32, si1>
+    yield %1 : rel<si32, si1>
   }
 }
 
@@ -54,6 +54,6 @@ substrait.plan version 0 : 42 : 1 {
       %3 = field_reference %arg[0] : tuple<si1>
       yield %3 : si1
     }
-    yield %1 : !substrait.relation<si32, si1>
+    yield %1 : rel<si32, si1>
   }
 }

--- a/test/Dialect/Substrait/project-invalid.mlir
+++ b/test/Dialect/Substrait/project-invalid.mlir
@@ -2,14 +2,14 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32' vs 'si1')}}
-    %1 = project %0 : tuple<si32> -> tuple<si1, si32> {
+    %1 = project %0 : <si32> -> <si1, si32> {
     ^bb0(%arg : tuple<si32>):
       %42 = literal 42 : si32
       yield %42 : si32
     }
-    yield %1 : tuple<si1, si32>
+    yield %1 : !substrait.relation<si1, si32>
   }
 }
 
@@ -17,14 +17,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32', 'si32' vs 'si32')}}
-    %1 = project %0 : tuple<si32, si32> -> tuple<si32> {
+    %1 = project %0 : <si32, si32> -> <si32> {
     ^bb0(%arg : tuple<si32, si32>):
       %42 = literal 42 : si32
       yield %42 : si32
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -32,14 +32,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose new fields are different from the yielded operand types ('si1' vs 'si32')}}
-    %1 = project %0 : tuple<si32> -> tuple<si32, si1> {
+    %1 = project %0 : <si32> -> <si32, si1> {
     ^bb0(%arg : tuple<si32>):
       %42 = literal 42 : si32
       yield %42 : si32
     }
-    yield %1 : tuple<si32, si1>
+    yield %1 : !substrait.relation<si32, si1>
   }
 }
 
@@ -47,13 +47,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.project' op has 'expressions' region with mismatching argument type (has: 'tuple<si1>', expected: 'tuple<si32>')}}
-    %1 = project %0 : tuple<si32> -> tuple<si32, si1> {
+    %1 = project %0 : <si32> -> <si32, si1> {
     ^bb0(%arg : tuple<si1>):
       %3 = field_reference %arg[0] : tuple<si1>
       yield %3 : si1
     }
-    yield %1 : tuple<si32, si1>
+    yield %1 : !substrait.relation<si32, si1>
   }
 }

--- a/test/Dialect/Substrait/project-invalid.mlir
+++ b/test/Dialect/Substrait/project-invalid.mlir
@@ -2,9 +2,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32' vs 'si1')}}
-    %1 = project %0 : <si32> -> <si1, si32> {
+    %1 = project %0 : rel<si32> -> rel<si1, si32> {
     ^bb0(%arg : tuple<si32>):
       %42 = literal 42 : si32
       yield %42 : si32
@@ -17,9 +17,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32', 'si32' vs 'si32')}}
-    %1 = project %0 : <si32, si32> -> <si32> {
+    %1 = project %0 : rel<si32, si32> -> rel<si32> {
     ^bb0(%arg : tuple<si32, si32>):
       %42 = literal 42 : si32
       yield %42 : si32
@@ -32,9 +32,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose new fields are different from the yielded operand types ('si1' vs 'si32')}}
-    %1 = project %0 : <si32> -> <si32, si1> {
+    %1 = project %0 : rel<si32> -> rel<si32, si1> {
     ^bb0(%arg : tuple<si32>):
       %42 = literal 42 : si32
       yield %42 : si32
@@ -47,9 +47,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.project' op has 'expressions' region with mismatching argument type (has: 'tuple<si1>', expected: 'tuple<si32>')}}
-    %1 = project %0 : <si32> -> <si32, si1> {
+    %1 = project %0 : rel<si32> -> rel<si32, si1> {
     ^bb0(%arg : tuple<si1>):
       %3 = field_reference %arg[0] : tuple<si1>
       yield %3 : si1

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -4,7 +4,7 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32, si1, si32> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si32> -> <si32, si1, si32> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 // CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32
@@ -14,14 +14,14 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = project %0 : tuple<si32> -> tuple<si32, si1, si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = project %0 : <si32> -> <si32, si1, si32> {
     ^bb0(%arg : tuple<si32>):
       %true = literal -1 : si1
       %42 = literal 42 : si32
       yield %true, %42 : si1, si32
     }
-    yield %1 : tuple<si32, si1, si32>
+    yield %1 : !substrait.relation<si32, si1, si32>
   }
 }
 
@@ -30,18 +30,18 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si32> -> <si32> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:    }
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = project %0 : tuple<si32> -> tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = project %0 : <si32> -> <si32> {
     ^bb0(%arg0: tuple<si32>):
       yield
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -53,18 +53,18 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]]
 // CHECK-SAME:      advanced_extension optimization = "\08*" :
 // CHECK-SAME:        !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:      tuple<si32> -> tuple<si32> {
+// CHECK-SAME:      <si32> -> <si32> {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = project %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> -> tuple<si32> {
+            : <si32> -> <si32> {
     ^bb0(%arg0: tuple<si32>):
       yield
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -4,7 +4,7 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si32> -> <si32, si1, si32> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si32> -> rel<si32, si1, si32> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 // CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32
@@ -14,8 +14,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = project %0 : <si32> -> <si32, si1, si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = project %0 : rel<si32> -> rel<si32, si1, si32> {
     ^bb0(%arg : tuple<si32>):
       %true = literal -1 : si1
       %42 = literal 42 : si32
@@ -30,14 +30,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si32> -> <si32> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si32> -> rel<si32> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 // CHECK-NEXT:    }
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = project %0 : <si32> -> <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = project %0 : rel<si32> -> rel<si32> {
     ^bb0(%arg0: tuple<si32>):
       yield
     }
@@ -53,15 +53,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]]
 // CHECK-SAME:      advanced_extension optimization = "\08*" :
 // CHECK-SAME:        !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:      <si32> -> <si32> {
+// CHECK-SAME:      rel<si32> -> rel<si32> {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> -> <si32> {
+            : rel<si32> -> rel<si32> {
     ^bb0(%arg0: tuple<si32>):
       yield
     }

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -21,7 +21,7 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si32
       yield %true, %42 : si1, si32
     }
-    yield %1 : !substrait.relation<si32, si1, si32>
+    yield %1 : rel<si32, si1, si32>
   }
 }
 
@@ -41,7 +41,7 @@ substrait.plan version 0 : 42 : 1 {
     ^bb0(%arg0: tuple<si32>):
       yield
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -65,6 +65,6 @@ substrait.plan version 0 : 42 : 1 {
     ^bb0(%arg0: tuple<si32>):
       yield
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/relation-invalid.mlir
+++ b/test/Dialect/Substrait/relation-invalid.mlir
@@ -6,7 +6,7 @@ substrait.plan version 0 : 42 : 1 {
   // expected-note@+1 {{too many field names provided}}
   relation as ["x", "y"] {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }
 
@@ -18,7 +18,7 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+1 {{not enough field names provided}}
   relation as ["x"] {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
 }
 
@@ -30,7 +30,7 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+1 {{duplicate field name: 'x'}}
   relation as ["x", "x"] {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
 }
 
@@ -41,6 +41,6 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+1 {{'substrait.relation' op must have 'body' region yielding one value (yields 2)}}
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
-    yield %0, %0 : !substrait.relation<si32, si32>, !substrait.relation<si32, si32>
+    yield %0, %0 : rel<si32, si32>, rel<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/relation-invalid.mlir
+++ b/test/Dialect/Substrait/relation-invalid.mlir
@@ -5,7 +5,7 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "y"]) and result type ('tuple<si32>')}}
   // expected-note@+1 {{too many field names provided}}
   relation as ["x", "y"] {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }
@@ -17,7 +17,7 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x"]) and result type ('tuple<si32, si32>')}}
   // expected-error@+1 {{not enough field names provided}}
   relation as ["x"] {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
 }
@@ -29,7 +29,7 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "x"]) and result type ('tuple<si32, si32>')}}
   // expected-error@+1 {{duplicate field name: 'x'}}
   relation as ["x", "x"] {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
 }
@@ -40,7 +40,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   // expected-error@+1 {{'substrait.relation' op must have 'body' region yielding one value (yields 2)}}
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
     yield %0, %0 : !substrait.relation<si32, si32>, !substrait.relation<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/relation-invalid.mlir
+++ b/test/Dialect/Substrait/relation-invalid.mlir
@@ -5,8 +5,8 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "y"]) and result type ('tuple<si32>')}}
   // expected-note@+1 {{too many field names provided}}
   relation as ["x", "y"] {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    yield %0 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }
 
@@ -17,11 +17,10 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x"]) and result type ('tuple<si32, si32>')}}
   // expected-error@+1 {{not enough field names provided}}
   relation as ["x"] {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
 }
-
 
 // -----
 
@@ -30,8 +29,8 @@ substrait.plan version 0 : 42 : 1 {
   // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "x"]) and result type ('tuple<si32, si32>')}}
   // expected-error@+1 {{duplicate field name: 'x'}}
   relation as ["x", "x"] {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
 }
 
@@ -41,7 +40,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   // expected-error@+1 {{'substrait.relation' op must have 'body' region yielding one value (yields 2)}}
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
-    yield %0, %0 : tuple<si32, si32>, tuple<si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    yield %0, %0 : !substrait.relation<si32, si32>, !substrait.relation<si32, si32>
   }
 }

--- a/test/Dialect/Substrait/set.mlir
+++ b/test/Dialect/Substrait/set.mlir
@@ -7,15 +7,15 @@
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK:           %[[V2:.*]] = named_table
 // CHECK-NEXT:      %[[V3:.*]] = set unspecified %[[V0]], %[[V1]], %[[V2]]
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 // CHECK-NEXT:      yield %[[V3]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = named_table @t2 as ["c"] : <si32>
-    %3 = set unspecified %0, %1, %2 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = named_table @t2 as ["c"] : rel<si32>
+    %3 = set unspecified %0, %1, %2 : rel<si32>
     yield %3 : !substrait.relation<si32>
   }
 }
@@ -27,14 +27,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set minus_primary %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set minus_primary %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -46,14 +46,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set minus_multiset %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set minus_multiset %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -65,14 +65,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set intersection_primary %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set intersection_primary %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -84,14 +84,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set intersection_multiset %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set intersection_multiset %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -103,14 +103,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set union_distinct %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set union_distinct %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -122,14 +122,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set union_all %[[V0]], %[[V1]]
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set union_all %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set union_all %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -140,16 +140,16 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           set union_all %{{.*}}, %{{[^ ]*}}
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : <si32>
+// CHECK-SAME:        : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set union_all %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/set.mlir
+++ b/test/Dialect/Substrait/set.mlir
@@ -8,7 +8,7 @@
 // CHECK:           %[[V2:.*]] = named_table
 // CHECK-NEXT:      %[[V3:.*]] = set unspecified %[[V0]], %[[V1]], %[[V2]]
 // CHECK-SAME:        : rel<si32>
-// CHECK-NEXT:      yield %[[V3]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V3]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -16,7 +16,7 @@ substrait.plan version 0 : 42 : 1 {
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = named_table @t2 as ["c"] : rel<si32>
     %3 = set unspecified %0, %1, %2 : rel<si32>
-    yield %3 : !substrait.relation<si32>
+    yield %3 : rel<si32>
   }
 }
 
@@ -28,14 +28,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set minus_primary %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -47,14 +47,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set minus_multiset %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -66,14 +66,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set intersection_primary %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -85,14 +85,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set intersection_multiset %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -104,14 +104,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set union_distinct %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -123,14 +123,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set union_all %[[V0]], %[[V1]]
 // CHECK-SAME:        : rel<si32>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
+// CHECK-NEXT:      yield %[[V2]] : rel<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set union_all %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -150,6 +150,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }

--- a/test/Dialect/Substrait/set.mlir
+++ b/test/Dialect/Substrait/set.mlir
@@ -7,16 +7,16 @@
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK:           %[[V2:.*]] = named_table
 // CHECK-NEXT:      %[[V3:.*]] = set unspecified %[[V0]], %[[V1]], %[[V2]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V3]] : tuple<si32>
+// CHECK-SAME:        : <si32>
+// CHECK-NEXT:      yield %[[V3]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = named_table @t2 as ["c"] : tuple<si32>
-    %3 = set unspecified %0, %1, %2: tuple<si32>
-    yield %3 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = named_table @t2 as ["c"] : <si32>
+    %3 = set unspecified %0, %1, %2 : <si32>
+    yield %3 : !substrait.relation<si32>
   }
 }
 
@@ -27,15 +27,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+// CHECK-SAME:        : <si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_primary %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set minus_primary %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -46,15 +46,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+// CHECK-SAME:        : <si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_multiset %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set minus_multiset %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -65,15 +65,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+// CHECK-SAME:        : <si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_primary %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set intersection_primary %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -84,15 +84,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+// CHECK-SAME:        : <si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_multiset %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set intersection_multiset %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -103,15 +103,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+// CHECK-SAME:        : <si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_distinct %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set union_distinct %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -122,15 +122,15 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           %[[V0:.*]] = named_table
 // CHECK:           %[[V1:.*]] = named_table
 // CHECK-NEXT:      %[[V2:.*]] = set union_all %[[V0]], %[[V1]]
-// CHECK-SAME:        : tuple<si32>
-// CHECK-NEXT:      yield %[[V2]] : tuple<si32>
+// CHECK-SAME:        : <si32>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_all %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set union_all %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -140,16 +140,16 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           set union_all %{{.*}}, %{{[^ ]*}}
 // CHECK-SAME:        advanced_extension optimization = "\08*"
 // CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-// CHECK-SAME:        : tuple<si32>
+// CHECK-SAME:        : <si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
     %2 = set union_all %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %2 : tuple<si32>
+            : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }

--- a/test/Dialect/Substrait/substrait-type.mlir
+++ b/test/Dialect/Substrait/substrait-type.mlir
@@ -13,8 +13,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = cross %0 x %1 : rel<si32> x rel<si1>
     yield %2 : !substrait.relation<si32, si1>
   }
@@ -30,8 +30,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = cross %0 x %1 : !substrait.relation<si32> x !substrait.relation<si1>
     yield %2 : !substrait.relation<si32, si1>
   }

--- a/test/Dialect/Substrait/substrait-type.mlir
+++ b/test/Dialect/Substrait/substrait-type.mlir
@@ -16,7 +16,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = cross %0 x %1 : rel<si32> x rel<si1>
-    yield %2 : !substrait.relation<si32, si1>
+    yield %2 : rel<si32, si1>
   }
 }
 
@@ -32,7 +32,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si1>
-    %2 = cross %0 x %1 : !substrait.relation<si32> x !substrait.relation<si1>
-    yield %2 : !substrait.relation<si32, si1>
+    %2 = cross %0 x %1 : rel<si32> x rel<si1>
+    yield %2 : rel<si32, si1>
   }
 }

--- a/test/Dialect/Substrait/substrait-type.mlir
+++ b/test/Dialect/Substrait/substrait-type.mlir
@@ -1,0 +1,38 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: substrait-opt -split-input-file %s | substrait-opt -split-input-file \
+// RUN: | FileCheck %s
+
+// This file tests the custom `SubstraitType` printer and parser.
+
+// Check round-tripping of short-hand form.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:            = cross %{{.*}} x %{{.*}} : rel<si32> x rel<si1>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si1>
+    %2 = cross %0 x %1 : rel<si32> x rel<si1>
+    yield %2 : !substrait.relation<si32, si1>
+  }
+}
+
+// -----
+
+
+// Check parsing of full form.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:            = cross %{{.*}} x %{{.*}} : rel<si32> x rel<si1>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si1>
+    %2 = cross %0 x %1 : !substrait.relation<si32> x !substrait.relation<si1>
+    yield %2 : !substrait.relation<si32, si1>
+  }
+}

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,12 +3,12 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.decimal<12, 2>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.decimal<12, 2>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.decimal<12, 2>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
     yield %0 : !substrait.relation<!substrait.decimal<12, 2>>
   }
 }
@@ -17,12 +17,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.fixed_binary<4>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.fixed_binary<4>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.fixed_binary<4>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
     yield %0 : !substrait.relation<!substrait.fixed_binary<4>>
   }
 }
@@ -31,12 +31,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.var_char<6>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.var_char<6>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.var_char<6>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
     yield %0 : !substrait.relation<!substrait.var_char<6>>
   }
 }
@@ -45,12 +45,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.fixed_char<5>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.fixed_char<5>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.fixed_char<5>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
     yield %0 : !substrait.relation<!substrait.fixed_char<5>>
   }
 }
@@ -59,12 +59,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.uuid>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.uuid>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.uuid>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.uuid>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.uuid>
     yield %0 : !substrait.relation<!substrait.uuid>
   }
 }
@@ -73,12 +73,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <!substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <!substrait.interval_year_month, !substrait.interval_day_second>
+    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
     yield %0 : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
@@ -87,12 +87,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.time>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.time>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.time>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.time>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.time>
     yield %0 : !substrait.relation<!substrait.time>
   }
 }
@@ -101,12 +101,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.date>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.date>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.date>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.date>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.date>
     yield %0 : !substrait.relation<!substrait.date>
   }
 }
@@ -115,12 +115,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <!substrait.timestamp, !substrait.timestamp_tz>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <!substrait.timestamp, !substrait.timestamp_tz>
+    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
     yield %0 : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
@@ -129,12 +129,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.binary>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.binary>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.binary>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
     yield %0 : !substrait.relation<!substrait.binary>
   }
 }
@@ -143,12 +143,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.binary>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.binary>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.binary>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
     yield %0 : !substrait.relation<!substrait.binary>
   }
 }
@@ -157,12 +157,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.string>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.string>
 // CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.string>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.string>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.string>
     yield %0 : !substrait.relation<!substrait.string>
   }
 }
@@ -171,12 +171,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <f32, f64>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<f32, f64>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <f32, f64>
+    %0 = named_table @t1 as ["a", "b"] : rel<f32, f64>
     yield %0 : !substrait.relation<f32, f64>
   }
 }
@@ -185,12 +185,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : <f32, tuple<f32>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <f32, tuple<f32>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
     yield %0 : !substrait.relation<f32, tuple<f32>>
   }
 }
@@ -199,12 +199,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si8, si16, si32, si64>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si8, si16, si32, si64>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si8, si16, si32, si64>
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si8, si16, si32, si64>
     yield %0 : !substrait.relation<si1, si8, si16, si32, si64>
   }
 }
@@ -213,12 +213,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
     yield %0 : !substrait.relation<si1, tuple<si1>>
   }
 }

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -1,15 +1,29 @@
 // RUN: substrait-opt -split-input-file %s \
 // RUN: | FileCheck %s
 
+// Check that full-form type names can be parsed.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<si1>
+// CHECK-NEXT:    yield %[[V0]] : rel<si1>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : !substrait.relation<si1>
+    yield %0 : !substrait.relation<si1>
+  }
+}
+
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.decimal<12, 2>>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.decimal<12, 2>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
-    yield %0 : !substrait.relation<!substrait.decimal<12, 2>>
+    yield %0 : rel<!substrait.decimal<12, 2>>
   }
 }
 
@@ -18,12 +32,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.fixed_binary<4>>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.fixed_binary<4>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
-    yield %0 : !substrait.relation<!substrait.fixed_binary<4>>
+    yield %0 : rel<!substrait.fixed_binary<4>>
   }
 }
 
@@ -32,12 +46,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.var_char<6>>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.var_char<6>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
-    yield %0 : !substrait.relation<!substrait.var_char<6>>
+    yield %0 : rel<!substrait.var_char<6>>
   }
 }
 
@@ -46,12 +60,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.fixed_char<5>>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.fixed_char<5>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
-    yield %0 : !substrait.relation<!substrait.fixed_char<5>>
+    yield %0 : rel<!substrait.fixed_char<5>>
   }
 }
 
@@ -60,12 +74,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.uuid>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.uuid>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.uuid>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.uuid>
-    yield %0 : !substrait.relation<!substrait.uuid>
+    yield %0 : rel<!substrait.uuid>
   }
 }
 
@@ -74,12 +88,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
-    yield %0 : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
+    yield %0 : rel<!substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -88,12 +102,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.time>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.time>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.time>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.time>
-    yield %0 : !substrait.relation<!substrait.time>
+    yield %0 : rel<!substrait.time>
   }
 }
 
@@ -102,12 +116,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.date>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.date>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.date>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.date>
-    yield %0 : !substrait.relation<!substrait.date>
+    yield %0 : rel<!substrait.date>
   }
 }
 
@@ -116,12 +130,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.timestamp, !substrait.timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : rel<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -130,12 +144,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.binary>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.binary>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
-    yield %0 : !substrait.relation<!substrait.binary>
+    yield %0 : rel<!substrait.binary>
   }
 }
 
@@ -144,12 +158,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.binary>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.binary>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
-    yield %0 : !substrait.relation<!substrait.binary>
+    yield %0 : rel<!substrait.binary>
   }
 }
 
@@ -158,12 +172,12 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.string>
-// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.string>
+// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.string>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.string>
-    yield %0 : !substrait.relation<!substrait.string>
+    yield %0 : rel<!substrait.string>
   }
 }
 
@@ -177,7 +191,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<f32, f64>
-    yield %0 : !substrait.relation<f32, f64>
+    yield %0 : rel<f32, f64>
   }
 }
 
@@ -191,7 +205,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
-    yield %0 : !substrait.relation<f32, tuple<f32>>
+    yield %0 : rel<f32, tuple<f32>>
   }
 }
 
@@ -205,7 +219,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si8, si16, si32, si64>
-    yield %0 : !substrait.relation<si1, si8, si16, si32, si64>
+    yield %0 : rel<si1, si8, si16, si32, si64>
   }
 }
 
@@ -219,6 +233,6 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    yield %0 : !substrait.relation<si1, tuple<si1>>
+    yield %0 : rel<si1, tuple<si1>>
   }
 }

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,13 +3,13 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.decimal<12, 2>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.decimal<12, 2>>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.decimal<12, 2>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
-    yield %0 : tuple<!substrait.decimal<12, 2>>
+    %0 = named_table @t1 as ["a"] : <!substrait.decimal<12, 2>>
+    yield %0 : !substrait.relation<!substrait.decimal<12, 2>>
   }
 }
 
@@ -17,13 +17,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.fixed_binary<4>>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.fixed_binary<4>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.fixed_binary<4>>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.fixed_binary<4>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.fixed_binary<4>>
-    yield %0 : tuple<!substrait.fixed_binary<4>>
+    %0 = named_table @t1 as ["a"] : <!substrait.fixed_binary<4>>
+    yield %0 : !substrait.relation<!substrait.fixed_binary<4>>
   }
 }
 
@@ -31,13 +31,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.var_char<6>>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.var_char<6>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.var_char<6>>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.var_char<6>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.var_char<6>>
-    yield %0 : tuple<!substrait.var_char<6>>
+    %0 = named_table @t1 as ["a"] : <!substrait.var_char<6>>
+    yield %0 : !substrait.relation<!substrait.var_char<6>>
   }
 }
 
@@ -45,13 +45,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.fixed_char<5>>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.fixed_char<5>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.fixed_char<5>>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.fixed_char<5>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.fixed_char<5>>
-    yield %0 : tuple<!substrait.fixed_char<5>>
+    %0 = named_table @t1 as ["a"] : <!substrait.fixed_char<5>>
+    yield %0 : !substrait.relation<!substrait.fixed_char<5>>
   }
 }
 
@@ -59,13 +59,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.uuid>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.uuid>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.uuid>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.uuid>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.uuid>
-    yield %0 : tuple<!substrait.uuid>
+    %0 = named_table @t1 as ["a"] : <!substrait.uuid>
+    yield %0 : !substrait.relation<!substrait.uuid>
   }
 }
 
@@ -73,13 +73,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <!substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
-    yield %0 : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+    %0 = named_table @t1 as ["a", "b"] : <!substrait.interval_year_month, !substrait.interval_day_second>
+    yield %0 : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -87,13 +87,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.time>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.time>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.time>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.time>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.time>
-    yield %0 : tuple<!substrait.time>
+    %0 = named_table @t1 as ["a"] : <!substrait.time>
+    yield %0 : !substrait.relation<!substrait.time>
   }
 }
 
@@ -101,13 +101,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.date>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.date>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.date>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.date>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.date>
-    yield %0 : tuple<!substrait.date>
+    %0 = named_table @t1 as ["a"] : <!substrait.date>
+    yield %0 : !substrait.relation<!substrait.date>
   }
 }
 
@@ -115,13 +115,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <!substrait.timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+    %0 = named_table @t1 as ["a", "b"] : <!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -129,13 +129,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.binary>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.binary>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.binary>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.binary>
-    yield %0 : tuple<!substrait.binary>
+    %0 = named_table @t1 as ["a"] : <!substrait.binary>
+    yield %0 : !substrait.relation<!substrait.binary>
   }
 }
 
@@ -143,13 +143,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.string>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.string>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.binary>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.string>
-    yield %0 : tuple<!substrait.string>
+    %0 = named_table @t1 as ["a"] : <!substrait.binary>
+    yield %0 : !substrait.relation<!substrait.binary>
   }
 }
 
@@ -157,13 +157,27 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<f32, f64>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <!substrait.string>
+// CHECK-NEXT:    yield %[[V0]] : !substrait.relation<!substrait.string>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : <!substrait.string>
+    yield %0 : !substrait.relation<!substrait.string>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <f32, f64>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<f32, f64>
-    yield %0 : tuple<f32, f64>
+    %0 = named_table @t1 as ["a", "b"] : <f32, f64>
+    yield %0 : !substrait.relation<f32, f64>
   }
 }
 
@@ -171,13 +185,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : tuple<f32, tuple<f32>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : <f32, tuple<f32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<f32, tuple<f32>>
-    yield %0 : tuple<f32, tuple<f32>>
+    %0 = named_table @t1 as ["a", "b", "c"] : <f32, tuple<f32>>
+    yield %0 : !substrait.relation<f32, tuple<f32>>
   }
 }
 
@@ -185,13 +199,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c", "d", "e"] : tuple<si1, si8, si16, si32, si64>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si8, si16, si32, si64>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : tuple<si1, si8, si16, si32, si64>
-    yield %0 : tuple<si1, si8, si16, si32, si64>
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si8, si16, si32, si64>
+    yield %0 : !substrait.relation<si1, si8, si16, si32, si64>
   }
 }
 
@@ -199,12 +213,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
-    yield %0 : tuple<si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    yield %0 : !substrait.relation<si1, tuple<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
@@ -6,9 +6,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.aggregate' op cannot be exported: values yielded from 'groupings' region are not all distinct after CSE}}
-    %1 = aggregate %0 : <si32> -> <si1, si1>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1

--- a/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
@@ -6,15 +6,15 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     // expected-error@+1 {{'substrait.aggregate' op cannot be exported: values yielded from 'groupings' region are not all distinct after CSE}}
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1>
+    %1 = aggregate %0 : <si32> -> <si1, si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         %3 = literal 0 : si1
         yield %2, %3 : si1, si1
       }
-    yield %1 : tuple<si1, si1>
+    yield %1 : !substrait.relation<si1, si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
@@ -15,6 +15,6 @@ substrait.plan version 0 : 42 : 1 {
         %3 = literal 0 : si1
         yield %2, %3 : si1, si1
       }
-    yield %1 : !substrait.relation<si1, si1>
+    yield %1 : rel<si1, si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/aggregate.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate.mlir
@@ -92,7 +92,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : !substrait.relation<si1, si1, si32, si32>
+    yield %1 : rel<si1, si1, si32, si32>
   }
 }
 
@@ -118,7 +118,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %2 : si1
       }
       grouping_sets [[0]]
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }
 
@@ -146,7 +146,7 @@ substrait.plan version 0 : 42 : 1 {
         %4 = call @function(%2) aggregate : (si32) -> si32
         yield %4 : si32
       }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -173,7 +173,7 @@ substrait.plan version 0 : 42 : 1 {
         %4 = call @function(%2) aggregate : (si32) -> si32
         yield %4 : si32
       }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -239,7 +239,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %3, %4, %5, %6, %7, %8, %9
               : si32, si32, si32, si32, si32, si32, si32
       }
-    yield %1 : !substrait.relation<si32, si32, si32, si32, si32, si32, si32>
+    yield %1 : rel<si32, si32, si32, si32, si32, si32, si32>
   }
 }
 
@@ -270,6 +270,6 @@ substrait.plan version 0 : 42 : 1 {
         %2 = literal 0 : si1
         yield %2 : si1
       }
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/aggregate.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate.mlir
@@ -77,8 +77,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si1, si1, si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -110,8 +110,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -137,8 +137,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32>
       grouping_sets []
       measures {
       ^bb0(%arg : tuple<si32>):
@@ -165,8 +165,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32> -> <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -223,9 +223,9 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = aggregate %0 : <si32>
-          -> <si32, si32, si32, si32, si32, si32, si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = aggregate %0 : rel<si32>
+          -> rel<si32, si32, si32, si32, si32, si32, si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -260,11 +260,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> -> <si1>
+            : rel<si32> -> rel<si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1

--- a/test/Target/SubstraitPB/Export/aggregate.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate.mlir
@@ -77,8 +77,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1, si1, si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si1, si1, si32, si32>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
@@ -92,7 +92,7 @@ substrait.plan version 0 : 42 : 1 {
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
-    yield %1 : tuple<si1, si1, si32, si32>
+    yield %1 : !substrait.relation<si1, si1, si32, si32>
   }
 }
 
@@ -110,15 +110,15 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
       grouping_sets [[0]]
-    yield %1 : tuple<si1>
+    yield %1 : !substrait.relation<si1>
   }
 }
 
@@ -137,8 +137,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si32>
       grouping_sets []
       measures {
       ^bb0(%arg : tuple<si32>):
@@ -146,7 +146,7 @@ substrait.plan version 0 : 42 : 1 {
         %4 = call @function(%2) aggregate : (si32) -> si32
         yield %4 : si32
       }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -165,15 +165,15 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32> -> tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32> -> <si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
         %4 = call @function(%2) aggregate : (si32) -> si32
         yield %4 : si32
       }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -223,9 +223,9 @@ substrait.plan version 0 : 42 : 1 {
   extension_uri @extension at "http://some.url/with/extensions.yml"
   extension_function @function at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = aggregate %0 : tuple<si32>
-          -> tuple<si32, si32, si32, si32, si32, si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = aggregate %0 : <si32>
+          -> <si32, si32, si32, si32, si32, si32, si32>
       measures {
       ^bb0(%arg : tuple<si32>):
         %2 = field_reference %arg[0] : tuple<si32>
@@ -239,7 +239,7 @@ substrait.plan version 0 : 42 : 1 {
         yield %3, %4, %5, %6, %7, %8, %9
               : si32, si32, si32, si32, si32, si32, si32
       }
-    yield %1 : tuple<si32, si32, si32, si32, si32, si32, si32>
+    yield %1 : !substrait.relation<si32, si32, si32, si32, si32, si32, si32>
   }
 }
 
@@ -260,16 +260,16 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = aggregate %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> -> tuple<si1>
+            : <si32> -> <si1>
       groupings {
       ^bb0(%arg : tuple<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
-    yield %1 : tuple<si1>
+    yield %1 : !substrait.relation<si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/call.mlir
+++ b/test/Target/SubstraitPB/Export/call.mlir
@@ -46,6 +46,6 @@ substrait.plan version 0 : 42 : 1 {
       %3 = call @f2(%2) : (si32) -> si1
       yield %3 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/call.mlir
+++ b/test/Target/SubstraitPB/Export/call.mlir
@@ -39,13 +39,13 @@ substrait.plan version 0 : 42 : 1 {
   extension_function @f1 at @extension["somefunc"]
   extension_function @f2 at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = filter %0 : tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = field_reference %arg[0] : tuple<si32>
       %3 = call @f2(%2) : (si32) -> si1
       yield %3 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/call.mlir
+++ b/test/Target/SubstraitPB/Export/call.mlir
@@ -39,8 +39,8 @@ substrait.plan version 0 : 42 : 1 {
   extension_function @f1 at @extension["somefunc"]
   extension_function @f2 at @extension["somefunc"]
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = filter %0 : <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = field_reference %arg[0] : tuple<si32>
       %3 = call @f2(%2) : (si32) -> si1

--- a/test/Target/SubstraitPB/Export/cast.mlir
+++ b/test/Target/SubstraitPB/Export/cast.mlir
@@ -59,8 +59,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = project %0 : tuple<si32> -> tuple<si32, si64, si64, si64> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = project %0 : <si32> -> <si32, si64, si64, si64> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si64
@@ -68,6 +68,6 @@ substrait.plan version 0 : 42 : 1 {
       %5 = cast %2 or unspecified : si32 to si64
       yield %3, %4, %5 : si64, si64, si64
     }
-    yield %1 : tuple<si32, si64, si64, si64>
+    yield %1 : !substrait.relation<si32, si64, si64, si64>
   }
 }

--- a/test/Target/SubstraitPB/Export/cast.mlir
+++ b/test/Target/SubstraitPB/Export/cast.mlir
@@ -59,8 +59,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = project %0 : <si32> -> <si32, si64, si64, si64> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = project %0 : rel<si32> -> rel<si32, si64, si64, si64> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si64

--- a/test/Target/SubstraitPB/Export/cast.mlir
+++ b/test/Target/SubstraitPB/Export/cast.mlir
@@ -68,6 +68,6 @@ substrait.plan version 0 : 42 : 1 {
       %5 = cast %2 or unspecified : si32 to si64
       yield %3, %4, %5 : si64, si64, si64
     }
-    yield %1 : !substrait.relation<si32, si64, si64, si64>
+    yield %1 : rel<si32, si64, si64, si64>
   }
 }

--- a/test/Target/SubstraitPB/Export/cross.mlir
+++ b/test/Target/SubstraitPB/Export/cross.mlir
@@ -23,10 +23,10 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = cross %0 x %1 : tuple<si32> x tuple<si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = cross %0 x %1 : <si32> x <si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -43,12 +43,12 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si1>
     %2 = cross %0 x %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> x tuple<si1>
-    yield %2 : tuple<si32, si1>
+            : <si32> x <si1>
+    yield %2 : !substrait.relation<si32, si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/cross.mlir
+++ b/test/Target/SubstraitPB/Export/cross.mlir
@@ -23,8 +23,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = cross %0 x %1 : rel<si32> x rel<si32>
     yield %2 : !substrait.relation<si32, si32>
   }
@@ -43,8 +43,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = cross %0 x %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">

--- a/test/Target/SubstraitPB/Export/cross.mlir
+++ b/test/Target/SubstraitPB/Export/cross.mlir
@@ -26,7 +26,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = cross %0 x %1 : rel<si32> x rel<si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -49,6 +49,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> x rel<si1>
-    yield %2 : !substrait.relation<si32, si1>
+    yield %2 : rel<si32, si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/cross.mlir
+++ b/test/Target/SubstraitPB/Export/cross.mlir
@@ -25,7 +25,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : <si32>
     %1 = named_table @t2 as ["b"] : <si32>
-    %2 = cross %0 x %1 : <si32> x <si32>
+    %2 = cross %0 x %1 : rel<si32> x rel<si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -48,7 +48,7 @@ substrait.plan version 0 : 42 : 1 {
     %2 = cross %0 x %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> x <si1>
+            : rel<si32> x rel<si1>
     yield %2 : !substrait.relation<si32, si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/emit-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/emit-invalid.mlir
@@ -5,11 +5,11 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     // expected-note@+1 {{op exported to 'input' message}}
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
     // expected-error@+1 {{'substrait.emit' op has 'input' that already has 'emit' message (try running canonicalization?)}}
-    %2 = emit [1, 0] from %1 : tuple<si32, si1> -> tuple<si1, si32>
-    yield %2 : tuple<si1, si32>
+    %2 = emit [1, 0] from %1 : <si32, si1> -> <si1, si32>
+    yield %2 : !substrait.relation<si1, si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/emit-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/emit-invalid.mlir
@@ -5,11 +5,11 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     // expected-note@+1 {{op exported to 'input' message}}
-    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     // expected-error@+1 {{'substrait.emit' op has 'input' that already has 'emit' message (try running canonicalization?)}}
-    %2 = emit [1, 0] from %1 : <si32, si1> -> <si1, si32>
+    %2 = emit [1, 0] from %1 : rel<si32, si1> -> rel<si1, si32>
     yield %2 : !substrait.relation<si1, si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/emit-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/emit-invalid.mlir
@@ -10,6 +10,6 @@ substrait.plan version 0 : 42 : 1 {
     %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     // expected-error@+1 {{'substrait.emit' op has 'input' that already has 'emit' message (try running canonicalization?)}}
     %2 = emit [1, 0] from %1 : rel<si32, si1> -> rel<si1, si32>
-    yield %2 : !substrait.relation<si1, si32>
+    yield %2 : rel<si1, si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/emit.mlir
+++ b/test/Target/SubstraitPB/Export/emit.mlir
@@ -25,7 +25,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = cross %0 x %0 : rel<si32> x rel<si32>
     %2 = emit [1, 0] from %1 : rel<si32, si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -45,7 +45,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
     %1 = emit [1] from %0 : rel<si32, si1> -> rel<si1>
-    yield %1 : !substrait.relation<si1>
+    yield %1 : rel<si1>
   }
 }
 
@@ -74,6 +74,6 @@ substrait.plan version 0 : 42 : 1 {
       yield %2 : si1
     }
     %2 = emit [1] from %1 : rel<si32, si1> -> rel<si1>
-    yield %2 : !substrait.relation<si1>
+    yield %2 : rel<si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/emit.mlir
+++ b/test/Target/SubstraitPB/Export/emit.mlir
@@ -22,10 +22,10 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = cross %0 x %0 : tuple<si32> x tuple<si32>
-    %2 = emit [1, 0] from %1 : tuple<si32, si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = cross %0 x %0 : <si32> x <si32>
+    %2 = emit [1, 0] from %1 : <si32, si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -43,9 +43,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si1>
-    %1 = emit [1] from %0 : tuple<si32, si1> -> tuple<si1>
-    yield %1 : tuple<si1>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
+    %1 = emit [1] from %0 : <si32, si1> -> <si1>
+    yield %1 : !substrait.relation<si1>
   }
 }
 
@@ -67,13 +67,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si1>
-    %1 = filter %0 : tuple<si32, si1> {
+    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
+    %1 = filter %0 : <si32, si1> {
     ^bb0(%arg : tuple<si32, si1>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    %2 = emit [1] from %1 : tuple<si32, si1> -> tuple<si1>
-    yield %2 : tuple<si1>
+    %2 = emit [1] from %1 : <si32, si1> -> <si1>
+    yield %2 : !substrait.relation<si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/emit.mlir
+++ b/test/Target/SubstraitPB/Export/emit.mlir
@@ -23,7 +23,7 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : <si32>
-    %1 = cross %0 x %0 : <si32> x <si32>
+    %1 = cross %0 x %0 : rel<si32> x rel<si32>
     %2 = emit [1, 0] from %1 : <si32, si32> -> <si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }

--- a/test/Target/SubstraitPB/Export/emit.mlir
+++ b/test/Target/SubstraitPB/Export/emit.mlir
@@ -22,9 +22,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = cross %0 x %0 : rel<si32> x rel<si32>
-    %2 = emit [1, 0] from %1 : <si32, si32> -> <si32, si32>
+    %2 = emit [1, 0] from %1 : rel<si32, si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -43,8 +43,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
-    %1 = emit [1] from %0 : <si32, si1> -> <si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
+    %1 = emit [1] from %0 : rel<si32, si1> -> rel<si1>
     yield %1 : !substrait.relation<si1>
   }
 }
@@ -67,13 +67,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
-    %1 = filter %0 : <si32, si1> {
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
+    %1 = filter %0 : rel<si32, si1> {
     ^bb0(%arg : tuple<si32, si1>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    %2 = emit [1] from %1 : <si32, si1> -> <si1>
+    %2 = emit [1] from %1 : rel<si32, si1> -> rel<si1>
     yield %2 : !substrait.relation<si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/extension-table.mlir
+++ b/test/Target/SubstraitPB/Export/extension-table.mlir
@@ -43,7 +43,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
            as ["a"] : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }
 
@@ -64,6 +64,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/extension-table.mlir
+++ b/test/Target/SubstraitPB/Export/extension-table.mlir
@@ -42,8 +42,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-           as ["a"] : tuple<si32>
-    yield %0 : tuple<si32>
+           as ["a"] : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }
 
@@ -63,7 +63,7 @@ substrait.plan version 0 : 42 : 1 {
            "some detail" : !substrait.any<"some url"> as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %0 : tuple<si32>
+            : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/extension-table.mlir
+++ b/test/Target/SubstraitPB/Export/extension-table.mlir
@@ -42,7 +42,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-           as ["a"] : <si32>
+           as ["a"] : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }
@@ -63,7 +63,7 @@ substrait.plan version 0 : 42 : 1 {
            "some detail" : !substrait.any<"some url"> as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/fetch.mlir
+++ b/test/Target/SubstraitPB/Export/fetch.mlir
@@ -23,9 +23,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = fetch 5 offset 3 from %0 : tuple<si32>
-    yield %1 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = fetch 5 offset 3 from %0 : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -42,11 +42,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = fetch 3 from %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %1 : tuple<si32>
+            : <si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/fetch.mlir
+++ b/test/Target/SubstraitPB/Export/fetch.mlir
@@ -25,7 +25,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch 5 offset 3 from %0 : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -47,6 +47,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/fetch.mlir
+++ b/test/Target/SubstraitPB/Export/fetch.mlir
@@ -23,8 +23,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = fetch 5 offset 3 from %0 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = fetch 5 offset 3 from %0 : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }
@@ -42,11 +42,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = fetch 3 from %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/field-reference.mlir
+++ b/test/Target/SubstraitPB/Export/field-reference.mlir
@@ -27,8 +27,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
-    %1 = filter %0 : <si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
+    %1 = filter %0 : rel<si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
       yield %2 : si1
@@ -64,8 +64,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
-    %1 = filter %0 : <si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
+    %1 = filter %0 : rel<si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1] : tuple<si1, tuple<si1>>
       %3 = field_reference %2[0] : tuple<si1>

--- a/test/Target/SubstraitPB/Export/field-reference.mlir
+++ b/test/Target/SubstraitPB/Export/field-reference.mlir
@@ -33,7 +33,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si1, tuple<si1>>
+    yield %1 : rel<si1, tuple<si1>>
   }
 }
 
@@ -71,6 +71,6 @@ substrait.plan version 0 : 42 : 1 {
       %3 = field_reference %2[0] : tuple<si1>
       yield %3 : si1
     }
-    yield %1 : !substrait.relation<si1, tuple<si1>>
+    yield %1 : rel<si1, tuple<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Export/field-reference.mlir
+++ b/test/Target/SubstraitPB/Export/field-reference.mlir
@@ -27,13 +27,13 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
-    %1 = filter %0 : tuple<si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    %1 = filter %0 : <si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
       yield %2 : si1
     }
-    yield %1 : tuple<si1, tuple<si1>>
+    yield %1 : !substrait.relation<si1, tuple<si1>>
   }
 }
 
@@ -64,13 +64,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
-    %1 = filter %0 : tuple<si1, tuple<si1>> {
+    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    %1 = filter %0 : <si1, tuple<si1>> {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[1] : tuple<si1, tuple<si1>>
       %3 = field_reference %2[0] : tuple<si1>
       yield %3 : si1
     }
-    yield %1 : tuple<si1, tuple<si1>>
+    yield %1 : !substrait.relation<si1, tuple<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Export/filter.mlir
+++ b/test/Target/SubstraitPB/Export/filter.mlir
@@ -21,13 +21,13 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = filter %0 : tuple<si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = filter %0 : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }
 
@@ -44,15 +44,15 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = filter %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> {
+            : <si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/filter.mlir
+++ b/test/Target/SubstraitPB/Export/filter.mlir
@@ -21,8 +21,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = filter %0 : <si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = filter %0 : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
@@ -44,11 +44,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> {
+            : rel<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1

--- a/test/Target/SubstraitPB/Export/filter.mlir
+++ b/test/Target/SubstraitPB/Export/filter.mlir
@@ -27,7 +27,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }
 
@@ -53,6 +53,6 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal -1 : si1
       yield %2 : si1
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/join.mlir
+++ b/test/Target/SubstraitPB/Export/join.mlir
@@ -24,9 +24,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join unspecified %0, %1 : <si32>, <si32> -> <si32,si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join unspecified %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -48,9 +48,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join inner %0, %1 : <si32>, <si32> -> <si32,si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join inner %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -72,9 +72,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join outer %0, %1 : <si32>, <si32> -> <si32,si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join outer %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -96,9 +96,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join left %0, %1 : <si32>, <si32> -> <si32,si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join left %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -120,9 +120,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join right %0, %1 : <si32>, <si32> -> <si32,si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join right %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }
@@ -144,9 +144,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join semi %0, %1 : <si1>, <si32> -> <si1>
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join semi %0, %1 : rel<si1>, rel<si32> -> rel<si1>
     yield %2 : !substrait.relation<si1>
   }
 }
@@ -168,9 +168,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = join anti %0, %1 : <si1>, <si32> -> <si1>
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = join anti %0, %1 : rel<si1>, rel<si32> -> rel<si1>
     yield %2 : !substrait.relation<si1>
   }
 }
@@ -192,9 +192,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si1>
-    %2 = join single %0, %1 : <si32>, <si1> -> <si1>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si1>
+    %2 = join single %0, %1 : rel<si32>, rel<si1> -> rel<si1>
     yield %2 : !substrait.relation<si1>
   }
 }
@@ -212,12 +212,12 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join inner %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>, <si32> -> <si32, si32>
+            : rel<si32>, rel<si32> -> rel<si32, si32>
     yield %2 : !substrait.relation<si32, si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/join.mlir
+++ b/test/Target/SubstraitPB/Export/join.mlir
@@ -27,7 +27,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join unspecified %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -51,7 +51,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join inner %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -75,7 +75,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join outer %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -99,7 +99,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join left %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -123,7 +123,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join right %0, %1 : rel<si32>, rel<si32> -> rel<si32,si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }
 
@@ -147,7 +147,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join semi %0, %1 : rel<si1>, rel<si32> -> rel<si1>
-    yield %2 : !substrait.relation<si1>
+    yield %2 : rel<si1>
   }
 }
 
@@ -171,7 +171,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = join anti %0, %1 : rel<si1>, rel<si32> -> rel<si1>
-    yield %2 : !substrait.relation<si1>
+    yield %2 : rel<si1>
   }
 }
 
@@ -195,7 +195,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si1>
     %2 = join single %0, %1 : rel<si32>, rel<si1> -> rel<si1>
-    yield %2 : !substrait.relation<si1>
+    yield %2 : rel<si1>
   }
 }
 
@@ -218,6 +218,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>, rel<si32> -> rel<si32, si32>
-    yield %2 : !substrait.relation<si32, si32>
+    yield %2 : rel<si32, si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/join.mlir
+++ b/test/Target/SubstraitPB/Export/join.mlir
@@ -24,10 +24,10 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join unspecified %0, %1 : tuple<si32> , tuple<si32> -> tuple<si32,si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join unspecified %0, %1 : <si32>, <si32> -> <si32,si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -48,10 +48,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join inner %0, %1 : tuple<si32> , tuple<si32> -> tuple<si32,si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join inner %0, %1 : <si32>, <si32> -> <si32,si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -72,10 +72,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join outer %0, %1 : tuple<si32> , tuple<si32> -> tuple<si32,si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join outer %0, %1 : <si32>, <si32> -> <si32,si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -96,10 +96,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join left %0, %1 : tuple<si32> , tuple<si32> -> tuple<si32,si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join left %0, %1 : <si32>, <si32> -> <si32,si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -120,10 +120,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join right %0, %1 : tuple<si32> , tuple<si32> -> tuple<si32,si32>
-    yield %2 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join right %0, %1 : <si32>, <si32> -> <si32,si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }
 
@@ -144,10 +144,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join semi %0, %1 : tuple<si1>, tuple<si32> -> tuple<si1>
-    yield %2 : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join semi %0, %1 : <si1>, <si32> -> <si1>
+    yield %2 : !substrait.relation<si1>
   }
 }
 
@@ -168,10 +168,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = join anti %0, %1 : tuple<si1>, tuple<si32> -> tuple<si1>
-    yield %2 : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = join anti %0, %1 : <si1>, <si32> -> <si1>
+    yield %2 : !substrait.relation<si1>
   }
 }
 
@@ -192,10 +192,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si1>
-    %2 = join single %0, %1 : tuple<si32>, tuple<si1> -> tuple<si1>
-    yield %2 : tuple<si1>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si1>
+    %2 = join single %0, %1 : <si32>, <si1> -> <si1>
+    yield %2 : !substrait.relation<si1>
   }
 }
 
@@ -212,12 +212,12 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
     %2 = join inner %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-    yield %2 : tuple<si32, si32>
+            : <si32>, <si32> -> <si32, si32>
+    yield %2 : !substrait.relation<si32, si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -27,8 +27,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.decimal<9, 2>> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.decimal<9, 2>> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal #substrait.decimal<"0.05", P = 9, S = 2>
       yield %hi : !substrait.decimal<9, 2>
@@ -54,8 +54,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.fixed_binary<10>> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
       %fixed_binary = literal #substrait.fixed_binary<"8181818181">
       yield %fixed_binary : !substrait.fixed_binary<10>
@@ -85,8 +85,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.var_char<6>> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.var_char<6>> {
     ^bb0(%arg0: tuple<si1>):
       %2 = literal #substrait.var_char<"hello", 6>
       yield %2 : !substrait.var_char<6>
@@ -114,8 +114,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.fixed_char<5>> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
     ^bb0(%arg0: tuple<si1>):
       %2 = literal #substrait.fixed_char<"hello">
       yield %2 : !substrait.fixed_char<5>
@@ -141,8 +141,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.uuid> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.uuid> {
     ^bb0(%arg : tuple<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : !substrait.uuid
@@ -178,8 +178,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
     ^bb0(%arg : tuple<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
@@ -208,8 +208,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.time> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.time> {
     ^bb0(%arg : tuple<si1>):
       %time = literal #substrait.time<200000000us>
       yield %time : !substrait.time
@@ -235,8 +235,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.date> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.date> {
     ^bb0(%arg : tuple<si1>):
       %date = literal #substrait.date<200000000>
       yield %date : !substrait.date
@@ -267,8 +267,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
@@ -295,8 +295,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.binary> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.binary> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : !substrait.binary
@@ -322,8 +322,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, !substrait.string> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, !substrait.string> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal "hi" : !substrait.string
       yield %hi : !substrait.string
@@ -354,8 +354,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <f32>
-    %1 = project %0 : <f32> -> <f32, f32, f64> {
+    %0 = named_table @t1 as ["a"] : rel<f32>
+    %1 = project %0 : rel<f32> -> rel<f32, f32, f64> {
     ^bb0(%arg : tuple<f32>):
       %35 = literal 35.35 : f32
       %42 = literal 42.42 : f64
@@ -402,8 +402,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si1>
-    %1 = project %0 : <si1> -> <si1, si1, si8, si16, si32, si64> {
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    %1 = project %0 : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
     ^bb0(%arg : tuple<si1>):
       %false = literal 0 : si1
       %2 = literal 2 : si8

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -33,7 +33,7 @@ substrait.plan version 0 : 42 : 1 {
       %hi = literal #substrait.decimal<"0.05", P = 9, S = 2>
       yield %hi : !substrait.decimal<9, 2>
     }
-    yield %1 : !substrait.relation<si1, !substrait.decimal<9, 2>>
+    yield %1 : rel<si1, !substrait.decimal<9, 2>>
   }
 }
 
@@ -60,7 +60,7 @@ substrait.plan version 0 : 42 : 1 {
       %fixed_binary = literal #substrait.fixed_binary<"8181818181">
       yield %fixed_binary : !substrait.fixed_binary<10>
     }
-    yield %1 : !substrait.relation<si1, !substrait.fixed_binary<10>>
+    yield %1 : rel<si1, !substrait.fixed_binary<10>>
   }
 }
 
@@ -91,7 +91,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal #substrait.var_char<"hello", 6>
       yield %2 : !substrait.var_char<6>
     }
-    yield %1 : !substrait.relation<si1, !substrait.var_char<6>>
+    yield %1 : rel<si1, !substrait.var_char<6>>
   }
 }
 
@@ -120,7 +120,7 @@ substrait.plan version 0 : 42 : 1 {
       %2 = literal #substrait.fixed_char<"hello">
       yield %2 : !substrait.fixed_char<5>
     }
-    yield %1 : !substrait.relation<si1, !substrait.fixed_char<5>>
+    yield %1 : rel<si1, !substrait.fixed_char<5>>
   }
 }
 
@@ -147,7 +147,7 @@ substrait.plan version 0 : 42 : 1 {
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : !substrait.uuid
     }
-    yield %1 : !substrait.relation<si1, !substrait.uuid>
+    yield %1 : rel<si1, !substrait.uuid>
   }
 }
 
@@ -185,7 +185,7 @@ substrait.plan version 0 : 42 : 1 {
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
       yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
     }
-    yield %1 : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+    yield %1 : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -214,7 +214,7 @@ substrait.plan version 0 : 42 : 1 {
       %time = literal #substrait.time<200000000us>
       yield %time : !substrait.time
     }
-    yield %1 : !substrait.relation<si1, !substrait.time>
+    yield %1 : rel<si1, !substrait.time>
   }
 }
 
@@ -241,7 +241,7 @@ substrait.plan version 0 : 42 : 1 {
       %date = literal #substrait.date<200000000>
       yield %date : !substrait.date
     }
-    yield %1 : !substrait.relation<si1, !substrait.date>
+    yield %1 : rel<si1, !substrait.date>
   }
 }
 
@@ -274,7 +274,7 @@ substrait.plan version 0 : 42 : 1 {
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
       yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
     }
-    yield %1 : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
+    yield %1 : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -301,7 +301,7 @@ substrait.plan version 0 : 42 : 1 {
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : !substrait.binary
     }
-    yield %1 : !substrait.relation<si1, !substrait.binary>
+    yield %1 : rel<si1, !substrait.binary>
   }
 }
 
@@ -328,7 +328,7 @@ substrait.plan version 0 : 42 : 1 {
       %hi = literal "hi" : !substrait.string
       yield %hi : !substrait.string
     }
-    yield %1 : !substrait.relation<si1, !substrait.string>
+    yield %1 : rel<si1, !substrait.string>
   }
 }
 
@@ -361,7 +361,7 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42.42 : f64
       yield %35, %42 : f32, f64
     }
-    yield %1 : !substrait.relation<f32, f32, f64>
+    yield %1 : rel<f32, f32, f64>
   }
 }
 
@@ -412,6 +412,6 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si64
       yield %false, %2, %-1, %35, %42 : si1, si8, si16, si32, si64
     }
-    yield %1 : !substrait.relation<si1, si1, si8, si16, si32, si64>
+    yield %1 : rel<si1, si1, si8, si16, si32, si64>
   }
 }

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -27,13 +27,13 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.decimal<9, 2>> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.decimal<9, 2>> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal #substrait.decimal<"0.05", P = 9, S = 2>
       yield %hi : !substrait.decimal<9, 2>
     }
-    yield %1 : tuple<si1, !substrait.decimal<9, 2>>
+    yield %1 : !substrait.relation<si1, !substrait.decimal<9, 2>>
   }
 }
 
@@ -54,13 +54,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
       %fixed_binary = literal #substrait.fixed_binary<"8181818181">
       yield %fixed_binary : !substrait.fixed_binary<10>
     }
-    yield %1 : tuple<si1, !substrait.fixed_binary<10>>
+    yield %1 : !substrait.relation<si1, !substrait.fixed_binary<10>>
   }
 }
 
@@ -85,13 +85,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.var_char<6>> {
     ^bb0(%arg0: tuple<si1>):
       %2 = literal #substrait.var_char<"hello", 6>
       yield %2 : !substrait.var_char<6>
     }
-    yield %1 : tuple<si1, !substrait.var_char<6>>
+    yield %1 : !substrait.relation<si1, !substrait.var_char<6>>
   }
 }
 
@@ -114,13 +114,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_char<5>> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.fixed_char<5>> {
     ^bb0(%arg0: tuple<si1>):
       %2 = literal #substrait.fixed_char<"hello">
       yield %2 : !substrait.fixed_char<5>
     }
-    yield %1 : tuple<si1, !substrait.fixed_char<5>>
+    yield %1 : !substrait.relation<si1, !substrait.fixed_char<5>>
   }
 }
 
@@ -141,13 +141,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.uuid> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.uuid> {
     ^bb0(%arg : tuple<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : !substrait.uuid
     }
-    yield %1 : tuple<si1, !substrait.uuid>
+    yield %1 : !substrait.relation<si1, !substrait.uuid>
   }
 }
 
@@ -178,14 +178,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
     ^bb0(%arg : tuple<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
       yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
     }
-    yield %1 : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+    yield %1 : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -208,13 +208,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.time> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.time> {
     ^bb0(%arg : tuple<si1>):
       %time = literal #substrait.time<200000000us>
       yield %time : !substrait.time
     }
-    yield %1 : tuple<si1, !substrait.time>
+    yield %1 : !substrait.relation<si1, !substrait.time>
   }
 }
 
@@ -235,13 +235,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.date> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.date> {
     ^bb0(%arg : tuple<si1>):
       %date = literal #substrait.date<200000000>
       yield %date : !substrait.date
     }
-    yield %1 : tuple<si1, !substrait.date>
+    yield %1 : !substrait.relation<si1, !substrait.date>
   }
 }
 
@@ -267,14 +267,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
       yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
     }
-    yield %1 : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+    yield %1 : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -295,13 +295,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.binary> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.binary> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : !substrait.binary
     }
-    yield %1 : tuple<si1, !substrait.binary>
+    yield %1 : !substrait.relation<si1, !substrait.binary>
   }
 }
 
@@ -322,13 +322,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.string> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, !substrait.string> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal "hi" : !substrait.string
       yield %hi : !substrait.string
     }
-    yield %1 : tuple<si1, !substrait.string>
+    yield %1 : !substrait.relation<si1, !substrait.string>
   }
 }
 
@@ -354,14 +354,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<f32>
-    %1 = project %0 : tuple<f32> -> tuple<f32, f32, f64> {
+    %0 = named_table @t1 as ["a"] : <f32>
+    %1 = project %0 : <f32> -> <f32, f32, f64> {
     ^bb0(%arg : tuple<f32>):
       %35 = literal 35.35 : f32
       %42 = literal 42.42 : f64
       yield %35, %42 : f32, f64
     }
-    yield %1 : tuple<f32, f32, f64>
+    yield %1 : !substrait.relation<f32, f32, f64>
   }
 }
 
@@ -402,8 +402,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, si1, si8, si16, si32, si64> {
+    %0 = named_table @t1 as ["a"] : <si1>
+    %1 = project %0 : <si1> -> <si1, si1, si8, si16, si32, si64> {
     ^bb0(%arg : tuple<si1>):
       %false = literal 0 : si1
       %2 = literal 2 : si8
@@ -412,6 +412,6 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si64
       yield %false, %2, %-1, %35, %42 : si1, si8, si16, si32, si64
     }
-    yield %1 : tuple<si1, si1, si8, si16, si32, si64>
+    yield %1 : !substrait.relation<si1, si1, si8, si16, si32, si64>
   }
 }

--- a/test/Target/SubstraitPB/Export/named-table.mlir
+++ b/test/Target/SubstraitPB/Export/named-table.mlir
@@ -31,8 +31,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as [] : tuple<>
-    yield %0 : tuple<>
+    %0 = named_table @t1 as [] : <>
+    yield %0 : !substrait.relation<>
   }
 }
 
@@ -66,8 +66,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    yield %0 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }
 
@@ -107,8 +107,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
-    yield %0 : tuple<si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    yield %0 : !substrait.relation<si32, si32>
   }
 }
 
@@ -147,8 +147,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["outer", "inner"] : tuple<tuple<si32>>
-    yield %0 : tuple<tuple<si32>>
+    %0 = named_table @t1 as ["outer", "inner"] : <tuple<si32>>
+    yield %0 : !substrait.relation<tuple<si32>>
   }
 }
 
@@ -187,8 +187,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "a"] : tuple<tuple<si32>>
-    yield %0 : tuple<tuple<si32>>
+    %0 = named_table @t1 as ["a", "a"] : <tuple<si32>>
+    yield %0 : !substrait.relation<tuple<si32>>
   }
 }
 
@@ -207,7 +207,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %0 : tuple<si32>
+            : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/named-table.mlir
+++ b/test/Target/SubstraitPB/Export/named-table.mlir
@@ -32,7 +32,7 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as [] : rel<>
-    yield %0 : !substrait.relation<>
+    yield %0 : rel<>
   }
 }
 
@@ -67,7 +67,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }
 
@@ -108,7 +108,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
-    yield %0 : !substrait.relation<si32, si32>
+    yield %0 : rel<si32, si32>
   }
 }
 
@@ -148,7 +148,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["outer", "inner"] : rel<tuple<si32>>
-    yield %0 : !substrait.relation<tuple<si32>>
+    yield %0 : rel<tuple<si32>>
   }
 }
 
@@ -188,7 +188,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "a"] : rel<tuple<si32>>
-    yield %0 : !substrait.relation<tuple<si32>>
+    yield %0 : rel<tuple<si32>>
   }
 }
 
@@ -208,6 +208,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/named-table.mlir
+++ b/test/Target/SubstraitPB/Export/named-table.mlir
@@ -31,7 +31,7 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as [] : <>
+    %0 = named_table @t1 as [] : rel<>
     yield %0 : !substrait.relation<>
   }
 }
@@ -66,7 +66,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }
@@ -107,7 +107,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
     yield %0 : !substrait.relation<si32, si32>
   }
 }
@@ -147,7 +147,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["outer", "inner"] : <tuple<si32>>
+    %0 = named_table @t1 as ["outer", "inner"] : rel<tuple<si32>>
     yield %0 : !substrait.relation<tuple<si32>>
   }
 }
@@ -187,7 +187,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "a"] : <tuple<si32>>
+    %0 = named_table @t1 as ["a", "a"] : rel<tuple<si32>>
     yield %0 : !substrait.relation<tuple<si32>>
   }
 }
@@ -207,7 +207,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"]
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -51,12 +51,12 @@ substrait.plan
 
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
-    %0 = named_table @t as ["a", "b", "c"] : tuple<si32, tuple<si32>>
-    yield %0 : tuple<si32, tuple<si32>>
+    %0 = named_table @t as ["a", "b", "c"] : <si32, tuple<si32>>
+    yield %0 : !substrait.relation<si32, tuple<si32>>
   }
   relation  {
-    %0 = named_table @t as ["a"] : tuple<si32>
-    yield %0 : tuple<si32>
+    %0 = named_table @t as ["a"] : <si32>
+    yield %0 : !substrait.relation<si32>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -51,11 +51,11 @@ substrait.plan
 
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
-    %0 = named_table @t as ["a", "b", "c"] : <si32, tuple<si32>>
+    %0 = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
     yield %0 : !substrait.relation<si32, tuple<si32>>
   }
   relation  {
-    %0 = named_table @t as ["a"] : <si32>
+    %0 = named_table @t as ["a"] : rel<si32>
     yield %0 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -52,11 +52,11 @@ substrait.plan
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
     %0 = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
-    yield %0 : !substrait.relation<si32, tuple<si32>>
+    yield %0 : rel<si32, tuple<si32>>
   }
   relation  {
     %0 = named_table @t as ["a"] : rel<si32>
-    yield %0 : !substrait.relation<si32>
+    yield %0 : rel<si32>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -29,14 +29,14 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = project %0 : tuple<si32> -> tuple<si32, si1, si32> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = project %0 : <si32> -> <si32, si1, si32> {
     ^bb0(%arg : tuple<si32>):
       %true = literal -1 : si1
       %42 = literal 42 : si32
       yield %true, %42 : si1, si32
     }
-    yield %1 : tuple<si32, si1, si32>
+    yield %1 : !substrait.relation<si32, si1, si32>
   }
 }
 
@@ -56,14 +56,14 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
     %1 = project %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32> -> tuple<si32> {
+            : <si32> -> <si32> {
     ^bb0(%arg0: tuple<si32>):
       yield
     }
-    yield %1 : tuple<si32>
+    yield %1 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -29,8 +29,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = project %0 : <si32> -> <si32, si1, si32> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = project %0 : rel<si32> -> rel<si32, si1, si32> {
     ^bb0(%arg : tuple<si32>):
       %true = literal -1 : si1
       %42 = literal 42 : si32
@@ -56,11 +56,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32> -> <si32> {
+            : rel<si32> -> rel<si32> {
     ^bb0(%arg0: tuple<si32>):
       yield
     }

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -36,7 +36,7 @@ substrait.plan version 0 : 42 : 1 {
       %42 = literal 42 : si32
       yield %true, %42 : si1, si32
     }
-    yield %1 : !substrait.relation<si32, si1, si32>
+    yield %1 : rel<si32, si1, si32>
   }
 }
 
@@ -64,6 +64,6 @@ substrait.plan version 0 : 42 : 1 {
     ^bb0(%arg0: tuple<si32>):
       yield
     }
-    yield %1 : !substrait.relation<si32>
+    yield %1 : rel<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/set.mlir
+++ b/test/Target/SubstraitPB/Export/set.mlir
@@ -27,7 +27,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set unspecified %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -51,7 +51,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set minus_primary %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -75,7 +75,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set minus_multiset %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -99,7 +99,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set intersection_primary %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -123,7 +123,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set intersection_multiset %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -147,7 +147,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set union_distinct %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -171,7 +171,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set union_all %0, %1 : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }
 
@@ -194,6 +194,6 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32>
-    yield %2 : !substrait.relation<si32>
+    yield %2 : rel<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/set.mlir
+++ b/test/Target/SubstraitPB/Export/set.mlir
@@ -24,10 +24,10 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set unspecified %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set unspecified %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -48,10 +48,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_primary %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set minus_primary %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -72,10 +72,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set minus_multiset %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set minus_multiset %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -96,10 +96,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_primary %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set intersection_primary %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -120,10 +120,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set intersection_multiset %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set intersection_multiset %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -144,10 +144,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_distinct %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set union_distinct %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -168,10 +168,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
-    %2 = set union_all %0, %1 : tuple<si32>
-    yield %2 : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
+    %2 = set union_all %0, %1 : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }
 
@@ -188,12 +188,12 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = named_table @t2 as ["b"] : <si32>
     %2 = set union_all %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : tuple<si32>
-    yield %2 : tuple<si32>
+            : <si32>
+    yield %2 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/set.mlir
+++ b/test/Target/SubstraitPB/Export/set.mlir
@@ -24,9 +24,9 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set unspecified %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set unspecified %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -48,9 +48,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set minus_primary %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set minus_primary %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -72,9 +72,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set minus_multiset %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set minus_multiset %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -96,9 +96,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set intersection_primary %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set intersection_primary %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -120,9 +120,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set intersection_multiset %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set intersection_multiset %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -144,9 +144,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set union_distinct %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set union_distinct %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -168,9 +168,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
-    %2 = set union_all %0, %1 : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
+    %2 = set union_all %0, %1 : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }
@@ -188,12 +188,12 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = named_table @t2 as ["b"] : <si32>
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = named_table @t2 as ["b"] : rel<si32>
     %2 = set union_all %0, %1
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : <si32>
+            : rel<si32>
     yield %2 : !substrait.relation<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -29,7 +29,7 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.decimal<12, 2>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
     yield %0 : !substrait.relation<!substrait.decimal<12, 2>>
   }
 }
@@ -55,7 +55,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.fixed_binary<4>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
     yield %0 : !substrait.relation<!substrait.fixed_binary<4>>
   }
 }
@@ -81,7 +81,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.var_char<6>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
     yield %0 : !substrait.relation<!substrait.var_char<6>>
   }
 }
@@ -107,7 +107,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.fixed_char<5>>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
     yield %0 : !substrait.relation<!substrait.fixed_char<5>>
   }
 }
@@ -132,7 +132,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.uuid>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.uuid>
     yield %0 : !substrait.relation<!substrait.uuid>
   }
 }
@@ -163,7 +163,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <!substrait.interval_year_month, !substrait.interval_day_second>
+    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
     yield %0 : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
@@ -188,7 +188,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.time>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.time>
     yield %0 : !substrait.relation<!substrait.time>
   }
 }
@@ -213,7 +213,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.date>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.date>
     yield %0 : !substrait.relation<!substrait.date>
   }
 }
@@ -244,7 +244,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <!substrait.timestamp, !substrait.timestamp_tz>
+    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
     yield %0 : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
@@ -269,7 +269,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.binary>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
     yield %0 : !substrait.relation<!substrait.binary>
   }
 }
@@ -294,7 +294,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <!substrait.string>
+    %0 = named_table @t1 as ["a"] : rel<!substrait.string>
     yield %0 : !substrait.relation<!substrait.string>
   }
 }
@@ -325,7 +325,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <f32, f64>
+    %0 = named_table @t1 as ["a", "b"] : rel<f32, f64>
     yield %0 : !substrait.relation<f32, f64>
   }
 }
@@ -361,7 +361,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <f32, tuple<f32>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
     yield %0 : !substrait.relation<f32, tuple<f32>>
   }
 }
@@ -410,7 +410,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si8, si16, si32, si64>
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si8, si16, si32, si64>
     yield %0 : !substrait.relation<si1, si8, si16, si32, si64>
   }
 }
@@ -446,7 +446,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
     yield %0 : !substrait.relation<si1, tuple<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -29,8 +29,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
-    yield %0 : tuple<!substrait.decimal<12, 2>>
+    %0 = named_table @t1 as ["a"] : <!substrait.decimal<12, 2>>
+    yield %0 : !substrait.relation<!substrait.decimal<12, 2>>
   }
 }
 
@@ -55,8 +55,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.fixed_binary<4>>
-    yield %0 : tuple<!substrait.fixed_binary<4>>
+    %0 = named_table @t1 as ["a"] : <!substrait.fixed_binary<4>>
+    yield %0 : !substrait.relation<!substrait.fixed_binary<4>>
   }
 }
 
@@ -81,8 +81,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.var_char<6>>
-    yield %0 : tuple<!substrait.var_char<6>>
+    %0 = named_table @t1 as ["a"] : <!substrait.var_char<6>>
+    yield %0 : !substrait.relation<!substrait.var_char<6>>
   }
 }
 
@@ -107,8 +107,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.fixed_char<5>>
-    yield %0 : tuple<!substrait.fixed_char<5>>
+    %0 = named_table @t1 as ["a"] : <!substrait.fixed_char<5>>
+    yield %0 : !substrait.relation<!substrait.fixed_char<5>>
   }
 }
 
@@ -132,8 +132,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.uuid>
-    yield %0 : tuple<!substrait.uuid>
+    %0 = named_table @t1 as ["a"] : <!substrait.uuid>
+    yield %0 : !substrait.relation<!substrait.uuid>
   }
 }
 
@@ -163,8 +163,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
-    yield %0 : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+    %0 = named_table @t1 as ["a", "b"] : <!substrait.interval_year_month, !substrait.interval_day_second>
+    yield %0 : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -188,8 +188,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.time>
-    yield %0 : tuple<!substrait.time>
+    %0 = named_table @t1 as ["a"] : <!substrait.time>
+    yield %0 : !substrait.relation<!substrait.time>
   }
 }
 
@@ -213,8 +213,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.date>
-    yield %0 : tuple<!substrait.date>
+    %0 = named_table @t1 as ["a"] : <!substrait.date>
+    yield %0 : !substrait.relation<!substrait.date>
   }
 }
 
@@ -244,8 +244,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+    %0 = named_table @t1 as ["a", "b"] : <!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -269,8 +269,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.binary>
-    yield %0 : tuple<!substrait.binary>
+    %0 = named_table @t1 as ["a"] : <!substrait.binary>
+    yield %0 : !substrait.relation<!substrait.binary>
   }
 }
 
@@ -294,8 +294,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.string>
-    yield %0 : tuple<!substrait.string>
+    %0 = named_table @t1 as ["a"] : <!substrait.string>
+    yield %0 : !substrait.relation<!substrait.string>
   }
 }
 
@@ -325,8 +325,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<f32, f64>
-    yield %0 : tuple<f32, f64>
+    %0 = named_table @t1 as ["a", "b"] : <f32, f64>
+    yield %0 : !substrait.relation<f32, f64>
   }
 }
 
@@ -361,8 +361,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<f32, tuple<f32>>
-    yield %0 : tuple<f32, tuple<f32>>
+    %0 = named_table @t1 as ["a", "b", "c"] : <f32, tuple<f32>>
+    yield %0 : !substrait.relation<f32, tuple<f32>>
   }
 }
 
@@ -410,8 +410,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : tuple<si1, si8, si16, si32, si64>
-    yield %0 : tuple<si1, si8, si16, si32, si64>
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si8, si16, si32, si64>
+    yield %0 : !substrait.relation<si1, si8, si16, si32, si64>
   }
 }
 
@@ -446,7 +446,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
-    yield %0 : tuple<si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : <si1, tuple<si1>>
+    yield %0 : !substrait.relation<si1, tuple<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -30,7 +30,7 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
-    yield %0 : !substrait.relation<!substrait.decimal<12, 2>>
+    yield %0 : rel<!substrait.decimal<12, 2>>
   }
 }
 
@@ -56,7 +56,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
-    yield %0 : !substrait.relation<!substrait.fixed_binary<4>>
+    yield %0 : rel<!substrait.fixed_binary<4>>
   }
 }
 
@@ -82,7 +82,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
-    yield %0 : !substrait.relation<!substrait.var_char<6>>
+    yield %0 : rel<!substrait.var_char<6>>
   }
 }
 
@@ -108,7 +108,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
-    yield %0 : !substrait.relation<!substrait.fixed_char<5>>
+    yield %0 : rel<!substrait.fixed_char<5>>
   }
 }
 
@@ -133,7 +133,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.uuid>
-    yield %0 : !substrait.relation<!substrait.uuid>
+    yield %0 : rel<!substrait.uuid>
   }
 }
 
@@ -164,7 +164,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
-    yield %0 : !substrait.relation<!substrait.interval_year_month, !substrait.interval_day_second>
+    yield %0 : rel<!substrait.interval_year_month, !substrait.interval_day_second>
   }
 }
 
@@ -189,7 +189,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.time>
-    yield %0 : !substrait.relation<!substrait.time>
+    yield %0 : rel<!substrait.time>
   }
 }
 
@@ -214,7 +214,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.date>
-    yield %0 : !substrait.relation<!substrait.date>
+    yield %0 : rel<!substrait.date>
   }
 }
 
@@ -245,7 +245,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : !substrait.relation<!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : rel<!substrait.timestamp, !substrait.timestamp_tz>
   }
 }
 
@@ -270,7 +270,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
-    yield %0 : !substrait.relation<!substrait.binary>
+    yield %0 : rel<!substrait.binary>
   }
 }
 
@@ -295,7 +295,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<!substrait.string>
-    yield %0 : !substrait.relation<!substrait.string>
+    yield %0 : rel<!substrait.string>
   }
 }
 
@@ -326,7 +326,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<f32, f64>
-    yield %0 : !substrait.relation<f32, f64>
+    yield %0 : rel<f32, f64>
   }
 }
 
@@ -362,7 +362,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
-    yield %0 : !substrait.relation<f32, tuple<f32>>
+    yield %0 : rel<f32, tuple<f32>>
   }
 }
 
@@ -411,7 +411,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si8, si16, si32, si64>
-    yield %0 : !substrait.relation<si1, si8, si16, si32, si64>
+    yield %0 : rel<si1, si8, si16, si32, si64>
   }
 }
 
@@ -447,6 +447,6 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    yield %0 : !substrait.relation<si1, tuple<si1>>
+    yield %0 : rel<si1, tuple<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Import/aggregate.textpb
+++ b/test/Target/SubstraitPB/Import/aggregate.textpb
@@ -29,7 +29,7 @@
 # CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%[[V4]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V5]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si1, si1, si32, si32>
+# CHECK-NEXT:      yield %[[V1]] : rel<si1, si1, si32, si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -138,7 +138,7 @@ version {
 # CHECK-DAG:           %[[V2:.*]] = literal 0 : si1
 # CHECK-NEXT:          yield %[[V2]] : si1
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si1>
+# CHECK-NEXT:      yield %[[V1]] : rel<si1>
 
 relations {
   rel {
@@ -198,7 +198,7 @@ version {
 # CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V3]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+# CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -285,7 +285,7 @@ version {
 # CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V3]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+# CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"

--- a/test/Target/SubstraitPB/Import/aggregate.textpb
+++ b/test/Target/SubstraitPB/Import/aggregate.textpb
@@ -15,7 +15,7 @@
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si1, si1, si32, si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si1, si1, si32, si32>
 # CHECK-NEXT:        groupings {
 # CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = literal -1 : si1
@@ -132,7 +132,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si1>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si1>
 # CHECK-NEXT:        groupings {
 # CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = literal 0 : si1
@@ -191,7 +191,7 @@ version {
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si32>
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
@@ -277,7 +277,7 @@ version {
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si32>
 # CHECK-NEXT:        grouping_sets []
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
@@ -362,7 +362,7 @@ version {
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> ->
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> ->
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = call @[[F1]](%{{.*}}) aggregate initial_to_intermediate : (si32) -> si32
@@ -589,7 +589,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:           aggregate %{{.*}} advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : <si32> -> <si1>
+# CHECK-SAME:        : rel<si32> -> rel<si1>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/aggregate.textpb
+++ b/test/Target/SubstraitPB/Import/aggregate.textpb
@@ -15,7 +15,7 @@
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1, si1, si32, si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si1, si1, si32, si32>
 # CHECK-NEXT:        groupings {
 # CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = literal -1 : si1
@@ -29,7 +29,7 @@
 # CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%[[V4]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V5]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si1, si1, si32, si32>
+# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si1, si1, si32, si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -132,13 +132,13 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si1>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si1>
 # CHECK-NEXT:        groupings {
 # CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = literal 0 : si1
 # CHECK-NEXT:          yield %[[V2]] : si1
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si1>
+# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si1>
 
 relations {
   rel {
@@ -191,14 +191,14 @@ version {
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si32>
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
 # CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V3]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -277,7 +277,7 @@ version {
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> -> tuple<si32>
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> -> <si32>
 # CHECK-NEXT:        grouping_sets []
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
@@ -285,7 +285,7 @@ version {
 # CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V3]] : si32
 # CHECK-NEXT:        }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 extension_uris {
   uri: "http://some.url/with/extensions.yml"
@@ -362,7 +362,7 @@ version {
 # CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : tuple<si32> ->
+# CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : <si32> ->
 # CHECK-NEXT:        measures {
 # CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
 # CHECK-DAG:           %[[V2:.*]] = call @[[F1]](%{{.*}}) aggregate initial_to_intermediate : (si32) -> si32
@@ -589,7 +589,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:           aggregate %{{.*}} advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : tuple
+# CHECK-SAME:        : <si32> -> <si1>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/cross.textpb
+++ b/test/Target/SubstraitPB/Import/cross.textpb
@@ -15,7 +15,7 @@
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : rel<si32> x rel<si32>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/cross.textpb
+++ b/test/Target/SubstraitPB/Import/cross.textpb
@@ -14,9 +14,8 @@
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]]
-# CHECK-SAME:        : tuple<si32> x tuple<si32>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+# CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : <si32> x <si32>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
   rel {
@@ -84,7 +83,7 @@ version {
 # CHECK:           cross %{{.*}} x %{{[^ ]*}}
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : tuple<si32> x tuple<si1>
+# CHECK-SAME:        : <si32> x <si1>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/cross.textpb
+++ b/test/Target/SubstraitPB/Import/cross.textpb
@@ -14,7 +14,7 @@
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : <si32> x <si32>
+# CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] : rel<si32> x rel<si32>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
@@ -83,7 +83,7 @@ version {
 # CHECK:           cross %{{.*}} x %{{[^ ]*}}
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : <si32> x <si1>
+# CHECK-SAME:        : rel<si32> x rel<si1>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/extension-table.textpb
+++ b/test/Target/SubstraitPB/Import/extension-table.textpb
@@ -14,8 +14,8 @@
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = extension_table
 # CHECK-SAME:          "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        as ["a"] : tuple<si32>
-# CHECK-NEXT:      yield %[[V0]] : tuple<si32>
+# CHECK-SAME:        as ["a"] : <si32>
+# CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -56,7 +56,7 @@ version {
 # CHECK-SAME:        "some detail" : !substrait.any<"some url"> as ["a"]
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : tuple<si32>
+# CHECK-SAME:        : <si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/extension-table.textpb
+++ b/test/Target/SubstraitPB/Import/extension-table.textpb
@@ -14,7 +14,7 @@
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = extension_table
 # CHECK-SAME:          "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        as ["a"] : <si32>
+# CHECK-SAME:        as ["a"] : rel<si32>
 # CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32>
 
 relations {
@@ -56,7 +56,7 @@ version {
 # CHECK-SAME:        "some detail" : !substrait.any<"some url"> as ["a"]
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : <si32>
+# CHECK-SAME:        : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/extension-table.textpb
+++ b/test/Target/SubstraitPB/Import/extension-table.textpb
@@ -15,7 +15,7 @@
 # CHECK-NEXT:      %[[V0:.*]] = extension_table
 # CHECK-SAME:          "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 # CHECK-SAME:        as ["a"] : rel<si32>
-# CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32>
+# CHECK-NEXT:      yield %[[V0]] : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/fetch.textpb
+++ b/test/Target/SubstraitPB/Import/fetch.textpb
@@ -14,7 +14,7 @@
 # CHECK:         relation
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : rel<si32>
-# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+# CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/fetch.textpb
+++ b/test/Target/SubstraitPB/Import/fetch.textpb
@@ -13,9 +13,8 @@
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:           %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]]
-# CHECK-SAME:        : tuple<si32>
-# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+# CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : <si32>
+# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -61,7 +60,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:           fetch 3 from %{{.*}} advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : tuple<si32>
+# CHECK-SAME:        : <si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/fetch.textpb
+++ b/test/Target/SubstraitPB/Import/fetch.textpb
@@ -13,7 +13,7 @@
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:           %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : <si32>
+# CHECK-NEXT:      %[[V1:.*]] = fetch 5 offset 3 from %[[V0]] : rel<si32>
 # CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 relations {
@@ -60,7 +60,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:           fetch 3 from %{{.*}} advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : <si32>
+# CHECK-SAME:        : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/filter.textpb
+++ b/test/Target/SubstraitPB/Import/filter.textpb
@@ -18,7 +18,7 @@
 # CHECK-NEXT:        %[[V2:.*]] = literal -1 : si1
 # CHECK-NEXT:        yield %[[V2]] : si1
 # CHECK-NEXT:      }
-# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+# CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/filter.textpb
+++ b/test/Target/SubstraitPB/Import/filter.textpb
@@ -13,12 +13,12 @@
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = filter %[[V0]] : tuple<si32>
+# CHECK-NEXT:      %[[V1:.*]] = filter %[[V0]] : <si32>
 # CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: tuple<si32>):
 # CHECK-NEXT:        %[[V2:.*]] = literal -1 : si1
 # CHECK-NEXT:        yield %[[V2]] : si1
 # CHECK-NEXT:      }
-# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -67,7 +67,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         filter {{.*}} advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : tuple<si32> {
+# CHECK-SAME:        : <si32> {
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/filter.textpb
+++ b/test/Target/SubstraitPB/Import/filter.textpb
@@ -13,7 +13,7 @@
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
-# CHECK-NEXT:      %[[V1:.*]] = filter %[[V0]] : <si32>
+# CHECK-NEXT:      %[[V1:.*]] = filter %[[V0]] : rel<si32>
 # CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: tuple<si32>):
 # CHECK-NEXT:        %[[V2:.*]] = literal -1 : si1
 # CHECK-NEXT:        yield %[[V2]] : si1
@@ -67,7 +67,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         filter {{.*}} advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : <si32> {
+# CHECK-SAME:        : rel<si32> {
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/join.textpb
+++ b/test/Target/SubstraitPB/Import/join.textpb
@@ -16,7 +16,7 @@
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join unspecified %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 relations {
   rel {
@@ -85,7 +85,7 @@ version {
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join inner %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 relations {
   rel {
@@ -155,7 +155,7 @@ version {
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join outer %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 relations {
   rel {
@@ -225,7 +225,7 @@ version {
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join left %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 relations {
   rel {
@@ -295,7 +295,7 @@ version {
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join right %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : rel<si32, si32>
 
 relations {
   rel {
@@ -365,7 +365,7 @@ version {
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join semi %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si1>, rel<si32> -> rel<si1>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
+# CHECK-NEXT:      yield %[[V2]] : rel<si1>
 
 relations {
   rel {
@@ -435,7 +435,7 @@ version {
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join anti %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si1>, rel<si32> -> rel<si1>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
+# CHECK-NEXT:      yield %[[V2]] : rel<si1>
 
 relations {
   rel {
@@ -505,7 +505,7 @@ version {
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join single %[[V0]], %[[V1]] :
 # CHECK-SAME:                     rel<si32>, rel<si1> -> rel<si1>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
+# CHECK-NEXT:      yield %[[V2]] : rel<si1>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/join.textpb
+++ b/test/Target/SubstraitPB/Import/join.textpb
@@ -14,8 +14,9 @@
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join unspecified %[[V0]], %[[V1]] : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+# CHECK-NEXT:      %[[V2:.*]] = join unspecified %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
   rel {
@@ -82,8 +83,9 @@ version {
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join inner %[[V0]], %[[V1]] : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+# CHECK-NEXT:      %[[V2:.*]] = join inner %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
   rel {
@@ -151,8 +153,9 @@ version {
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join outer %[[V0]], %[[V1]] : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+# CHECK-NEXT:      %[[V2:.*]] = join outer %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
   rel {
@@ -220,8 +223,9 @@ version {
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join left %[[V0]], %[[V1]] : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+# CHECK-NEXT:      %[[V2:.*]] = join left %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
   rel {
@@ -289,8 +293,9 @@ version {
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join right %[[V0]], %[[V1]] : tuple<si32>, tuple<si32> -> tuple<si32, si32>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si32, si32>
+# CHECK-NEXT:      %[[V2:.*]] = join right %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
   rel {
@@ -358,8 +363,9 @@ version {
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join semi %[[V0]], %[[V1]] : tuple<si1>, tuple<si32> -> tuple<si1>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si1>
+# CHECK-NEXT:      %[[V2:.*]] = join semi %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si1>, <si32> -> <si1>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 relations {
   rel {
@@ -427,8 +433,9 @@ version {
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join anti %[[V0]], %[[V1]] : tuple<si1>, tuple<si32> -> tuple<si1>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si1>
+# CHECK-NEXT:      %[[V2:.*]] = join anti %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si1>, <si32> -> <si1>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 relations {
   rel {
@@ -496,8 +503,9 @@ version {
 # CHECK:         relation {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
-# CHECK-NEXT:      %[[V2:.*]] = join single %[[V0]], %[[V1]] : tuple<si32>, tuple<si1> -> tuple<si1>
-# CHECK-NEXT:      yield %[[V2]] : tuple<si1>
+# CHECK-NEXT:      %[[V2:.*]] = join single %[[V0]], %[[V1]] :
+# CHECK-SAME:                     <si32>, <si1> -> <si1>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 relations {
   rel {
@@ -565,7 +573,7 @@ version {
 # CHECK:           join inner %{{.*}}, %{{[^ ]*}}
 # CHECK-SAME:          advanced_extension optimization = "\08*"
 # CHECK-SAME:            : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:          : tuple<si32>, tuple<si32> -> tuple<si32, si32>
+# CHECK-SAME:          : <si32>, <si32> -> <si32, si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/join.textpb
+++ b/test/Target/SubstraitPB/Import/join.textpb
@@ -15,7 +15,7 @@
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join unspecified %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
@@ -84,7 +84,7 @@ version {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join inner %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
@@ -154,7 +154,7 @@ version {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join outer %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
@@ -224,7 +224,7 @@ version {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join left %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
@@ -294,7 +294,7 @@ version {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join right %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si32>, <si32> -> <si32, si32>
+# CHECK-SAME:                     rel<si32>, rel<si32> -> rel<si32, si32>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si32, si32>
 
 relations {
@@ -364,7 +364,7 @@ version {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join semi %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si1>, <si32> -> <si1>
+# CHECK-SAME:                     rel<si1>, rel<si32> -> rel<si1>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 relations {
@@ -434,7 +434,7 @@ version {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join anti %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si1>, <si32> -> <si1>
+# CHECK-SAME:                     rel<si1>, rel<si32> -> rel<si1>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 relations {
@@ -504,7 +504,7 @@ version {
 # CHECK:           %[[V0:.*]] = named_table
 # CHECK:           %[[V1:.*]] = named_table
 # CHECK-NEXT:      %[[V2:.*]] = join single %[[V0]], %[[V1]] :
-# CHECK-SAME:                     <si32>, <si1> -> <si1>
+# CHECK-SAME:                     rel<si32>, rel<si1> -> rel<si1>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.relation<si1>
 
 relations {
@@ -573,7 +573,7 @@ version {
 # CHECK:           join inner %{{.*}}, %{{[^ ]*}}
 # CHECK-SAME:          advanced_extension optimization = "\08*"
 # CHECK-SAME:            : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:          : <si32>, <si32> -> <si32, si32>
+# CHECK-SAME:          : rel<si32>, rel<si32> -> rel<si32, si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -18,7 +18,7 @@
 # CHECK-NEXT:               %[[VAL_3:.*]] = literal #substrait.decimal<"0.05", P = 3, S = 2>
 # CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<3, 2>
 # CHECK-NEXT:             }
-# CHECK-NEXT:             yield %[[VAL_1]] : !substrait.relation<f32, !substrait.decimal<3, 2>>
+# CHECK-NEXT:             yield %[[VAL_1]] : rel<f32, !substrait.decimal<3, 2>>
 
 relations {
   rel {
@@ -76,7 +76,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_binary<10>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_binary<10>
 
 relations {
   rel {
@@ -130,7 +130,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<5>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.var_char<5>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.var_char<5>
 
 relations {
   rel {
@@ -186,7 +186,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_char<5>>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_char<5>>
 
 relations {
   rel {
@@ -240,7 +240,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.uuid>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.uuid>
 
 relations {
   rel {
@@ -295,7 +295,7 @@ version {
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
 
 relations {
   rel {
@@ -360,7 +360,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.time
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.time>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.time>
 
 relations {
   rel {
@@ -414,7 +414,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.date
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.date>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.date>
 
 relations {
   rel {
@@ -469,7 +469,7 @@ version {
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
 
 relations {
   rel {
@@ -528,7 +528,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 # CHECK-NEXT:      yield %[[V2]] : !substrait.binary
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.binary>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.binary>
 
 relations {
   rel {
@@ -582,7 +582,7 @@ version {
 # CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 # CHECK-NEXT:      yield %[[V2]] : !substrait.string
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.string>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.string>
 
 relations {
   rel {
@@ -637,7 +637,7 @@ version {
 # CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : f32, f64
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<f32, f32, f64>
+# CHECK-NEXT:    yield %[[V1]] : rel<f32, f32, f64>
 
 relations {
   rel {
@@ -700,7 +700,7 @@ version {
 # CHECK-NEXT:      %[[V6:.*]] = literal 42 : si64
 # CHECK-NEXT:      yield %[[V2]], %[[V3]], %[[V4]], %[[V5]], %[[V6]] : si1, si8, si16, si32, si64
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, si1, si8, si16, si32, si64>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, si1, si8, si16, si32, si64>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -12,13 +12,13 @@
 
 # CHECK:   substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:           relation {
-# CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : tuple<f32>
-# CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : tuple<f32> -> tuple<f32, !substrait.decimal<3, 2>> {
+# CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : <f32>
+# CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : <f32> -> <f32, !substrait.decimal<3, 2>> {
 # CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<f32>):
 # CHECK-NEXT:               %[[VAL_3:.*]] = literal #substrait.decimal<"0.05", P = 3, S = 2>
 # CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<3, 2>
 # CHECK-NEXT:             }
-# CHECK-NEXT:             yield %[[VAL_1]] : tuple<f32, !substrait.decimal<3, 2>>
+# CHECK-NEXT:             yield %[[VAL_1]] : !substrait.relation<f32, !substrait.decimal<3, 2>>
 
 relations {
   rel {
@@ -71,12 +71,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_binary<10>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_binary<10>
 
 relations {
   rel {
@@ -125,12 +125,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<5>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.var_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<5>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<5>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.var_char<5>
 
 relations {
   rel {
@@ -181,12 +181,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_char<5>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_char<5>>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.fixed_char<5>>
 
 relations {
   rel {
@@ -235,12 +235,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.uuid> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.uuid> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.uuid>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.uuid>
 
 relations {
   rel {
@@ -289,13 +289,13 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.interval_year_month, !substrait.interval_day_second>
 
 relations {
   rel {
@@ -355,12 +355,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.time> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.time> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.time
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.time>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.time>
 
 relations {
   rel {
@@ -409,12 +409,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.date> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.date> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.date
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.date>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.date>
 
 relations {
   rel {
@@ -463,13 +463,13 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.timestamp, !substrait.timestamp_tz>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.timestamp, !substrait.timestamp_tz>
 
 relations {
   rel {
@@ -523,12 +523,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.binary> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.binary> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 # CHECK-NEXT:      yield %[[V2]] : !substrait.binary
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.binary>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.binary>
 
 relations {
   rel {
@@ -577,12 +577,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.string> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.string> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 # CHECK-NEXT:      yield %[[V2]] : !substrait.string
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.string>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, !substrait.string>
 
 relations {
   rel {
@@ -631,13 +631,13 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<f32> -> tuple<f32, f32, f64> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <f32> -> <f32, f32, f64> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<f32>):
 # CHECK-NEXT:      %[[V2:.*]] = literal 3.535000e+01 : f32
 # CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : f32, f64
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<f32, f32, f64>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<f32, f32, f64>
 
 relations {
   rel {
@@ -691,7 +691,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, si1, si8, si16, si32, si64> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, si1, si8, si16, si32, si64> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal 0 : si1
 # CHECK-NEXT:      %[[V3:.*]] = literal 2 : si8
@@ -700,7 +700,7 @@ version {
 # CHECK-NEXT:      %[[V6:.*]] = literal 42 : si64
 # CHECK-NEXT:      yield %[[V2]], %[[V3]], %[[V4]], %[[V5]], %[[V6]] : si1, si8, si16, si32, si64
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, si1, si8, si16, si32, si64>
+# CHECK-NEXT:    yield %[[V1]] : !substrait.relation<si1, si1, si8, si16, si32, si64>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -12,8 +12,8 @@
 
 # CHECK:   substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:           relation {
-# CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : <f32>
-# CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : <f32> -> <f32, !substrait.decimal<3, 2>> {
+# CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : rel<f32>
+# CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : rel<f32> -> rel<f32, !substrait.decimal<3, 2>> {
 # CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<f32>):
 # CHECK-NEXT:               %[[VAL_3:.*]] = literal #substrait.decimal<"0.05", P = 3, S = 2>
 # CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<3, 2>
@@ -71,7 +71,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_binary<10>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
@@ -125,7 +125,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.var_char<5>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.var_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<5>
@@ -181,7 +181,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.fixed_char<5>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
@@ -235,7 +235,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.uuid> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.uuid> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
@@ -289,7 +289,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>
@@ -355,7 +355,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.time> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.time> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.time
@@ -409,7 +409,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.date> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.date> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.date
@@ -463,7 +463,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.timestamp, !substrait.timestamp_tz> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>
@@ -523,7 +523,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.binary> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.binary> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 # CHECK-NEXT:      yield %[[V2]] : !substrait.binary
@@ -577,7 +577,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, !substrait.string> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.string> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 # CHECK-NEXT:      yield %[[V2]] : !substrait.string
@@ -631,7 +631,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <f32> -> <f32, f32, f64> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<f32> -> rel<f32, f32, f64> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<f32>):
 # CHECK-NEXT:      %[[V2:.*]] = literal 3.535000e+01 : f32
 # CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
@@ -691,7 +691,7 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si1> -> <si1, si1, si8, si16, si32, si64> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal 0 : si1
 # CHECK-NEXT:      %[[V3:.*]] = literal 2 : si8

--- a/test/Target/SubstraitPB/Import/named-table.textpb
+++ b/test/Target/SubstraitPB/Import/named-table.textpb
@@ -12,7 +12,7 @@
 
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
-# CHECK:         %[[V0:.*]] = named_table @t1 as [] : tuple<>
+# CHECK:         %[[V0:.*]] = named_table @t1 as [] : <>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -42,7 +42,7 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
-# CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<si32>
+# CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <si32>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -78,7 +78,7 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
-# CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : tuple<si32, si32>
+# CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <si32, si32>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -121,7 +121,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:         %[[V0:.*]] = named_table @t1
-# CHECK-SAME:      as ["outer", "inner"] : tuple<tuple<si32>>
+# CHECK-SAME:      as ["outer", "inner"] : <tuple<si32>>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -163,7 +163,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:         %[[V0:.*]] = named_table @t1
-# CHECK-SAME:      as ["a", "a"] : tuple<tuple<si32>>
+# CHECK-SAME:      as ["a", "a"] : <tuple<si32>>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -206,7 +206,7 @@ version {
 # CHECK:         named_table @t1 as ["a"]
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : tuple<si32>
+# CHECK-SAME:        : <si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/named-table.textpb
+++ b/test/Target/SubstraitPB/Import/named-table.textpb
@@ -12,7 +12,7 @@
 
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
-# CHECK:         %[[V0:.*]] = named_table @t1 as [] : <>
+# CHECK:         %[[V0:.*]] = named_table @t1 as [] : rel<>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -42,7 +42,7 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
-# CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : <si32>
+# CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<si32>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -78,7 +78,7 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
-# CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : <si32, si32>
+# CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<si32, si32>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -121,7 +121,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:         %[[V0:.*]] = named_table @t1
-# CHECK-SAME:      as ["outer", "inner"] : <tuple<si32>>
+# CHECK-SAME:      as ["outer", "inner"] : rel<tuple<si32>>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -163,7 +163,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:         %[[V0:.*]] = named_table @t1
-# CHECK-SAME:      as ["a", "a"] : <tuple<si32>>
+# CHECK-SAME:      as ["a", "a"] : rel<tuple<si32>>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -206,7 +206,7 @@ version {
 # CHECK:         named_table @t1 as ["a"]
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : <si32>
+# CHECK-SAME:        : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -25,12 +25,12 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation as ["x", "y", "z"] {
-# CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : tuple<si32, tuple<si32>>
-# CHECK-NEXT:      yield %[[V0]] : tuple<si32, tuple<si32>>
+# CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : <si32, tuple<si32>>
+# CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32, tuple<si32>>
 # CHECK-NEXT:    }
 # CHECK-NEXT:    relation {
-# CHECK-NEXT:      %[[V1:.*]] = named_table @t as ["a"] : tuple<si32>
-# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+# CHECK-NEXT:      %[[V1:.*]] = named_table @t as ["a"] : <si32>
+# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 relations {
   root {

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -25,11 +25,11 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation as ["x", "y", "z"] {
-# CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : <si32, tuple<si32>>
+# CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
 # CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32, tuple<si32>>
 # CHECK-NEXT:    }
 # CHECK-NEXT:    relation {
-# CHECK-NEXT:      %[[V1:.*]] = named_table @t as ["a"] : <si32>
+# CHECK-NEXT:      %[[V1:.*]] = named_table @t as ["a"] : rel<si32>
 # CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
 
 relations {

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -26,11 +26,11 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation as ["x", "y", "z"] {
 # CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
-# CHECK-NEXT:      yield %[[V0]] : !substrait.relation<si32, tuple<si32>>
+# CHECK-NEXT:      yield %[[V0]] : rel<si32, tuple<si32>>
 # CHECK-NEXT:    }
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V1:.*]] = named_table @t as ["a"] : rel<si32>
-# CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32>
+# CHECK-NEXT:      yield %[[V1]] : rel<si32>
 
 relations {
   root {

--- a/test/Target/SubstraitPB/Import/project.textpb
+++ b/test/Target/SubstraitPB/Import/project.textpb
@@ -13,7 +13,7 @@
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si32> -> <si32, si1, si32> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si32> -> rel<si32, si1, si32> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 # CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 # CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32

--- a/test/Target/SubstraitPB/Import/project.textpb
+++ b/test/Target/SubstraitPB/Import/project.textpb
@@ -13,7 +13,7 @@
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32, si1, si32> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : <si32> -> <si32, si1, si32> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
 # CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 # CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32

--- a/test/Target/SubstraitPB/Import/set.textpb
+++ b/test/Target/SubstraitPB/Import/set.textpb
@@ -14,7 +14,7 @@
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set unspecified %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       %[[V2:.*]] = set unspecified %[[V0]], %[[V1]] : rel<si32>
 # CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
@@ -82,7 +82,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]] : rel<si32>
 # CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
@@ -151,7 +151,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]] : rel<si32>
 # CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
@@ -220,7 +220,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]] : rel<si32>
 # CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
@@ -289,7 +289,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]] : rel<si32>
 # CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
@@ -358,7 +358,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]] : rel<si32>
 # CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
@@ -427,7 +427,7 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set union_all %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       %[[V2:.*]] = set union_all %[[V0]], %[[V1]] : rel<si32>
 # CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
@@ -496,7 +496,7 @@ version {
 # CHECK:           set union_all %{{.*}}, %{{[^ ]*}}
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : <si32>
+# CHECK-SAME:        : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/set.textpb
+++ b/test/Target/SubstraitPB/Import/set.textpb
@@ -14,8 +14,8 @@
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set unspecified %[[V0]], %[[V1]] : tuple<si32>
-# CHECK-NEXT:       yield %[[V2]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set unspecified %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -82,8 +82,8 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]] : tuple<si32>
-# CHECK-NEXT:       yield %[[V2]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -151,8 +151,8 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]] : tuple<si32>
-# CHECK-NEXT:       yield %[[V2]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -220,8 +220,8 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]] : tuple<si32>
-# CHECK-NEXT:       yield %[[V2]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -289,8 +289,8 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]] : tuple<si32>
-# CHECK-NEXT:       yield %[[V2]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -358,8 +358,8 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]] : tuple<si32>
-# CHECK-NEXT:       yield %[[V2]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -427,8 +427,8 @@ version {
 # CHECK-NEXT:     relation {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
-# CHECK-NEXT:       %[[V2:.*]] = set union_all %[[V0]], %[[V1]] : tuple<si32>
-# CHECK-NEXT:       yield %[[V2]] : tuple<si32>
+# CHECK-NEXT:       %[[V2:.*]] = set union_all %[[V0]], %[[V1]] : <si32>
+# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
 
 relations {
   rel {
@@ -496,7 +496,7 @@ version {
 # CHECK:           set union_all %{{.*}}, %{{[^ ]*}}
 # CHECK-SAME:        advanced_extension optimization = "\08*"
 # CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-# CHECK-SAME:        : tuple<si32>
+# CHECK-SAME:        : <si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/set.textpb
+++ b/test/Target/SubstraitPB/Import/set.textpb
@@ -15,7 +15,7 @@
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
 # CHECK-NEXT:       %[[V2:.*]] = set unspecified %[[V0]], %[[V1]] : rel<si32>
-# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
+# CHECK-NEXT:       yield %[[V2]] : rel<si32>
 
 relations {
   rel {
@@ -83,7 +83,7 @@ version {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
 # CHECK-NEXT:       %[[V2:.*]] = set minus_primary %[[V0]], %[[V1]] : rel<si32>
-# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
+# CHECK-NEXT:       yield %[[V2]] : rel<si32>
 
 relations {
   rel {
@@ -152,7 +152,7 @@ version {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
 # CHECK-NEXT:       %[[V2:.*]] = set minus_multiset %[[V0]], %[[V1]] : rel<si32>
-# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
+# CHECK-NEXT:       yield %[[V2]] : rel<si32>
 
 relations {
   rel {
@@ -221,7 +221,7 @@ version {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
 # CHECK-NEXT:       %[[V2:.*]] = set intersection_primary %[[V0]], %[[V1]] : rel<si32>
-# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
+# CHECK-NEXT:       yield %[[V2]] : rel<si32>
 
 relations {
   rel {
@@ -290,7 +290,7 @@ version {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
 # CHECK-NEXT:       %[[V2:.*]] = set intersection_multiset %[[V0]], %[[V1]] : rel<si32>
-# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
+# CHECK-NEXT:       yield %[[V2]] : rel<si32>
 
 relations {
   rel {
@@ -359,7 +359,7 @@ version {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
 # CHECK-NEXT:       %[[V2:.*]] = set union_distinct %[[V0]], %[[V1]] : rel<si32>
-# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
+# CHECK-NEXT:       yield %[[V2]] : rel<si32>
 
 relations {
   rel {
@@ -428,7 +428,7 @@ version {
 # CHECK-NEXT:       %[[V0:.*]] = named_table
 # CHECK-NEXT:       %[[V1:.*]] = named_table
 # CHECK-NEXT:       %[[V2:.*]] = set union_all %[[V0]], %[[V1]] : rel<si32>
-# CHECK-NEXT:       yield %[[V2]] : !substrait.relation<si32>
+# CHECK-NEXT:       yield %[[V2]] : rel<si32>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,7 +13,7 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.decimal<12, 3>>
+# CHECK-SAME:       : <!substrait.decimal<12, 3>>
 
 relations {
   rel {
@@ -51,7 +51,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.fixed_binary<5>>
+# CHECK-SAME:       : <!substrait.fixed_binary<5>>
 
 relations {
   rel {
@@ -88,7 +88,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.var_char<6>>
+# CHECK-SAME:       : <!substrait.var_char<6>>
 
 relations {
   rel {
@@ -125,7 +125,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.fixed_char<5>>
+# CHECK-SAME:       : <!substrait.fixed_char<5>>
 
 relations {
   rel {
@@ -170,7 +170,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.uuid>
+# CHECK-SAME:       : <!substrait.uuid>
 
 relations {
   rel {
@@ -206,7 +206,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.interval_year_month, !substrait.interval_day_second>
+# CHECK-SAME:       : <!substrait.interval_year_month, !substrait.interval_day_second>
 
 relations {
   rel {
@@ -248,7 +248,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.time>
+# CHECK-SAME:       : <!substrait.time>
 
 relations {
   rel {
@@ -283,8 +283,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.date>
+# CHECK-NEXT:     named_table {{.*}} : <!substrait.date>
 
 relations {
   rel {
@@ -320,7 +319,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.timestamp, !substrait.timestamp_tz>
+# CHECK-SAME:       : <!substrait.timestamp, !substrait.timestamp_tz>
 
 relations {
   rel {
@@ -361,8 +360,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.binary>
+# CHECK-NEXT:     named_table {{.*}} : <!substrait.binary>
 
 relations {
   rel {
@@ -397,8 +395,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<!substrait.string>
+# CHECK-NEXT:     named_table {{.*}} : <!substrait.string>
 
 relations {
   rel {
@@ -433,8 +430,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<f32, f64>
+# CHECK-NEXT:     named_table {{.*}} : <f32, f64>
 
 relations {
   rel {
@@ -475,8 +471,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<f32, tuple<f32>>
+# CHECK-NEXT:     named_table {{.*}} : <f32, tuple<f32>>
 
 relations {
   rel {
@@ -522,8 +517,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<si1, si8, si16, si32, si64>
+# CHECK-NEXT:     named_table {{.*}} : <si1, si8, si16, si32, si64>
 
 relations {
   rel {
@@ -582,8 +576,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table
-# CHECK-SAME:       : tuple<si1, tuple<si1>>
+# CHECK-NEXT:     named_table {{.*}} : <si1, tuple<si1>>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,7 +13,7 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.decimal<12, 3>>
+# CHECK-SAME:       : rel<!substrait.decimal<12, 3>>
 
 relations {
   rel {
@@ -51,7 +51,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.fixed_binary<5>>
+# CHECK-SAME:       : rel<!substrait.fixed_binary<5>>
 
 relations {
   rel {
@@ -88,7 +88,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.var_char<6>>
+# CHECK-SAME:       : rel<!substrait.var_char<6>>
 
 relations {
   rel {
@@ -125,7 +125,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.fixed_char<5>>
+# CHECK-SAME:       : rel<!substrait.fixed_char<5>>
 
 relations {
   rel {
@@ -170,7 +170,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.uuid>
+# CHECK-SAME:       : rel<!substrait.uuid>
 
 relations {
   rel {
@@ -206,7 +206,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.interval_year_month, !substrait.interval_day_second>
+# CHECK-SAME:       : rel<!substrait.interval_year_month, !substrait.interval_day_second>
 
 relations {
   rel {
@@ -248,7 +248,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.time>
+# CHECK-SAME:       : rel<!substrait.time>
 
 relations {
   rel {
@@ -283,7 +283,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : <!substrait.date>
+# CHECK-NEXT:     named_table {{.*}} : rel<!substrait.date>
 
 relations {
   rel {
@@ -319,7 +319,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : <!substrait.timestamp, !substrait.timestamp_tz>
+# CHECK-SAME:       : rel<!substrait.timestamp, !substrait.timestamp_tz>
 
 relations {
   rel {
@@ -360,7 +360,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : <!substrait.binary>
+# CHECK-NEXT:     named_table {{.*}} : rel<!substrait.binary>
 
 relations {
   rel {
@@ -395,7 +395,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : <!substrait.string>
+# CHECK-NEXT:     named_table {{.*}} : rel<!substrait.string>
 
 relations {
   rel {
@@ -430,7 +430,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : <f32, f64>
+# CHECK-NEXT:     named_table {{.*}} : rel<f32, f64>
 
 relations {
   rel {
@@ -471,7 +471,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : <f32, tuple<f32>>
+# CHECK-NEXT:     named_table {{.*}} : rel<f32, tuple<f32>>
 
 relations {
   rel {
@@ -517,7 +517,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : <si1, si8, si16, si32, si64>
+# CHECK-NEXT:     named_table {{.*}} : rel<si1, si8, si16, si32, si64>
 
 relations {
   rel {
@@ -576,7 +576,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : <si1, tuple<si1>>
+# CHECK-NEXT:     named_table {{.*}} : rel<si1, tuple<si1>>
 
 relations {
   rel {

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -10,14 +10,14 @@
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
 // CHECK-NEXT:      %[[V2:.*]] = cross %[[V1]] x %[[V0]] :
 // CHECK-NEXT:      %[[V3:.*]] = emit [0, 0, 1, 1, 0, 2, 3] from %[[V2]] :
-// CHECK-NEXT:      yield %[[V3]] : tuple<si32, si32, si1, si1, si32, si1, si32>
+// CHECK-NEXT:      yield %[[V3]] : !substrait.relation<si32, si32, si1, si1, si32, si1, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 1, 0, 0, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32, si1, si1, si32>
-    %2 = cross %1 x %0 : tuple<si32, si32, si1, si1, si32> x tuple<si1, si32>
-    yield %2 : tuple<si32, si32, si1, si1, si32, si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 1, 0, 0, 1] from %0 : <si1, si32> -> <si32, si32, si1, si1, si32>
+    %2 = cross %1 x %0 : <si32, si32, si1, si1, si32> x <si1, si32>
+    yield %2 : !substrait.relation<si32, si32, si1, si1, si32, si1, si32>
   }
 }
 
@@ -34,10 +34,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    %2 = cross %0 x %1 : tuple<si1, si32> x tuple<si32, si1>
-    yield %2 : tuple<si1,si32, si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %2 = cross %0 x %1 : <si1, si32> x <si32, si1>
+    yield %2 : !substrait.relation<si1,si32, si32, si1>
   }
 }
 
@@ -51,14 +51,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
 // CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] :
 // CHECK-NEXT:      %[[V3:.*]] = emit [0, 1, 2, 2, 3, 3, 2] from %[[V2]] :
-// CHECK-NEXT:      yield %[[V3]] : tuple<si1, si32, si32, si32, si1, si1, si32>
+// CHECK-NEXT:      yield %[[V3]] : !substrait.relation<si1, si32, si32, si32, si1, si1, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 1, 0, 0, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32, si1, si1, si32>
-    %2 = cross %0 x %1 : tuple<si1, si32> x tuple<si32, si32, si1, si1, si32>
-    yield %2 : tuple<si1, si32, si32, si32, si1, si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 1, 0, 0, 1] from %0 : <si1, si32> -> <si32, si32, si1, si1, si32>
+    %2 = cross %0 x %1 : <si1, si32> x <si32, si32, si1, si1, si32>
+    yield %2 : !substrait.relation<si1, si32, si32, si32, si1, si1, si32>
   }
 }
 
@@ -75,10 +75,10 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    %2 = cross %1 x %0 : tuple<si32, si1> x tuple<si1, si32>
-    yield %2 : tuple<si32, si1, si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %2 = cross %1 x %0 : <si32, si1> x <si1, si32>
+    yield %2 : !substrait.relation<si32, si1, si1, si32>
   }
 }
 
@@ -97,11 +97,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32>
-    %2 = emit [0, 0] from %0 : tuple<si1, si32> -> tuple<si1, si1>
-    %3 = cross %1 x %2 : tuple<si32, si32> x tuple<si1, si1>
-    yield %3 : tuple<si32, si32, si1, si1>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
+    %2 = emit [0, 0] from %0 : <si1, si32> -> <si1, si1>
+    %3 = cross %1 x %2 : <si32, si32> x <si1, si1>
+    yield %3 : !substrait.relation<si32, si32, si1, si1>
   }
 }
 
@@ -120,11 +120,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    %2 = emit [0, 0] from %0 : tuple<si1, si32> -> tuple<si1, si1>
-    %3 = cross %1 x %2 : tuple<si32, si1> x tuple<si1, si1>
-    yield %3 : tuple<si32, si1, si1, si1>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %2 = emit [0, 0] from %0 : <si1, si32> -> <si1, si1>
+    %3 = cross %1 x %2 : <si32, si1> x <si1, si1>
+    yield %3 : !substrait.relation<si32, si1, si1, si1>
   }
 }
 
@@ -143,11 +143,11 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32>
-    %2 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    %3 = cross %1 x %2 : tuple<si32, si32> x tuple<si32, si1>
-    yield %3 : tuple<si32, si32, si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
+    %2 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %3 = cross %1 x %2 : <si32, si32> x <si32, si1>
+    yield %3 : !substrait.relation<si32, si32, si32, si1>
   }
 }
 
@@ -173,13 +173,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : tuple<si1, si1, tuple<si1, si32>>
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si1, tuple<si1, si32>>
     // Fields in position 1 and 3 are duplicates of field in position 0, so we
     // expect all references to the former to be replaced by the latter and an
     // `emit` re-establishing the original fields after the `filter`.
     %1 = emit [1, 1, 2, 1, 0] from %0
-        : tuple<si1, si1, tuple<si1, si32>> -> tuple<si1, si1, tuple<si1, si32>, si1, si1>
-    %2 = filter %1 : tuple<si1, si1, tuple<si1, si32>, si1, si1> {
+        : <si1, si1, tuple<si1, si32>> -> <si1, si1, tuple<si1, si32>, si1, si1>
+    %2 = filter %1 : <si1, si1, tuple<si1, si32>, si1, si1> {
     ^bb0(%arg0: tuple<si1, si1, tuple<si1, si32>, si1, si1>):
       %3 = field_reference %arg0[0] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
       %4 = field_reference %arg0[1] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
@@ -191,7 +191,7 @@ substrait.plan version 0 : 42 : 1 {
       %a = "test.op"(%3, %4, %5, %7, %8, %9) : (si1, si1, si1, si32, si1, si1) -> si1
       yield %a : si1
     }
-    yield %2 : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+    yield %2 : !substrait.relation<si1, si1, tuple<si1, si32>, si1, si1>
   }
 }
 
@@ -203,7 +203,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]] :
-// CHECK-NEXT:      %[[V2:.*]] = project %[[V1]] : tuple<si32> -> tuple<si32, si1> {
+// CHECK-NEXT:      %[[V2:.*]] = project %[[V1]] : <si32> -> <si32, si1> {
 // CHECK-NEXT:      ^{{.*}}(%[[ARG0:.*]]: [[TYPE:.*]]):
 // CHECK-NEXT:        %[[V3:.*]] = field_reference %[[ARG0]][0] : [[TYPE]]
 // CHECK-NEXT:        %[[V5:.*]] = "test.op"(%[[V3]], %[[V3]]) :
@@ -213,16 +213,16 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32>
-    %2 = project %1 : tuple<si32, si32> -> tuple<si32, si32, si1> {
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
+    %2 = project %1 : <si32, si32> -> <si32, si32, si1> {
     ^bb0(%arg : tuple<si32, si32>):
       %3 = field_reference %arg[0] : tuple<si32, si32>
       %4 = field_reference %arg[1] : tuple<si32, si32>
       %5 = "test.op"(%3, %4) : (si32, si32) -> si1
       yield %5 : si1
     }
-    yield %2 : tuple<si32, si32, si1>
+    yield %2 : !substrait.relation<si32, si32, si1>
   }
 }
 
@@ -243,8 +243,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : tuple<si32>
-    %1 = project %0 : tuple<si32> -> tuple<si32, si1, si1> {
+    %0 = named_table @t1 as ["a"] : <si32>
+    %1 = project %0 : <si32> -> <si32, si1, si1> {
     ^bb0(%arg : tuple<si32>):
       %2 = field_reference %arg[0] : tuple<si32>
       %3 = "test.op"(%2) : (si32) -> si1
@@ -253,7 +253,7 @@ substrait.plan version 0 : 42 : 1 {
       // `project`.
       yield %3, %3 : si1, si1
     }
-    yield %1 : tuple<si32, si1, si1>
+    yield %1 : !substrait.relation<si32, si1, si1>
   }
 }
 
@@ -274,8 +274,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si1>
-    %1 = project %0 : tuple<si32, si1> -> tuple<si32, si1, si32, si1> {
+    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
+    %1 = project %0 : <si32, si1> -> <si32, si1, si32, si1> {
     ^bb0(%arg0: tuple<si32, si1>):
       %2 = field_reference %arg0[0] : tuple<si32, si1>
       %3 = "test.op"(%2) : (si32) -> si1
@@ -284,7 +284,7 @@ substrait.plan version 0 : 42 : 1 {
       // following the `project` instead.
       yield %2, %3 : si32, si1
     }
-    yield %1 : tuple<si32, si1, si32, si1>
+    yield %1 : !substrait.relation<si32, si1, si32, si1>
   }
 }
 
@@ -304,18 +304,18 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 1, 1, 1] from %[[V0]] :
-// CHECK-NEXT:      yield %[[V1]] : tuple<si32, si32, si32, si32>
+// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32, si32, si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32>
-    %2 = project %1 : tuple<si32, si32> -> tuple<si32, si32, si32, si32> {
+    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
+    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
+    %2 = project %1 : <si32, si32> -> <si32, si32, si32, si32> {
     ^bb0(%arg : tuple<si32, si32>):
       %3 = field_reference %arg[0] : tuple<si32, si32>
       %4 = field_reference %arg[1] : tuple<si32, si32>
       yield %3, %4 : si32, si32
     }
-    yield %2 : tuple<si32, si32, si32, si32>
+    yield %2 : !substrait.relation<si32, si32, si32, si32>
   }
 }

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -16,7 +16,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     %1 = emit [1, 1, 0, 0, 1] from %0 : <si1, si32> -> <si32, si32, si1, si1, si32>
-    %2 = cross %1 x %0 : <si32, si32, si1, si1, si32> x <si1, si32>
+    %2 = cross %1 x %0 : rel<si32, si32, si1, si1, si32> x rel<si1, si32>
     yield %2 : !substrait.relation<si32, si32, si1, si1, si32, si1, si32>
   }
 }
@@ -36,7 +36,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
-    %2 = cross %0 x %1 : <si1, si32> x <si32, si1>
+    %2 = cross %0 x %1 : rel<si1, si32> x rel<si32, si1>
     yield %2 : !substrait.relation<si1,si32, si32, si1>
   }
 }
@@ -57,7 +57,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     %1 = emit [1, 1, 0, 0, 1] from %0 : <si1, si32> -> <si32, si32, si1, si1, si32>
-    %2 = cross %0 x %1 : <si1, si32> x <si32, si32, si1, si1, si32>
+    %2 = cross %0 x %1 : rel<si1, si32> x rel<si32, si32, si1, si1, si32>
     yield %2 : !substrait.relation<si1, si32, si32, si32, si1, si1, si32>
   }
 }
@@ -77,7 +77,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
-    %2 = cross %1 x %0 : <si32, si1> x <si1, si32>
+    %2 = cross %1 x %0 : rel<si32, si1> x rel<si1, si32>
     yield %2 : !substrait.relation<si32, si1, si1, si32>
   }
 }
@@ -100,7 +100,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
     %2 = emit [0, 0] from %0 : <si1, si32> -> <si1, si1>
-    %3 = cross %1 x %2 : <si32, si32> x <si1, si1>
+    %3 = cross %1 x %2 : rel<si32, si32> x rel<si1, si1>
     yield %3 : !substrait.relation<si32, si32, si1, si1>
   }
 }
@@ -123,7 +123,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
     %2 = emit [0, 0] from %0 : <si1, si32> -> <si1, si1>
-    %3 = cross %1 x %2 : <si32, si1> x <si1, si1>
+    %3 = cross %1 x %2 : rel<si32, si1> x rel<si1, si1>
     yield %3 : !substrait.relation<si32, si1, si1, si1>
   }
 }
@@ -146,7 +146,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : <si1, si32>
     %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
     %2 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
-    %3 = cross %1 x %2 : <si32, si32> x <si32, si1>
+    %3 = cross %1 x %2 : rel<si32, si32> x rel<si32, si1>
     yield %3 : !substrait.relation<si32, si32, si32, si1>
   }
 }

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -14,8 +14,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 1, 0, 0, 1] from %0 : <si1, si32> -> <si32, si32, si1, si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 1, 0, 0, 1] from %0 : rel<si1, si32> -> rel<si32, si32, si1, si1, si32>
     %2 = cross %1 x %0 : rel<si32, si32, si1, si1, si32> x rel<si1, si32>
     yield %2 : !substrait.relation<si32, si32, si1, si1, si32, si1, si32>
   }
@@ -34,8 +34,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     %2 = cross %0 x %1 : rel<si1, si32> x rel<si32, si1>
     yield %2 : !substrait.relation<si1,si32, si32, si1>
   }
@@ -55,8 +55,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 1, 0, 0, 1] from %0 : <si1, si32> -> <si32, si32, si1, si1, si32>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 1, 0, 0, 1] from %0 : rel<si1, si32> -> rel<si32, si32, si1, si1, si32>
     %2 = cross %0 x %1 : rel<si1, si32> x rel<si32, si32, si1, si1, si32>
     yield %2 : !substrait.relation<si1, si32, si32, si32, si1, si1, si32>
   }
@@ -75,8 +75,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     %2 = cross %1 x %0 : rel<si32, si1> x rel<si1, si32>
     yield %2 : !substrait.relation<si32, si1, si1, si32>
   }
@@ -97,9 +97,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
-    %2 = emit [0, 0] from %0 : <si1, si32> -> <si1, si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
+    %2 = emit [0, 0] from %0 : rel<si1, si32> -> rel<si1, si1>
     %3 = cross %1 x %2 : rel<si32, si32> x rel<si1, si1>
     yield %3 : !substrait.relation<si32, si32, si1, si1>
   }
@@ -120,9 +120,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
-    %2 = emit [0, 0] from %0 : <si1, si32> -> <si1, si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
+    %2 = emit [0, 0] from %0 : rel<si1, si32> -> rel<si1, si1>
     %3 = cross %1 x %2 : rel<si32, si1> x rel<si1, si1>
     yield %3 : !substrait.relation<si32, si1, si1, si1>
   }
@@ -143,9 +143,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
-    %2 = emit [1, 0] from %0 : <si1, si32> -> <si32, si1>
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
+    %2 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     %3 = cross %1 x %2 : rel<si32, si32> x rel<si32, si1>
     yield %3 : !substrait.relation<si32, si32, si32, si1>
   }
@@ -173,13 +173,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : <si1, si1, tuple<si1, si32>>
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si1, tuple<si1, si32>>
     // Fields in position 1 and 3 are duplicates of field in position 0, so we
     // expect all references to the former to be replaced by the latter and an
     // `emit` re-establishing the original fields after the `filter`.
     %1 = emit [1, 1, 2, 1, 0] from %0
-        : <si1, si1, tuple<si1, si32>> -> <si1, si1, tuple<si1, si32>, si1, si1>
-    %2 = filter %1 : <si1, si1, tuple<si1, si32>, si1, si1> {
+        : rel<si1, si1, tuple<si1, si32>> -> rel<si1, si1, tuple<si1, si32>, si1, si1>
+    %2 = filter %1 : rel<si1, si1, tuple<si1, si32>, si1, si1> {
     ^bb0(%arg0: tuple<si1, si1, tuple<si1, si32>, si1, si1>):
       %3 = field_reference %arg0[0] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
       %4 = field_reference %arg0[1] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
@@ -203,7 +203,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]] :
-// CHECK-NEXT:      %[[V2:.*]] = project %[[V1]] : <si32> -> <si32, si1> {
+// CHECK-NEXT:      %[[V2:.*]] = project %[[V1]] : rel<si32> -> rel<si32, si1> {
 // CHECK-NEXT:      ^{{.*}}(%[[ARG0:.*]]: [[TYPE:.*]]):
 // CHECK-NEXT:        %[[V3:.*]] = field_reference %[[ARG0]][0] : [[TYPE]]
 // CHECK-NEXT:        %[[V5:.*]] = "test.op"(%[[V3]], %[[V3]]) :
@@ -213,9 +213,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
-    %2 = project %1 : <si32, si32> -> <si32, si32, si1> {
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
+    %2 = project %1 : rel<si32, si32> -> rel<si32, si32, si1> {
     ^bb0(%arg : tuple<si32, si32>):
       %3 = field_reference %arg[0] : tuple<si32, si32>
       %4 = field_reference %arg[1] : tuple<si32, si32>
@@ -243,8 +243,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : <si32>
-    %1 = project %0 : <si32> -> <si32, si1, si1> {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    %1 = project %0 : rel<si32> -> rel<si32, si1, si1> {
     ^bb0(%arg : tuple<si32>):
       %2 = field_reference %arg[0] : tuple<si32>
       %3 = "test.op"(%2) : (si32) -> si1
@@ -274,8 +274,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si32, si1>
-    %1 = project %0 : <si32, si1> -> <si32, si1, si32, si1> {
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
+    %1 = project %0 : rel<si32, si1> -> rel<si32, si1, si32, si1> {
     ^bb0(%arg0: tuple<si32, si1>):
       %2 = field_reference %arg0[0] : tuple<si32, si1>
       %3 = "test.op"(%2) : (si32) -> si1
@@ -308,9 +308,9 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : <si1, si32>
-    %1 = emit [1, 1] from %0 : <si1, si32> -> <si32, si32>
-    %2 = project %1 : <si32, si32> -> <si32, si32, si32, si32> {
+    %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
+    %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
+    %2 = project %1 : rel<si32, si32> -> rel<si32, si32, si32, si32> {
     ^bb0(%arg : tuple<si32, si32>):
       %3 = field_reference %arg[0] : tuple<si32, si32>
       %4 = field_reference %arg[1] : tuple<si32, si32>

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -10,14 +10,14 @@
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
 // CHECK-NEXT:      %[[V2:.*]] = cross %[[V1]] x %[[V0]] :
 // CHECK-NEXT:      %[[V3:.*]] = emit [0, 0, 1, 1, 0, 2, 3] from %[[V2]] :
-// CHECK-NEXT:      yield %[[V3]] : !substrait.relation<si32, si32, si1, si1, si32, si1, si32>
+// CHECK-NEXT:      yield %[[V3]] : rel<si32, si32, si1, si1, si32, si1, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 1, 0, 0, 1] from %0 : rel<si1, si32> -> rel<si32, si32, si1, si1, si32>
     %2 = cross %1 x %0 : rel<si32, si32, si1, si1, si32> x rel<si1, si32>
-    yield %2 : !substrait.relation<si32, si32, si1, si1, si32, si1, si32>
+    yield %2 : rel<si32, si32, si1, si1, si32, si1, si32>
   }
 }
 
@@ -37,7 +37,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     %2 = cross %0 x %1 : rel<si1, si32> x rel<si32, si1>
-    yield %2 : !substrait.relation<si1,si32, si32, si1>
+    yield %2 : rel<si1,si32, si32, si1>
   }
 }
 
@@ -51,14 +51,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
 // CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] :
 // CHECK-NEXT:      %[[V3:.*]] = emit [0, 1, 2, 2, 3, 3, 2] from %[[V2]] :
-// CHECK-NEXT:      yield %[[V3]] : !substrait.relation<si1, si32, si32, si32, si1, si1, si32>
+// CHECK-NEXT:      yield %[[V3]] : rel<si1, si32, si32, si32, si1, si1, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 1, 0, 0, 1] from %0 : rel<si1, si32> -> rel<si32, si32, si1, si1, si32>
     %2 = cross %0 x %1 : rel<si1, si32> x rel<si32, si32, si1, si1, si32>
-    yield %2 : !substrait.relation<si1, si32, si32, si32, si1, si1, si32>
+    yield %2 : rel<si1, si32, si32, si32, si1, si1, si32>
   }
 }
 
@@ -78,7 +78,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     %2 = cross %1 x %0 : rel<si32, si1> x rel<si1, si32>
-    yield %2 : !substrait.relation<si32, si1, si1, si32>
+    yield %2 : rel<si32, si1, si1, si32>
   }
 }
 
@@ -101,7 +101,7 @@ substrait.plan version 0 : 42 : 1 {
     %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
     %2 = emit [0, 0] from %0 : rel<si1, si32> -> rel<si1, si1>
     %3 = cross %1 x %2 : rel<si32, si32> x rel<si1, si1>
-    yield %3 : !substrait.relation<si32, si32, si1, si1>
+    yield %3 : rel<si32, si32, si1, si1>
   }
 }
 
@@ -124,7 +124,7 @@ substrait.plan version 0 : 42 : 1 {
     %1 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     %2 = emit [0, 0] from %0 : rel<si1, si32> -> rel<si1, si1>
     %3 = cross %1 x %2 : rel<si32, si1> x rel<si1, si1>
-    yield %3 : !substrait.relation<si32, si1, si1, si1>
+    yield %3 : rel<si32, si1, si1, si1>
   }
 }
 
@@ -147,7 +147,7 @@ substrait.plan version 0 : 42 : 1 {
     %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
     %2 = emit [1, 0] from %0 : rel<si1, si32> -> rel<si32, si1>
     %3 = cross %1 x %2 : rel<si32, si32> x rel<si32, si1>
-    yield %3 : !substrait.relation<si32, si32, si32, si1>
+    yield %3 : rel<si32, si32, si32, si1>
   }
 }
 
@@ -191,7 +191,7 @@ substrait.plan version 0 : 42 : 1 {
       %a = "test.op"(%3, %4, %5, %7, %8, %9) : (si1, si1, si1, si32, si1, si1) -> si1
       yield %a : si1
     }
-    yield %2 : !substrait.relation<si1, si1, tuple<si1, si32>, si1, si1>
+    yield %2 : rel<si1, si1, tuple<si1, si32>, si1, si1>
   }
 }
 
@@ -222,7 +222,7 @@ substrait.plan version 0 : 42 : 1 {
       %5 = "test.op"(%3, %4) : (si32, si32) -> si1
       yield %5 : si1
     }
-    yield %2 : !substrait.relation<si32, si32, si1>
+    yield %2 : rel<si32, si32, si1>
   }
 }
 
@@ -253,7 +253,7 @@ substrait.plan version 0 : 42 : 1 {
       // `project`.
       yield %3, %3 : si1, si1
     }
-    yield %1 : !substrait.relation<si32, si1, si1>
+    yield %1 : rel<si32, si1, si1>
   }
 }
 
@@ -284,7 +284,7 @@ substrait.plan version 0 : 42 : 1 {
       // following the `project` instead.
       yield %2, %3 : si32, si1
     }
-    yield %1 : !substrait.relation<si32, si1, si32, si1>
+    yield %1 : rel<si32, si1, si32, si1>
   }
 }
 
@@ -304,7 +304,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
 // CHECK-NEXT:      %[[V1:.*]] = emit [1, 1, 1, 1] from %[[V0]] :
-// CHECK-NEXT:      yield %[[V1]] : !substrait.relation<si32, si32, si32, si32>
+// CHECK-NEXT:      yield %[[V1]] : rel<si32, si32, si32, si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
@@ -316,6 +316,6 @@ substrait.plan version 0 : 42 : 1 {
       %4 = field_reference %arg[1] : tuple<si32, si32>
       yield %3, %4 : si32, si32
     }
-    yield %2 : !substrait.relation<si32, si32, si32, si32>
+    yield %2 : rel<si32, si32, si32, si32>
   }
 }

--- a/test/python/dialects/substrait/dialect.py
+++ b/test/python/dialects/substrait/dialect.py
@@ -48,7 +48,7 @@ def testNamedTable():
     plan_rel = ss.PlanRelOp()
     with ir.InsertionPoint(plan_rel.body):
       si32 = ir.IntegerType.get_signed(32)
-      result_type = ir.TupleType.get_tuple([si32, si32])
+      result_type = ss.RelationType.get([si32, si32])
       field_names = ir.ArrayAttr.get([ir.StringAttr.get(n) for n in ["a", "b"]])
       named_table = ss.NamedTableOp(result_type, "t", field_names)
       ss.YieldOp(named_table)

--- a/test/python/dialects/substrait/e2e_datafusion.py
+++ b/test/python/dialects/substrait/e2e_datafusion.py
@@ -39,7 +39,7 @@ def testNamedTable():
   plan = ir.Module.parse('''
     substrait.plan version 0 : 42 : 1 {
       relation {
-        %0 = named_table @t as ["a", "b"] : <si32, si32>
+        %0 = named_table @t as ["a", "b"] : rel<si32, si32>
         yield %0 : !substrait.relation<si32, si32>
       }
     }

--- a/test/python/dialects/substrait/e2e_datafusion.py
+++ b/test/python/dialects/substrait/e2e_datafusion.py
@@ -40,7 +40,7 @@ def testNamedTable():
     substrait.plan version 0 : 42 : 1 {
       relation {
         %0 = named_table @t as ["a", "b"] : rel<si32, si32>
-        yield %0 : !substrait.relation<si32, si32>
+        yield %0 : rel<si32, si32>
       }
     }
   ''')

--- a/test/python/dialects/substrait/e2e_datafusion.py
+++ b/test/python/dialects/substrait/e2e_datafusion.py
@@ -39,8 +39,8 @@ def testNamedTable():
   plan = ir.Module.parse('''
     substrait.plan version 0 : 42 : 1 {
       relation {
-        %0 = named_table @t as ["a", "b"] : tuple<si32, si32>
-        yield %0 : tuple<si32, si32>
+        %0 = named_table @t as ["a", "b"] : <si32, si32>
+        yield %0 : !substrait.relation<si32, si32>
       }
     }
   ''')

--- a/test/python/dialects/substrait/e2e_duckdb.py
+++ b/test/python/dialects/substrait/e2e_duckdb.py
@@ -40,8 +40,8 @@ def testNamedTable():
   plan = ir.Module.parse('''
     substrait.plan version 0 : 42 : 1 {
       relation as ["a", "b"] {
-        %0 = named_table @t as ["a", "b"] : tuple<si32, si32>
-        yield %0 : tuple<si32, si32>
+        %0 = named_table @t as ["a", "b"] : <si32, si32>
+        yield %0 : !substrait.relation<si32, si32>
       }
     }
   ''')

--- a/test/python/dialects/substrait/e2e_duckdb.py
+++ b/test/python/dialects/substrait/e2e_duckdb.py
@@ -40,7 +40,7 @@ def testNamedTable():
   plan = ir.Module.parse('''
     substrait.plan version 0 : 42 : 1 {
       relation as ["a", "b"] {
-        %0 = named_table @t as ["a", "b"] : <si32, si32>
+        %0 = named_table @t as ["a", "b"] : rel<si32, si32>
         yield %0 : !substrait.relation<si32, si32>
       }
     }

--- a/test/python/dialects/substrait/e2e_duckdb.py
+++ b/test/python/dialects/substrait/e2e_duckdb.py
@@ -41,7 +41,7 @@ def testNamedTable():
     substrait.plan version 0 : 42 : 1 {
       relation as ["a", "b"] {
         %0 = named_table @t as ["a", "b"] : rel<si32, si32>
-        yield %0 : !substrait.relation<si32, si32>
+        yield %0 : rel<si32, si32>
       }
     }
   ''')

--- a/test/python/dialects/substrait/e2e_ibis.py
+++ b/test/python/dialects/substrait/e2e_ibis.py
@@ -40,5 +40,5 @@ def testNamedTable():
   # CHECK-NEXT: module
   # CHECK-NEXT:   substrait.plan version {{.*}} producer "ibis-substrait" {
   # CHECK-NEXT:     relation as ["a", "b"] {
-  # CHECK-NEXT:       %[[V0:.*]] = named_table @t as ["a", "b"] : <si32, si32>
+  # CHECK-NEXT:       %[[V0:.*]] = named_table @t as ["a", "b"] : rel<si32, si32>
   # CHECK-NEXT:       yield %[[V0]] : !substrait.relation<si32, si32>

--- a/test/python/dialects/substrait/e2e_ibis.py
+++ b/test/python/dialects/substrait/e2e_ibis.py
@@ -41,4 +41,4 @@ def testNamedTable():
   # CHECK-NEXT:   substrait.plan version {{.*}} producer "ibis-substrait" {
   # CHECK-NEXT:     relation as ["a", "b"] {
   # CHECK-NEXT:       %[[V0:.*]] = named_table @t as ["a", "b"] : rel<si32, si32>
-  # CHECK-NEXT:       yield %[[V0]] : !substrait.relation<si32, si32>
+  # CHECK-NEXT:       yield %[[V0]] : rel<si32, si32>

--- a/test/python/dialects/substrait/e2e_ibis.py
+++ b/test/python/dialects/substrait/e2e_ibis.py
@@ -40,5 +40,5 @@ def testNamedTable():
   # CHECK-NEXT: module
   # CHECK-NEXT:   substrait.plan version {{.*}} producer "ibis-substrait" {
   # CHECK-NEXT:     relation as ["a", "b"] {
-  # CHECK-NEXT:       %[[V0:.*]] = named_table @t as ["a", "b"] : tuple<si32, si32>
-  # CHECK-NEXT:       yield %[[V0]] : tuple<si32, si32>
+  # CHECK-NEXT:       %[[V0:.*]] = named_table @t as ["a", "b"] : <si32, si32>
+  # CHECK-NEXT:       yield %[[V0]] : !substrait.relation<si32, si32>

--- a/test/python/dialects/substrait/e2e_pyarrow.py
+++ b/test/python/dialects/substrait/e2e_pyarrow.py
@@ -31,8 +31,8 @@ def testNamedTable():
   plan = ir.Module.parse('''
     substrait.plan version 0 : 42 : 1 {
       relation {
-        %0 = named_table @t as ["a", "b"] : tuple<si32, si32>
-        yield %0 : tuple<si32, si32>
+        %0 = named_table @t as ["a", "b"] : <si32, si32>
+        yield %0 : !substrait.relation<si32, si32>
       }
     }
   ''')

--- a/test/python/dialects/substrait/e2e_pyarrow.py
+++ b/test/python/dialects/substrait/e2e_pyarrow.py
@@ -31,7 +31,7 @@ def testNamedTable():
   plan = ir.Module.parse('''
     substrait.plan version 0 : 42 : 1 {
       relation {
-        %0 = named_table @t as ["a", "b"] : <si32, si32>
+        %0 = named_table @t as ["a", "b"] : rel<si32, si32>
         yield %0 : !substrait.relation<si32, si32>
       }
     }

--- a/test/python/dialects/substrait/e2e_pyarrow.py
+++ b/test/python/dialects/substrait/e2e_pyarrow.py
@@ -32,7 +32,7 @@ def testNamedTable():
     substrait.plan version 0 : 42 : 1 {
       relation {
         %0 = named_table @t as ["a", "b"] : rel<si32, si32>
-        yield %0 : !substrait.relation<si32, si32>
+        yield %0 : rel<si32, si32>
       }
     }
   ''')


### PR DESCRIPTION
~~Once rebased onto #87, this PR will need llvm/llvm-project#127518 to make `pyright` happy.~~

This PR introduces a new `RelationType` as the operands and result types of `RelOp`s, where previously `tuple` had been used as a placeholder. While this changes little in the structure of the IR, it (1) underlines the subtle difference between the relation, a *container* of records, and the records themselves, which had *both* been represented as `tuple`s before and (2) it allows defining an even shorter type name, `rel`, for that type. The latter is implemented using a custom printer and parser for these "pseudo type names" (which are really keywords for the printer and parser), which lays the basis for similar short-hand forms for some of our other types with long type names.