### PR TITLE
feat: add support for decimal values

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -176,6 +176,30 @@ def Substrait_VersionAttr : Substrait_Attr<"Version", "version"> {
   ];
 }
 
+def Substrait_DecimalAttr : Substrait_StaticallyTypedAttr<"Decimal", "decimal",
+                                      "DecimalType"> {
+  let summary = "Substrait decimal type";
+  let description = [{
+    This type represents a substrait decimal attribute type. The attribute is backed
+    by an IntegerAttr `value` which stores the 128-bit decimal value as an APInt.
+  }];
+  let parameters = (ins "DecimalType":$type, "IntegerAttr":$value);
+  let genVerifyDecl = 1;
+
+  // #substrait.decimal<"{integer}.{fraction}" : !substrait.decimal<{P}, {S}>>
+  let hasCustomAssemblyFormat = 1;
+
+  let builders = [
+    // Builder that accepts a string representation of the decimal value.
+    AttrBuilder<(ins "DecimalType":$type, "StringRef":$value)>,
+  ];
+
+  let extraClassDeclaration = [{
+    // Returns a string representation of the decimal value.
+    std::string decimalStr() const;
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Helpers and constraints
 //===----------------------------------------------------------------------===//
@@ -193,7 +217,7 @@ def Substrait_AtomicAttributes {
     F64Attr, // FP64
     TypedStrAttr<Substrait_StringType>, // String
     TypedStrAttr<Substrait_BinaryType>, // Binary
-    TypedStrAttr<Substrait_DecimalType>, // Decimal
+    Substrait_DecimalAttr, // Decimal
     Substrait_TimestampAttr, // Timestamp
     Substrait_TimestampTzAttr, // TimestampTZ
     Substrait_DateAttr, // Date

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitAttrs.td
@@ -193,6 +193,7 @@ def Substrait_AtomicAttributes {
     F64Attr, // FP64
     TypedStrAttr<Substrait_StringType>, // String
     TypedStrAttr<Substrait_BinaryType>, // Binary
+    TypedStrAttr<Substrait_DecimalType>, // Decimal
     Substrait_TimestampAttr, // Timestamp
     Substrait_TimestampTzAttr, // TimestampTZ
     Substrait_DateAttr, // Date

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -84,6 +84,16 @@ def Substrait_UUIDType : Substrait_Type<"UUID", "uuid"> {
   }];
 }
 
+def Substrait_DecimalType : Substrait_Type<"Decimal", "decimal"> {
+  let summary = "Substrait decimal type";
+  let description = [{
+    This type represents a substrait decimal type.
+  }];
+  let parameters = (ins "int32_t":$precision, "int32_t":$scale);
+  let assemblyFormat = "`<` $precision `,` $scale `>`";
+  let genVerifyDecl = 1;
+}
+
 /// Currently supported atomic types, listed in order of substrait specification.
 /// These correspond directly to the types in
 /// https://github.com/substrait-io/substrait/blob/main/proto/substrait/type.proto.
@@ -105,6 +115,7 @@ def Substrait_AtomicTypes {
     Substrait_IntervalYearMonthType, // IntervalYear
     Substrait_IntervalDaySecondType, // IntervalDay
     Substrait_UUIDType, // UUID
+    Substrait_DecimalType, // Decimal
   ];
 }
 

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -89,7 +89,7 @@ def Substrait_DecimalType : Substrait_Type<"Decimal", "decimal"> {
   let description = [{
     This type represents a substrait decimal type.
   }];
-  let parameters = (ins "int32_t":$precision, "int32_t":$scale);
+  let parameters = (ins "uint32_t":$precision, "uint32_t":$scale);
   let assemblyFormat = "`<` $precision `,` $scale `>`";
   let genVerifyDecl = 1;
 }

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -92,6 +92,25 @@ LogicalResult mlir::substrait::IntervalDaySecondAttr::verify(
 }
 
 //===----------------------------------------------------------------------===//
+// Substrait types
+//===----------------------------------------------------------------------===//
+
+LogicalResult mlir::substrait::DecimalType::verify(
+    llvm::function_ref<mlir::InFlightDiagnostic()> emitError, int32_t precision,
+    int32_t scale) {
+  if (precision > 38)
+    return emitError() << "precision must be in a range of [0..38] but got "
+                       << precision;
+
+  if (scale < 0 || scale > precision)
+    return emitError() << "scale must be in a range of [0..P] (P = "
+                       << precision << ")"
+                       << " but got " << scale;
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Substrait enums
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -987,14 +987,17 @@ SubstraitExporter::exportOperation(LiteralOp op) {
     std::string res(16, 0);
     llvm::StoreIntToMemory(uuid, reinterpret_cast<uint8_t *>(res.data()), 16);
     literal->set_uuid(res);
-  } else if (auto decimalType = dyn_cast<DecimalType>(literalType)) {
+  } // `DecimalType`.
+  else if (auto decimalType = dyn_cast<DecimalType>(literalType)) {
     auto decimal =
         std::make_unique<::substrait::proto::Expression_Literal_Decimal>();
-    auto decimalAttr = mlir::cast<StringAttr>(value);
-    std::string value = decimalAttr.getValue().str();
+    auto decimalAttr = mlir::cast<DecimalAttr>(value);
+    APInt value = decimalAttr.getValue().getValue();
+    std::string res(16, 0);
+    llvm::StoreIntToMemory(value, reinterpret_cast<uint8_t *>(res.data()), 16);
     decimal->set_scale(decimalType.getScale());
     decimal->set_precision(decimalType.getPrecision());
-    decimal->set_value(value);
+    decimal->set_value(res);
     literal->set_allocated_decimal(decimal.release());
   } else
     op->emitOpError("has unsupported value");

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -685,10 +685,15 @@ importLiteral(ImplicitLocOpBuilder builder,
     return builder.create<LiteralOp>(attr);
   }
   case Expression::Literal::LiteralTypeCase::kDecimal: {
-    auto attr =
-        StringAttr::get(message.decimal().value(),
-                        DecimalType::get(context, message.decimal().precision(),
-                                         message.decimal().scale()));
+    APInt var(128, 0);
+    llvm::LoadIntFromMemory(
+        var,
+        reinterpret_cast<const uint8_t *>(message.decimal().value().data()),
+        16);
+    DecimalType type = DecimalType::get(context, message.decimal().precision(),
+                                        message.decimal().scale());
+    IntegerAttr value = IntegerAttr::get(IntegerType::get(context, 128), var);
+    auto attr = DecimalAttr::get(context, type, value);
     return builder.create<LiteralOp>(attr);
   }
 

--- a/test/Dialect/Substrait/literal-invalid.mlir
+++ b/test/Dialect/Substrait/literal-invalid.mlir
@@ -6,7 +6,7 @@
 
 // -----
 
-// expected-error@+1 {{decimal value has incorrect number of digits after the decimal point: 123.453. Expected 2 as per the type '!substrait.decimal<10, 2>'}}
+// expected-error@+1 {{decimal value has incorrect number of digits after the decimal point (3). Expected <=2 as per the type '!substrait.decimal<10, 2>'}}
 %d0 = substrait.literal #substrait.decimal<"123.453" : !substrait.decimal<10, 2>>
 
 // -----

--- a/test/Dialect/Substrait/literal-invalid.mlir
+++ b/test/Dialect/Substrait/literal-invalid.mlir
@@ -3,3 +3,24 @@
 
 // expected-error@+1 {{unsuited attribute for literal value: unit}}
 %0 = substrait.literal unit
+
+// -----
+
+// expected-error@+1 {{decimal value has incorrect number of digits after the decimal point: 123.453. Expected 2 as per the type '!substrait.decimal<10, 2>'}}
+%d0 = substrait.literal #substrait.decimal<"123.453" : !substrait.decimal<10, 2>>
+
+// -----
+
+// expected-error@+1 {{invalid decimal value: 12e.45}}
+%d0 = substrait.literal #substrait.decimal<"12e.45" : !substrait.decimal<10, 2>>
+
+// -----
+
+// expected-error@+1 {{decimal value has too many digits (39). Expected at most 38 digits}}
+%d0 = substrait.literal #substrait.decimal<"11111111111111111111111111111111111111.1" : !substrait.decimal<10, 1>>
+
+// -----
+
+// expected-error@+1 {{value must have at most '37' digits as per the type ''!substrait.decimal<37, 1>'' but got 38}}
+%d0 = substrait.literal #substrait.decimal<"1111111111111111111111111111111111113.2" : !substrait.decimal<37, 1>>
+

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -230,23 +230,15 @@ substrait.plan version 0 : 42 : 1 {
 
 // -----
 
-// CHECK:   substrait.plan version 0 : 42 : 1 {
-// CHECK-NEXT:           relation {
-// CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : tuple<si1>
-// CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : tuple<si1> -> tuple<si1, !substrait.decimal<10, 2>> {
-// CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<si1>):
-// CHECK-NEXT:               %[[VAL_3:.*]] = literal "123.45" : !substrait.decimal<10, 2>
-// CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<10, 2>
-// CHECK-NEXT:             }
-// CHECK-NEXT:             yield %[[VAL_1]] : tuple<si1, !substrait.decimal<10, 2>>
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    %0 = named_table @t1 as ["a"] : tuple<si1>
-    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.decimal<10, 2>> {
-    ^bb0(%arg : tuple<si1>):
-      %decimal = literal "123.45" : !substrait.decimal<10, 2>
-      yield %decimal :!substrait.decimal<10, 2>
-    }
-    yield %1 : tuple<si1, !substrait.decimal<10, 2>>
-  }
-}
+// CHECK:         %[[VAL_8:.*]] = substrait.literal #substrait.decimal<"1234567.89" : !substrait.decimal<9, 2>>
+// CHECK:         %[[VAL_9:.*]] = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
+// CHECK:         %[[VAL_10:.*]] = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
+// CHECK:         %[[VAL_11:.*]] = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
+// CHECK:         %[[VAL_12:.*]] = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
+// CHECK:         %[[VAL_13:.*]] = substrait.literal #substrait.decimal<"1111111111111111111111111111111111113.2" : !substrait.decimal<38, 1>>
+%d0 = substrait.literal #substrait.decimal<"1234567.89" : !substrait.decimal<9, 2>>
+%d1 = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
+%d2 = substrait.literal #substrait.decimal<"000.123" : !substrait.decimal<3, 3>>
+%d3 = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
+%d4 = substrait.literal #substrait.decimal<"123.000" : !substrait.decimal<3, 0>>
+%d5 = substrait.literal #substrait.decimal<"1111111111111111111111111111111111113.2" : !substrait.decimal<38, 1>>

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -227,3 +227,26 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si1, si1, si8, si16, si32, si64>
   }
 }
