### PR TITLE
feat: add missing LLVMSupport link

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,6 +27,8 @@ declare_mlir_python_extension(SubstraitMLIRPythonSources.DialectExtension
   SubstraitDialects.cpp
   EMBED_CAPI_LINK_LIBS
   SubstraitMLIRCAPI
+  PRIVATE_LINK_LIBS
+  LLVMSupport
   PYTHON_BINDINGS_LIBRARY nanobind
 )
 


### PR DESCRIPTION
This appears to only be an issue on MSVC.