### PR TITLE
build: fix CMake dependencies for generated headers

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/CMakeLists.txt
+++ b/include/substrait-mlir/Dialect/Substrait/IR/CMakeLists.txt
@@ -1,20 +1,17 @@
 # Add dialect, types, and ops.
 add_mlir_dialect(SubstraitOps substrait)
-add_dependencies(MLIRSubstraitDialect MLIRSubstraitOpsIncGen)
 
 # Add enums.
 set(LLVM_TARGET_DEFINITIONS SubstraitOps.td)
 mlir_tablegen(SubstraitEnums.h.inc -gen-enum-decls)
 mlir_tablegen(SubstraitEnums.cpp.inc -gen-enum-defs)
 add_public_tablegen_target(MLIRSubstraitEnumsIncGen)
-add_dependencies(MLIRSubstraitDialect MLIRSubstraitEnumsIncGen)
 
 # Add attributes.
 set(LLVM_TARGET_DEFINITIONS SubstraitAttrs.td)
 mlir_tablegen(SubstraitOpsAttrs.h.inc --gen-attrdef-decls)
 mlir_tablegen(SubstraitOpsAttrs.cpp.inc --gen-attrdef-defs)
 add_public_tablegen_target(MLIRSubstraitAttrsIncGen)
-add_dependencies(MLIRSubstraitDialect MLIRSubstraitAttrsIncGen)
 
 # Add interfaces.
 set(LLVM_TARGET_DEFINITIONS SubstraitInterfaces.td)
@@ -25,8 +22,11 @@ mlir_tablegen(SubstraitOpInterfaces.cpp.inc -gen-op-interface-defs)
 mlir_tablegen(SubstraitTypeInterfaces.h.inc -gen-type-interface-decls)
 mlir_tablegen(SubstraitTypeInterfaces.cpp.inc -gen-type-interface-defs)
 add_public_tablegen_target(MLIRSubstraitInterfacesIncGen)
-add_dependencies(MLIRSubstraitDialect MLIRSubstraitInterfacesIncGen)
 
-add_dependencies(mlir-headers
+add_custom_target(MLIRSubstraitIncGen
+  DEPENDS
   MLIRSubstraitOpsIncGen
+  MLIRSubstraitEnumsIncGen
+  MLIRSubstraitAttrsIncGen
+  MLIRSubstraitInterfacesIncGen
 )

--- a/lib/Dialect/Substrait/IR/CMakeLists.txt
+++ b/lib/Dialect/Substrait/IR/CMakeLists.txt
@@ -7,5 +7,5 @@ add_mlir_dialect_library(MLIRSubstraitDialect
   MLIRIR
 
   DEPENDS
-  MLIRSubstraitOpsIncGen
+  MLIRSubstraitIncGen
 )


### PR DESCRIPTION
For a while, CI sporadically fails due to some generated headers not being found. I have finally understood why this happens. This PR fixes the dependencies among the generated headers and the main dialect target.