### PR TITLE
feat: collection of MSVC/Windows-related fixes

### DIFF
--- a/include/substrait-mlir/Target/SubstraitPB/Export.h
+++ b/include/substrait-mlir/Target/SubstraitPB/Export.h
@@ -9,15 +9,12 @@
 #ifndef SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_EXPORT_H
 #define SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_EXPORT_H
 
+#include "mlir/Support/LogicalResult.h"
 #include "substrait-mlir/Target/SubstraitPB/Options.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace llvm {
-class LogicalResult;
-}
 namespace mlir {
 class Operation;
-using LogicalResult = llvm::LogicalResult;
 
 namespace substrait {
 

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1497,12 +1497,9 @@ SubstraitExporter::exportOperation(Operation *op) {
 
 } // namespace
 
-namespace mlir {
-namespace substrait {
-
-LogicalResult
-translateSubstraitToProtobuf(Operation *op, llvm::raw_ostream &output,
-                             substrait::ImportExportOptions options) {
+LogicalResult mlir::substrait::translateSubstraitToProtobuf(
+    Operation *op, llvm::raw_ostream &output,
+    substrait::ImportExportOptions options) {
   SubstraitExporter exporter;
   FailureOr<std::unique_ptr<_pb::Message>> result =
       exporter.exportOperation(op);
@@ -1542,6 +1539,3 @@ translateSubstraitToProtobuf(Operation *op, llvm::raw_ostream &output,
   output << out;
   return success();
 }
-
-} // namespace substrait
-} // namespace mlir

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1499,7 +1499,7 @@ SubstraitExporter::exportOperation(Operation *op) {
 
 LogicalResult mlir::substrait::translateSubstraitToProtobuf(
     Operation *op, llvm::raw_ostream &output,
-    substrait::ImportExportOptions options) {
+    mlir::substrait::ImportExportOptions options) {
   SubstraitExporter exporter;
   FailureOr<std::unique_ptr<_pb::Message>> result =
       exporter.exportOperation(op);

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -1190,23 +1190,16 @@ OwningOpRef<ModuleOp> translateProtobufToSubstraitTopLevel(
 
 } // namespace
 
-namespace mlir {
-namespace substrait {
-
-OwningOpRef<ModuleOp>
-translateProtobufToSubstraitPlan(llvm::StringRef input, MLIRContext *context,
-                                 ImportExportOptions options) {
+OwningOpRef<ModuleOp> mlir::substrait::translateProtobufToSubstraitPlan(
+    llvm::StringRef input, MLIRContext *context, ImportExportOptions options) {
 
   Plan plan;
   return translateProtobufToSubstraitTopLevel(input, context, options, plan);
 }
 
-OwningOpRef<ModuleOp> translateProtobufToSubstraitPlanVersion(
+OwningOpRef<ModuleOp> mlir::substrait::translateProtobufToSubstraitPlanVersion(
     llvm::StringRef input, MLIRContext *context, ImportExportOptions options) {
   PlanVersion planVersion;
   return translateProtobufToSubstraitTopLevel(input, context, options,
                                               planVersion);
 }
-
-} // namespace substrait
-} // namespace mlir

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -15,7 +15,7 @@ using namespace mlir;
 using namespace ::substrait;
 using namespace ::substrait::proto;
 
-namespace pb = google::protobuf;
+namespace _pb = google::protobuf;
 
 namespace mlir::substrait::protobuf_utils {
 
@@ -44,7 +44,7 @@ FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
   case Rel::RelTypeCase::kSet:
     return getCommon(rel.set());
   default:
-    const pb::FieldDescriptor *desc =
+    const _pb::FieldDescriptor *desc =
         Rel::GetDescriptor()->FindFieldByNumber(relType);
     return emitError(loc) << Twine("unsupported Rel type: ") + desc->name();
   }
@@ -75,7 +75,7 @@ FailureOr<RelCommon *> getMutableCommon(Rel *rel, Location loc) {
   case Rel::RelTypeCase::kSet:
     return getMutableCommon(rel->mutable_set());
   default:
-    const pb::FieldDescriptor *desc =
+    const _pb::FieldDescriptor *desc =
         Rel::GetDescriptor()->FindFieldByNumber(relType);
     return emitError(loc) << Twine("unsupported Rel type: ") + desc->name();
   }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,6 +27,8 @@ declare_mlir_python_extension(SubstraitMLIRPythonSources.DialectExtension
   SubstraitDialects.cpp
   EMBED_CAPI_LINK_LIBS
   SubstraitMLIRCAPI
+  PRIVATE_LINK_LIBS
+  LLVMSupport
   PYTHON_BINDINGS_LIBRARY nanobind
 )
 


### PR DESCRIPTION
This PR adds some minor fixes that MSVC complains about on Windows.

* fix pb namespace redefinition: namespace `pb` may already be defined [here](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/extension_set.h#L77) (in case the depending build gets protobuf from there).
* Modifies usage of `google::protobuf::util::Status` to `auto`. `google::protobuf::util::Status` alias to `absl::Status` but that isn't being handled properly on MSVC. `auto` should make all platforms happy :).
* Added missing link to `LLVMSupport` for the `_substraitDialects` Python library.
