### PR TITLE
feat: introduce `fixedbinary<L>` type

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -120,6 +120,16 @@ def Substrait_FixedCharAttr
   }];
 }
 
+def Substrait_FixedBinaryAttr : Substrait_Attr<"FixedBinary", "fixed_binary",
+  [TypedAttrInterface ]> {
+  let summary = "Substrait fixed-length binary type";
+  let description = [{
+    This type represents a substrait binary string of L bytes.
+  }];
+  let parameters = (ins "StringAttr":$value, "FixedBinaryType":$type);
+  let assemblyFormat = "`<` custom<AddRemovePadding>($value, $type) `>`";
+}
+
 def Substrait_IntervalDaySecondAttr
     : Substrait_StaticallyTypedAttr<"IntervalDaySecond", "interval_day_second",
                                     "IntervalDaySecondType"> {
@@ -271,6 +281,7 @@ def Substrait_ParametrizedAttributes {
   list<Attr> attrs = [
     Substrait_FixedCharAttr, // FixedChar
     Substrait_VarCharAttr, // VarChar
+    Substrait_FixedBinaryAttr, // FixedBinary
     Substrait_DecimalAttr, // Decimal
   ];
 }

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -128,7 +128,7 @@ def Substrait_FixedBinaryAttr : Substrait_Attr<"FixedBinary", "fixed_binary",
   }];
   let parameters = (ins "StringAttr":$value, "FixedBinaryType":$type);
   let genVerifyDecl = 1;
-  let assemblyFormat = "`<` custom<AddRemovePadding>($value, $type) `>`";
+  let assemblyFormat = "`<` custom<FixedBinaryTypeRemoveLength>($value, $type) `>`";
 }
 
 def Substrait_IntervalDaySecondAttr

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -128,7 +128,7 @@ def Substrait_FixedBinaryAttr : Substrait_Attr<"FixedBinary", "fixed_binary",
   }];
   let parameters = (ins "StringAttr":$value, "FixedBinaryType":$type);
   let genVerifyDecl = 1;
-  let assemblyFormat = "`<` custom<FixedBinaryTypeRemoveLength>($value, $type) `>`";
+  let assemblyFormat = "`<` custom<FixedBinaryLiteral>($value, $type) `>`";
 }
 
 def Substrait_IntervalDaySecondAttr

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -121,12 +121,13 @@ def Substrait_FixedCharAttr
 }
 
 def Substrait_FixedBinaryAttr : Substrait_Attr<"FixedBinary", "fixed_binary",
