### PR TITLE
chore: remove type of date/time attribute from test

### DIFF
--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -16,7 +16,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.time> {
     ^bb0(%arg : tuple<si1>):
-      %time = literal #substrait.time<200000000us> : !substrait.time
+      %time = literal #substrait.time<200000000us> 
       yield %time : !substrait.time
     }
     yield %1 : tuple<si1, !substrait.time>
@@ -40,7 +40,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.date> {
     ^bb0(%arg : tuple<si1>):
-      %date = literal #substrait.date<200000000> : !substrait.date
+      %date = literal #substrait.date<200000000> 
       yield %date : !substrait.date
     }
     yield %1 : tuple<si1, !substrait.date>

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -16,7 +16,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.time> {
     ^bb0(%arg : tuple<si1>):
-      %time = literal #substrait.time<200000000us> 
+      %time = literal #substrait.time<200000000us>
       yield %time : !substrait.time
     }
     yield %1 : tuple<si1, !substrait.time>

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -29,7 +29,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.time> {
     ^bb0(%arg : tuple<si1>):
-      %time = literal #substrait.time<200000000us> : !substrait.time
+      %time = literal #substrait.time<200000000us> 
       yield %time : !substrait.time
     }
     yield %1 : tuple<si1, !substrait.time> 
@@ -56,7 +56,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.date> {
     ^bb0(%arg : tuple<si1>):
-      %date = literal #substrait.date<200000000> : !substrait.date
+      %date = literal #substrait.date<200000000> 
       yield %date : !substrait.date
     }
     yield %1 : tuple<si1, !substrait.date> 


### PR DESCRIPTION
Removed types of date/time attributes from the literal test and Export/literal tests to align with the timestamp tests. I noticed that these attributes were still present in date/time but not in timestamp tests - was this an oversight or intentional? Let me know if they were intentionally kept and will close the PR.