### PR TITLE
build: use and adapt to more recent Protobuf from `substrait-cpp`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies from apt
       uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
       with:
-        packages: protobuf-compiler libprotobuf-dev libcurl4-gnutls-dev
+        packages: libcurl4-gnutls-dev
         version: 1.0
 
     - name: Checkout project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,6 @@ option(SUBSTRAIT_MLIR_COMPILE_WARNING_AS_ERROR
        OFF)
 
 ################################################################################
-# Set up dependencies
-################################################################################
-
-# Required for Substrait. v3.6.1 provided by Ubuntu 20.04 did not work due to
-# an incompatibility with `-fno-rtti`, which LLVM uses, while v3.12.4 provided
-# by Ubuntu 22.04 worked. Possibly some versions inbetween work as well.
-find_package(Protobuf 3.12.0 REQUIRED)
-
-################################################################################
 # Set some variables
 ################################################################################
 set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)

--- a/README.md
+++ b/README.md
@@ -199,15 +199,13 @@ for the `LLVM_EXTERNAL_PROJECTS` config setting).
 
 ### Prerequisites
 
-You need to have the following software installed and in your `PATH` or
-[discoverable](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html)
-by CMake:
+You need to have the following software installed and in your `PATH`:
 
 * `git`
 * [`ninja`](<https://ninja-build.org/>)
-* [LLVM prerequisites](https://llvm.org/docs/GettingStarted.html#software) and a
+* [LLVM prerequisites](https://llvm.org/docs/GettingStarted.html#software)
+  including [CMake](https://cmake.org/download/) and a
   [C/C++ toolchain](https://llvm.org/docs/GettingStarted.html#host-c-toolchain-both-compiler-and-standard-library)
-* Protobuf >= 3.12 (compiler, runtime, and headers)
 
 ### Define Paths
 

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -18,12 +18,17 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
 
+// TODO(ingomueller): Find a way to make `substrait-cpp` declare these headers
+// as system headers and remove the diagnostic fiddling here.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
 #include <substrait/proto/algebra.pb.h>
 #include <substrait/proto/extensions/extensions.pb.h>
 #include <substrait/proto/plan.pb.h>
 #include <substrait/proto/type.pb.h>
+#pragma clang diagnostic pop
 
 using namespace mlir;
 using namespace mlir::substrait;
@@ -31,9 +36,9 @@ using namespace mlir::substrait::protobuf_utils;
 using namespace ::substrait;
 using namespace ::substrait::proto;
 
-namespace pb = google::protobuf;
-
 namespace {
+
+namespace pb = ::google::protobuf;
 
 /// Main structure to drive export from the dialect to protobuf. This class
 /// holds the visitor functions for the various ops etc. from the dialect as
@@ -1499,6 +1504,8 @@ SubstraitExporter::exportOperation(Operation *op) {
 namespace mlir {
 namespace substrait {
 
+namespace pb = ::google::protobuf;
+
 LogicalResult
 translateSubstraitToProtobuf(Operation *op, llvm::raw_ostream &output,
                              substrait::ImportExportOptions options) {
@@ -1523,10 +1530,10 @@ translateSubstraitToProtobuf(Operation *op, llvm::raw_ostream &output,
     break;
   case substrait::SerdeFormat::kJson:
   case substrait::SerdeFormat::kPrettyJson: {
-    pb::util::JsonOptions jsonOptions;
+    pb::util::JsonPrintOptions jsonOptions;
     if (options.serdeFormat == SerdeFormat::kPrettyJson)
       jsonOptions.add_whitespace = true;
-    pb::util::Status status =
+    absl::Status status =
         pb::util::MessageToJsonString(*result.value(), &out, jsonOptions);
     if (!status.ok()) {
       InFlightDiagnostic diag =

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -14,8 +14,11 @@
 #include "mlir/IR/OwningOpRef.h"
 #include "substrait-mlir/Dialect/Substrait/IR/Substrait.h"
 #include "substrait-mlir/Target/SubstraitPB/Options.h"
-#include "llvm/ADT/SmallSet.h"
 
+// TODO(ingomueller): Find a way to make `substrait-cpp` declare these headers
+// as system headers and remove the diagnostic fiddling here.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
@@ -23,6 +26,7 @@
 #include <substrait/proto/extensions/extensions.pb.h>
 #include <substrait/proto/plan.pb.h>
 #include <substrait/proto/type.pb.h>
+#pragma clang diagnostic pop
 
 using namespace mlir;
 using namespace mlir::substrait;
@@ -30,9 +34,9 @@ using namespace mlir::substrait::protobuf_utils;
 using namespace ::substrait;
 using namespace ::substrait::proto;
 
-namespace pb = google::protobuf;
-
 namespace {
+
+namespace pb = ::google::protobuf;
 
 using ImportedNamedStruct = std::tuple<ArrayAttr, TupleType>;
 
@@ -1163,12 +1167,11 @@ OwningOpRef<ModuleOp> translateProtobufToSubstraitTopLevel(
     break;
   case SerdeFormat::kJson:
   case SerdeFormat::kPrettyJson: {
-    pb::util::Status status =
-        pb::util::JsonStringToMessage(input.str(), &message);
+    absl::Status status = pb::util::JsonStringToMessage(input.str(), &message);
     if (!status.ok()) {
       emitError(loc) << "could not deserialize JSON as '"
                      << message.GetTypeName() << "' message:\n"
-                     << status.message().as_string();
+                     << status.message();
       return {};
     }
   }

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -9,15 +9,20 @@
 #include "ProtobufUtils.h"
 #include "mlir/IR/Diagnostics.h"
 
+// TODO(ingomueller): Find a way to make `substrait-cpp` declare these headers
+// as system headers and remove the diagnostic fiddling here.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #include <substrait/proto/algebra.pb.h>
+#pragma clang diagnostic pop
 
 using namespace mlir;
 using namespace ::substrait;
 using namespace ::substrait::proto;
 
-namespace pb = google::protobuf;
-
 namespace mlir::substrait::protobuf_utils {
+
+namespace pb = ::google::protobuf;
 
 template <typename RelType>
 static const RelCommon *getCommon(const RelType &rel) {

--- a/test/python/dialects/substrait/translate.py
+++ b/test/python/dialects/substrait/translate.py
@@ -102,8 +102,7 @@ def testInvalid():
   try:
     ss.from_json('this is not json')
     # CHECK-NEXT: error: could not deserialize JSON as 'substrait.proto.Plan' message:
-    # CHECK-NEXT: Unexpected token.
-    # CHECK-NEXT: this is not json
+    # CHECK-NEXT: invalid JSON
   except ValueError as ex:
     print(ex)
     # CHECK:      Could not import Substrait plan


### PR DESCRIPTION
This PR upgrades the codebase to the more recent Protobuf version downloaded and compiled by `substrait-cpp`. Previously, we used `find_package` from our CMake files, even though we don't use those targets directly and only use those imported by `substrait-cpp` already. Also, since recently, `substrait-cpp` can download Protobuf if none is installed in the systems, so we rely on that mechanism in CI now. Since that version is newer than the one we used in CI until now, the PR also updates the code base to the new version.

The PR suppresses some warnings in the headers of the new Protobuf version, which are errors in CI due to our using of `-Werror`, by setting some diagnostic pragmas. However, it would be better if those headers were imported as `SYSTEM` headers by `substrait-cpp`, but I still need to figure out how to do that and update that repository accordingly.