### PR TITLE
build: minor clean-ups of the main `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
 set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
 set(SUBSTRAIT_MLIR_MAIN_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(SUBSTRAIT_MLIR_INCLUDE_DIRS ${SUBSTRAIT_MLIR_MAIN_SRC_DIR}/include)
+set(SUBSTRAIT_MLIR_INCLUDE_DIR ${SUBSTRAIT_MLIR_MAIN_SRC_DIR}/include)
 set(SUBSTRAIT_MLIR_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(SUBSTRAIT_MLIR_TABLEGEN_OUTPUT_DIR ${SUBSTRAIT_MLIR_BINARY_DIR}/include)
 message(STATUS "Substrait MLIR build directory: ${SUBSTRAIT_MLIR_BINARY_DIR}")
@@ -44,9 +44,8 @@ message(STATUS "Substrait MLIR build directory: ${SUBSTRAIT_MLIR_BINARY_DIR}")
 ################################################################################
 include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
 include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})
-include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
 
-include_directories(${SUBSTRAIT_MLIR_INCLUDE_DIRS})
+include_directories(${SUBSTRAIT_MLIR_INCLUDE_DIR})
 include_directories(${SUBSTRAIT_MLIR_TABLEGEN_OUTPUT_DIR})
 
 ################################################################################


### PR DESCRIPTION
This PR does some minor clean-ups of the main CMakes file:
* Remove a call to `include_directories` with a variable that wasn't set.
* Rename a variable from `_DIRS` to `_DIR` because it only holds a single directory.