### PR TITLE
chore: add comment to `IntervalDaySecondAttr` verify function

### DIFF
--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -85,6 +85,9 @@ LogicalResult mlir::substrait::IntervalDaySecondAttr::verify(
   if (days < -3650000 || days > 3650000)
     return emitError()
            << "days must be in a range of [-3,650,000..3,650,000] days";
+  // The value of `seconds` should be within the range [-315,360,000,000..
+  // 315,360,000,000]. However, this exceeds the limits of int32_t (as required
+  // by the specification), making it untestable within the given constraints.
   return success();
 }
 


### PR DESCRIPTION
This comment makes clear why we do not test if the `seconds` value as part of the `IntervalDaySecondAttr` type is within the required interval range [-315,360,000,000..315,360,000,000]. This is because the `seconds` value is an int32_t, and this interval range exceeds the limits of int32_t.