-  [TypedAttrInterface ]> {
+    [TypedAttrInterface]> {
   let summary = "Substrait fixed-length binary type";
   let description = [{
     This type represents a substrait binary string of L bytes.
   }];
   let parameters = (ins "StringAttr":$value, "FixedBinaryType":$type);
+  let genVerifyDecl = 1;
   let assemblyFormat = "`<` custom<AddRemovePadding>($value, $type) `>`";
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -43,6 +43,15 @@ def Substrait_DecimalType : Substrait_Type<"Decimal", "decimal"> {
   let genVerifyDecl = 1;
 }
 
+def Substrait_FixedBinaryType : Substrait_Type<"FixedBinary", "fixed_binary"> {
+  let summary = "Substrait fixed-length binary type";
+  let description = [{
+    This type represents a substrait binary string of L bytes.
+  }];
+  let parameters = (ins "int32_t":$length);
+  let assemblyFormat = [{ `<` $length `>` }];
+}
+
 def Substrait_FixedCharType : Substrait_Type<"FixedChar", "fixed_char"> {
   let summary = "Substrait fixed-length char type";
   let description = [{
@@ -145,6 +154,7 @@ def Substrait_ParametrizedTypes {
   list<Type> types = [
     Substrait_FixedCharType, // FixedChar
     Substrait_VarCharType, // VarChar
+    Substrait_FixedBinaryType, // FixedBinary
     Substrait_DecimalType, // Decimal
   ];
 }

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -369,8 +369,9 @@ void printDecimalNumber(AsmPrinter &printer, DecimalType type,
   printer << "P = " << type.getPrecision() << ", S = " << type.getScale();
 }
 
-ParseResult parseFixedBinaryTypeRemoveLength(AsmParser &parser, StringAttr &value,
-                                  FixedBinaryType &type) {
+ParseResult parseFixedBinaryTypeRemoveLength(AsmParser &parser,
+                                             StringAttr &value,
+                                             FixedBinaryType &type) {
   std::string valueStr;
 
   // Parse fixed binary value as quoted string.
@@ -393,7 +394,7 @@ ParseResult parseFixedBinaryTypeRemoveLength(AsmParser &parser, StringAttr &valu
 }
 
 void printFixedBinaryTypeRemoveLength(AsmPrinter &printer, StringAttr value,
-                           FixedBinaryType type) {
+                                      FixedBinaryType type) {
   printer << value;
 }
 

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -371,11 +371,10 @@ void printDecimalNumber(AsmPrinter &printer, DecimalType type,
   printer << "P = " << type.getPrecision() << ", S = " << type.getScale();
 }
 
-ParseResult parseFixedBinaryTypeRemoveLength(AsmParser &parser,
+ParseResult parseFixedBinaryLiteral(AsmParser &parser,
                                              StringAttr &value,
                                              FixedBinaryType &type) {
   std::string valueStr;
-
   // Parse fixed binary value as quoted string.
   if (parser.parseString(&valueStr))
     return failure();
@@ -389,13 +388,12 @@ ParseResult parseFixedBinaryTypeRemoveLength(AsmParser &parser,
   if (!(type = FixedBinaryType::getChecked(emitError, context, length)))
     return failure();
 
-  //  Set the processed value.
   value = parser.getBuilder().getStringAttr(valueStr);
 
   return success();
 }
 
-void printFixedBinaryTypeRemoveLength(AsmPrinter &printer, StringAttr value,
+void printFixedBinaryLiteral(AsmPrinter &printer, StringAttr value,
                                       FixedBinaryType type) {
   printer << value;
 }

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -84,8 +84,10 @@ LogicalResult mlir::substrait::FixedBinaryAttr::verify(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError, StringAttr value,
     FixedBinaryType type) {
   FixedBinaryType fixedBinaryType = mlir::dyn_cast<FixedBinaryType>(type);
+  if (fixedBinaryType == nullptr)
+    return emitError() << "expected a fixed binary type";
   int32_t value_length = value.size();
-  if (fixedBinaryType == nullptr || value_length != fixedBinaryType.getLength())
+  if (value_length != fixedBinaryType.getLength())
     return emitError() << "value length must be " << fixedBinaryType.getLength()
                        << " characters.";
   return success();

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -371,9 +371,8 @@ void printDecimalNumber(AsmPrinter &printer, DecimalType type,
   printer << "P = " << type.getPrecision() << ", S = " << type.getScale();
 }
 
-ParseResult parseFixedBinaryLiteral(AsmParser &parser,
-                                             StringAttr &value,
-                                             FixedBinaryType &type) {
+ParseResult parseFixedBinaryLiteral(AsmParser &parser, StringAttr &value,
+                                    FixedBinaryType &type) {
   std::string valueStr;
   // Parse fixed binary value as quoted string.
   if (parser.parseString(&valueStr))
@@ -394,7 +393,7 @@ ParseResult parseFixedBinaryLiteral(AsmParser &parser,
 }
 
 void printFixedBinaryLiteral(AsmPrinter &printer, StringAttr value,
-                                      FixedBinaryType type) {
+                             FixedBinaryType type) {
   printer << value;
 }
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -715,10 +715,9 @@ importLiteral(ImplicitLocOpBuilder builder,
     return builder.create<LiteralOp>(attr);
   }
   case Expression::Literal::LiteralTypeCase::kFixedBinary: {
-    StringAttr stringAttr =
-    StringAttr::get(context, message.fixed_binary());
+    StringAttr stringAttr = StringAttr::get(context, message.fixed_binary());
     FixedBinaryType fixedBinaryType =
-    FixedBinaryType::get(context, message.fixed_binary().size());
+        FixedBinaryType::get(context, message.fixed_binary().size());
     auto attr = FixedBinaryAttr::get(context, stringAttr, fixedBinaryType);
     return builder.create<LiteralOp>(attr);
   }

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -221,6 +221,8 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
     return FixedCharType::get(context, type.fixed_char().length());
   case proto::Type::kVarchar:
     return VarCharType::get(context, type.varchar().length());
+  case proto::Type::kFixedBinary:
+    return FixedBinaryType::get(context, type.fixed_binary().length());
   case proto::Type::kDecimal: {
     const proto::Type::Decimal &decimalType = type.decimal();
     return mlir::substrait::DecimalType::get(context, decimalType.precision(),
@@ -710,6 +712,14 @@ importLiteral(ImplicitLocOpBuilder builder,
     VarCharType varCharType =
         VarCharType::get(context, message.var_char().value().size());
     auto attr = VarCharAttr::get(context, stringAttr, varCharType);
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kFixedBinary: {
+    StringAttr stringAttr =
+    StringAttr::get(context, message.fixed_binary());
+    FixedBinaryType fixedBinaryType =
+    FixedBinaryType::get(context, message.fixed_binary().size());
+    auto attr = FixedBinaryAttr::get(context, stringAttr, fixedBinaryType);
     return builder.create<LiteralOp>(attr);
   }
   case Expression::Literal::LiteralTypeCase::kDecimal: {

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -34,33 +34,9 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<6>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<6>
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
-    ^bb0(%arg : tuple<si1>):
-      %var_char = literal #substrait.var_char<"hello", 6>
-      yield %var_char : !substrait.var_char<6>
-    }
-    yield %1 : tuple<si1, !substrait.var_char<6>>
-  }
-}
-
-// -----
-
-// CHECK:      substrait.plan version 0 : 42 : 1 {
-// CHECK-NEXT:   relation
-// CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181", 10>
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>
@@ -70,7 +46,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
-      %bytes = literal #substrait.fixed_binary<"8181818181", 10>
+      %bytes = literal #substrait.fixed_binary<"8181818181">
       yield %bytes : !substrait.fixed_binary<10>
     }
     yield %1 : tuple<si1, !substrait.fixed_binary<10>>

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -58,6 +58,30 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+    ^bb0(%arg : tuple<si1>):
+      %bytes = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+      yield %bytes : !substrait.fixed_binary<10>
+    }
+    yield %1 : tuple<si1, !substrait.fixed_binary<10>>
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -60,7 +60,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello"> : !substrait.var_char<6>
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<6>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<6>
@@ -70,8 +70,8 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
     ^bb0(%arg : tuple<si1>):
-      %fixed_char = literal #substrait.var_char<"hello"> : !substrait.var_char<6>
-      yield %fixed_char : !substrait.var_char<6>
+      %var_char = literal #substrait.var_char<"hello", 6>
+      yield %var_char : !substrait.var_char<6>
     }
     yield %1 : tuple<si1, !substrait.var_char<6>>
   }

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -60,7 +60,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181", 10>
 // CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>
@@ -70,7 +70,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
-      %bytes = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+      %bytes = literal #substrait.fixed_binary<"8181818181", 10>
       yield %bytes : !substrait.fixed_binary<10>
     }
     yield %1 : tuple<si1, !substrait.fixed_binary<10>>

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -58,6 +58,30 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello"> : !substrait.var_char<6>
+// CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<6>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<6>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
+    ^bb0(%arg : tuple<si1>):
+      %fixed_char = literal #substrait.var_char<"hello"> : !substrait.var_char<6>
+      yield %fixed_char : !substrait.var_char<6>
+    }
+    yield %1 : tuple<si1, !substrait.var_char<6>>
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_char<5>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,6 +3,20 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.fixed_binary<4>>
+// CHECK-NEXT:    yield %0 : tuple<!substrait.fixed_binary<4>>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.fixed_binary<4>>
+    yield %0 : tuple<!substrait.fixed_binary<4>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.var_char<6>>
 // CHECK-NEXT:    yield %0 : tuple<!substrait.var_char<6>>
 

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,6 +3,20 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
+// CHECK-NEXT:    yield %0 : tuple<!substrait.decimal<12, 2>>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
+    yield %0 : tuple<!substrait.decimal<12, 2>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.fixed_binary<4>>
 // CHECK-NEXT:    yield %0 : tuple<!substrait.fixed_binary<4>>
 
@@ -24,20 +38,6 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<!substrait.var_char<6>>
     yield %0 : tuple<!substrait.var_char<6>>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: substrait.plan
-// CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
-// CHECK-NEXT:    yield %0 : tuple<!substrait.decimal<12, 2>>
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
-    yield %0 : tuple<!substrait.decimal<12, 2>>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -81,14 +81,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
-// CHECK-NEXT:            fixed_binary: "1838191\000\000\000"
+// CHECK-NEXT:            fixed_binary: "8181818181"
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
-      %fixed_binary = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+      %fixed_binary = literal #substrait.fixed_binary<"8181818181", 10>
       yield %fixed_binary : !substrait.fixed_binary<10>
     }
     yield %1 : tuple<si1, !substrait.fixed_binary<10>>

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -81,6 +81,37 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
+// CHECK-NEXT:           var_char {
+// CHECK-NEXT:            value: "hello"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:       }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
+    ^bb0(%arg0: tuple<si1>):
+      %2 = literal #substrait.var_char<"hello"> : !substrait.var_char<6>
+      yield %2 : !substrait.var_char<6>
+    }
+    yield %1 : tuple<si1, !substrait.var_char<6>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        input {
+// CHECK-NEXT:          read {
+// CHECK:             expressions {
+// CHECK-NEXT:          literal {
 // CHECK-NEXT:            fixed_char: "hello"
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -81,6 +81,33 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
+// CHECK-NEXT:            fixed_binary: "1838191\000\000\000"
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+    ^bb0(%arg : tuple<si1>):
+      %fixed_binary = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+      yield %fixed_binary : !substrait.fixed_binary<10>
+    }
+    yield %1 : tuple<si1, !substrait.fixed_binary<10>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      project {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        input {
+// CHECK-NEXT:          read {
+// CHECK:             expressions {
+// CHECK-NEXT:          literal {
 // CHECK-NEXT:           var_char {
 // CHECK-NEXT:            value: "hello"
 // CHECK-NEXT:          }

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -92,7 +92,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
     ^bb0(%arg0: tuple<si1>):
-      %2 = literal #substrait.var_char<"hello"> : !substrait.var_char<6>
+      %2 = literal #substrait.var_char<"hello", 6>
       yield %2 : !substrait.var_char<6>
     }
     yield %1 : tuple<si1, !substrait.var_char<6>>

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -50,37 +50,6 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          read {
 // CHECK:             expressions {
 // CHECK-NEXT:          literal {
-// CHECK-NEXT:           var_char {
-// CHECK-NEXT:            value: "hello"
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:       }
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.var_char<6>> {
-    ^bb0(%arg0: tuple<si1>):
-      %2 = literal #substrait.var_char<"hello", 6>
-      yield %2 : !substrait.var_char<6>
-    }
-    yield %1 : tuple<si1, !substrait.var_char<6>>
-  }
-}
-
-// -----
-
-// CHECK-LABEL: relations {
-// CHECK-NEXT:    rel {
-// CHECK-NEXT:      project {
-// CHECK-NEXT:        common {
-// CHECK-NEXT:          direct {
-// CHECK-NEXT:          }
-// CHECK-NEXT:        }
-// CHECK-NEXT:        input {
-// CHECK-NEXT:          read {
-// CHECK:             expressions {
-// CHECK-NEXT:          literal {
 // CHECK-NEXT:            fixed_binary: "8181818181"
 
 substrait.plan version 0 : 42 : 1 {
@@ -88,7 +57,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : tuple<si1>
     %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
-      %fixed_binary = literal #substrait.fixed_binary<"8181818181", 10>
+      %fixed_binary = literal #substrait.fixed_binary<"8181818181">
       yield %fixed_binary : !substrait.fixed_binary<10>
     }
     yield %1 : tuple<si1, !substrait.fixed_binary<10>>

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -43,6 +43,32 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:          names: "a"
 // CHECK-NEXT:          struct {
 // CHECK-NEXT:            types {
+// CHECK-NEXT:              fixed_binary {
+// CHECK-NEXT:                length: 4
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        named_table {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.fixed_binary<4>>
+    yield %0 : tuple<!substrait.fixed_binary<4>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK:             base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
 // CHECK-NEXT:              varchar {
 // CHECK-NEXT:                length: 6
 // CHECK-NEXT:                nullability: NULLABILITY_REQUIRED

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -129,7 +129,7 @@ version {
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello"> : !substrait.var_char<5>
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<5>
 # CHECK-NEXT:    }
 # CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<5>

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -127,6 +127,60 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
+# CHECK-NEXT:    }
+# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          fixed_binary: "1838191\00\00\00"
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -71,65 +71,9 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<5>> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<5>
-# CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<5>
-
-relations {
-  rel {
-    project {
-      common {
-        direct {
-        }
-      }
-      input {
-        read {
-          common {
-            direct {
-            }
-          }
-          base_schema {
-            names: "a"
-            struct {
-              types {
-                bool {
-                  nullability: NULLABILITY_REQUIRED
-                }
-              }
-              nullability: NULLABILITY_REQUIRED
-            }
-          }
-          named_table {
-            names: "t1"
-          }
-        }
-      }
-      expressions {
-        literal {
-          var_char {
-            value: "hello"
-          }
-        }
-      }
-    }
-  }
-}
-version {
-  minor_number: 42
-  patch_number: 1
-}
-
-# -----
-
-# CHECK:      substrait.plan version 0 : 42 : 1 {
-# CHECK-NEXT:   relation
-# CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181", 10>
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 # CHECK-NEXT:    }
 # CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -129,7 +129,7 @@ version {
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_binary<10>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
-# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"1838191\00\00\00", 10>
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181", 10>
 # CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
 # CHECK-NEXT:    }
 # CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.fixed_binary<10>
@@ -165,7 +165,7 @@ relations {
       }
       expressions {
         literal {
-          fixed_binary: "1838191\00\00\00"
+          fixed_binary: "8181818181"
         }
       }
     }

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -127,6 +127,62 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.var_char<5>> {
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello"> : !substrait.var_char<5>
+# CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<5>
+# CHECK-NEXT:    }
+# CHECK-NEXT:    yield %[[V1]] : tuple<si1, !substrait.var_char<5>
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          var_char {
+            value: "hello"
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK:      substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si1> -> tuple<si1, !substrait.fixed_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -48,6 +48,11 @@ version {
 
 # -----
 
+# CHECK:      substrait.plan
+# CHECK-NEXT:   relation
+# CHECK-NEXT:     named_table
+# CHECK-SAME:       : tuple<!substrait.fixed_binary<5>>
+
 relations {
   rel {
     read {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -48,6 +48,38 @@ version {
 
 # -----
 
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            fixed_binary {
+              length: 5
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table


### PR DESCRIPTION
This PR is based on and, therefor, contains #82.

This PR introduces the compound type `fixedBinary<L>` representing a binary string of L bytes. 