### PR TITLE
ci: freeze dependencies in `requirements.txt`

### DIFF
--- a/requirements-unfrozen.txt
+++ b/requirements-unfrozen.txt
@@ -1,0 +1,16 @@
+# MLIR dependencies.
+-r third_party/llvm-project/mlir/python/requirements.txt
+
+# Testing.
+datafusion==32.0.0
+duckdb==1.1.3
+ibis==3.3.0
+ibis-framework==8.0.0
+ibis-substrait==3.2.0
+pyarrow
+pyright
+yapf
+
+# Plotting.
+pandas
+matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,41 @@
-# MLIR dependencies.
--r third_party/llvm-project/mlir/python/requirements.txt
-
-# Testing.
+atpublic==4.1.0
+bidict==0.23.1
+contourpy==1.3.1
+cycler==0.12.1
 datafusion==32.0.0
-duckdb
+duckdb==1.1.3
+fonttools==4.55.8
 ibis==3.3.0
 ibis-framework==8.0.0
 ibis-substrait==3.2.0
-pyarrow
-
-# Plotting.
-pandas
-matplotlib
+kiwisolver==1.4.8
+markdown-it-py==3.0.0
+matplotlib==3.10.0
+mdurl==0.1.2
+ml_dtypes==0.5.0
+multipledispatch==1.0.0
+nodeenv==1.9.1
+numpy==1.26.4
+packaging==24.2
+pandas==2.2.3
+parsy==2.1
+pillow==11.1.0
+platformdirs==4.3.6
+protobuf==5.29.3
+pyarrow==15.0.2
+pyarrow-hotfix==0.6
+pybind11==2.13.6
+Pygments==2.19.1
+pyparsing==3.2.1
+pyright==1.1.393
+python-dateutil==2.9.0.post0
+pytz==2025.1
+PyYAML==6.0.1
+rich==13.9.4
+six==1.17.0
+sqlglot==20.11.0
+substrait==0.23.0
+toolz==0.12.1
+typing_extensions==4.12.2
+tzdata==2025.1
+yapf==0.43.0


### PR DESCRIPTION
That file is now created with the following commands:

```
pip install --upgrade -r requirements-unfrozen.txt
pip freeze > requirements.txt
```

This prevents automatic updates of dependencies, which may break CI or new developers.