+
+// -----
+
+// CHECK:   substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:           relation {
+// CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : tuple<si1>
+// CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : tuple<si1> -> tuple<si1, !substrait.decimal<10, 2>> {
+// CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<si1>):
+// CHECK-NEXT:               %[[VAL_3:.*]] = literal "123.45" : !substrait.decimal<10, 2>
+// CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<10, 2>
+// CHECK-NEXT:             }
+// CHECK-NEXT:             yield %[[VAL_1]] : tuple<si1, !substrait.decimal<10, 2>>
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.decimal<10, 2>> {
+    ^bb0(%arg : tuple<si1>):
+      %decimal = literal "123.45" : !substrait.decimal<10, 2>
+      yield %decimal :!substrait.decimal<10, 2>
+    }
+    yield %1 : tuple<si1, !substrait.decimal<10, 2>>
+  }
+}

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -230,15 +230,23 @@ substrait.plan version 0 : 42 : 1 {
 
 // -----
 
-// CHECK:         %[[VAL_8:.*]] = substrait.literal #substrait.decimal<"1234567.89" : !substrait.decimal<9, 2>>
-// CHECK:         %[[VAL_9:.*]] = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
-// CHECK:         %[[VAL_10:.*]] = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
-// CHECK:         %[[VAL_11:.*]] = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
-// CHECK:         %[[VAL_12:.*]] = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
-// CHECK:         %[[VAL_13:.*]] = substrait.literal #substrait.decimal<"1111111111111111111111111111111111113.2" : !substrait.decimal<38, 1>>
+// CHECK: %[[V8:.*]] = substrait.literal #substrait.decimal<"1234567.89" : !substrait.decimal<9, 2>>
+// CHECK: %[[V9:.*]] = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
+// CHECK: %[[V10:.*]] = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
+// CHECK: %[[V11:.*]] = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
+// CHECK: %[[V12:.*]] = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
+// CHECK: %[[V13:.*]] = substrait.literal #substrait.decimal<"1111111111111111111111111111111111113.2" : !substrait.decimal<38, 1>>
+// CHECK: %[[V14:.*]] = substrait.literal #substrait.decimal<"0.12" : !substrait.decimal<3, 3>>
+// CHECK: %[[V15:.*]] = substrait.literal #substrait.decimal<"12.0345" : !substrait.decimal<20, 10>>
+// CHECK: %[[V16:.*]] = substrait.literal #substrait.decimal<"1234.0" : !substrait.decimal<20, 10>>
+// CHECK: %[[V17:.*]] = substrait.literal #substrait.decimal<"1234.0" : !substrait.decimal<20, 10>>
 %d0 = substrait.literal #substrait.decimal<"1234567.89" : !substrait.decimal<9, 2>>
 %d1 = substrait.literal #substrait.decimal<"0.123" : !substrait.decimal<3, 3>>
 %d2 = substrait.literal #substrait.decimal<"000.123" : !substrait.decimal<3, 3>>
 %d3 = substrait.literal #substrait.decimal<"123.0" : !substrait.decimal<3, 0>>
 %d4 = substrait.literal #substrait.decimal<"123.000" : !substrait.decimal<3, 0>>
 %d5 = substrait.literal #substrait.decimal<"1111111111111111111111111111111111113.2" : !substrait.decimal<38, 1>>
+%d6 = substrait.literal #substrait.decimal<"0.12" : !substrait.decimal<3, 3>>
+%d7 = substrait.literal #substrait.decimal<"12.0345" : !substrait.decimal<20, 10>>
+%d8 = substrait.literal #substrait.decimal<"1234.0" : !substrait.decimal<20, 10>>
+%d9 = substrait.literal #substrait.decimal<"00001234.0000" : !substrait.decimal<20, 10>>

--- a/test/Dialect/Substrait/types-invalid.mlir
+++ b/test/Dialect/Substrait/types-invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: substrait-opt -verify-diagnostics -split-input-file %s
+
+// expected-error@+1 {{precision must be in a range of [0..38] but got 40}}
+%0 = substrait.literal "0.42" : !substrait.decimal<40, 2>
+
+// -----
+
+// expected-error@+1 {{scale must be in a range of [0..P] (P = 3) but got 4}}
+%0 = substrait.literal "0.42" : !substrait.decimal<3, 4>
+
+// -----
+
+// expected-error@+1 {{scale must be in a range of [0..P] (P = 3) but got -1}}
+%0 = substrait.literal "0.42" : !substrait.decimal<3, -1>

--- a/test/Dialect/Substrait/types-invalid.mlir
+++ b/test/Dialect/Substrait/types-invalid.mlir
@@ -7,8 +7,3 @@
 
 // expected-error@+1 {{scale must be in a range of [0..P] (P = 3) but got 4}}
 %0 = substrait.literal "0.42" : !substrait.decimal<3, 4>
-
-// -----
-
-// expected-error@+1 {{scale must be in a range of [0..P] (P = 3) but got -1}}
-%0 = substrait.literal "0.42" : !substrait.decimal<3, -1>

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -3,6 +3,19 @@
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
+// CHECK-NEXT:    yield %0 : tuple<!substrait.decimal<12, 2>>
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<!substrait.decimal<12, 2>>
+    yield %0 : tuple<!substrait.decimal<12, 2>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : tuple<!substrait.uuid>
 // CHECK-NEXT:    yield %0 : tuple<!substrait.uuid>
 

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -298,3 +298,34 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si1, si1, si8, si16, si32, si64>
   }
 }
+
+// -----
+
+
+// CHECK: relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     project {
+// CHECK-NEXT:       common {
+// CHECK-NEXT:         direct {
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:       input {
+// CHECK-NEXT:         read {
+// CHECK:       expressions {
+// CHECK-NEXT:         literal {
+// CHECK-NEXT:           decimal {
+// CHECK-NEXT:             value: "\005\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+// CHECK-NEXT:             precision: 9
+// CHECK-NEXT:             scale: 2
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si1>
+    %1 = project %0 : tuple<si1> -> tuple<si1, !substrait.decimal<9, 2>> {
+    ^bb0(%arg : tuple<si1>):
+      %hi = literal #substrait.decimal<"0.05" : !substrait.decimal<9, 2>>
+      yield %hi : !substrait.decimal<9, 2>
+    }
+    yield %1 : tuple<si1, !substrait.decimal<9, 2>>
+  }
+}

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -301,16 +301,6 @@ substrait.plan version 0 : 42 : 1 {
 
 // -----
 
-
-// CHECK: relations {
-// CHECK-NEXT:   rel {
-// CHECK-NEXT:     project {
-// CHECK-NEXT:       common {
-// CHECK-NEXT:         direct {
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:       input {
-// CHECK-NEXT:         read {
 // CHECK:       expressions {
 // CHECK-NEXT:         literal {
 // CHECK-NEXT:           decimal {

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -549,7 +549,7 @@ version {
 # CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : tuple<f32>
 # CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : tuple<f32> -> tuple<f32, !substrait.decimal<3, 2>> {
 # CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<f32>):
-# CHECK-NEXT:               %[[VAL_3:.*]] = literal "0.05" : !substrait.decimal<3, 2>
+# CHECK-NEXT:               %[[VAL_3:.*]] = literal #substrait.decimal<"0.05" : !substrait.decimal<3, 2>>
 # CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<3, 2>
 # CHECK-NEXT:             }
 # CHECK-NEXT:             yield %[[VAL_1]] : tuple<f32, !substrait.decimal<3, 2>>
@@ -586,7 +586,7 @@ relations {
       expressions {
         literal {
           decimal: {
-            value: "0.05",
+            value: "\005\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000",
             precision: 3,
             scale: 2
           }

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -541,3 +541,61 @@ version {
   minor_number: 42
   patch_number: 1
 }
+
+# -----
+
+# CHECK:   substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:           relation {
+# CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : tuple<f32>
+# CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : tuple<f32> -> tuple<f32, !substrait.decimal<3, 2>> {
+# CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<f32>):
+# CHECK-NEXT:               %[[VAL_3:.*]] = literal "0.05" : !substrait.decimal<3, 2>
+# CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<3, 2>
+# CHECK-NEXT:             }
+# CHECK-NEXT:             yield %[[VAL_1]] : tuple<f32, !substrait.decimal<3, 2>>
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                fp32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          decimal: {
+            value: "0.05",
+            precision: 3,
+            scale: 2
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -467,3 +467,41 @@ version {
   minor_number: 42
   patch_number: 1
 }
+
+# -----
+
+# CHECK:      substrait.plan
+# CHECK-NEXT:   relation
+# CHECK-NEXT:     named_table
+# CHECK-SAME:       : tuple<!substrait.decimal<12, 3>>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            decimal {
+              nullability: NULLABILITY_REQUIRED
+              precision: 12
+              scale: 3
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
Adds the required type and attribute to support decimal values. Decimal values are represented as `TypedStrAttr`'d constrained strings with `DecimalType`s. Decimal types follow the constraints outlined in the [substrait docs](https://substrait.io/types/type_classes/).