### PR TITLE
build: remove unnecessary (incorrect) LLVM CMake includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,6 @@ include(MLIRDetectPythonEnv)
 mlir_configure_python_dev_packages()
 
 ################################################################################
-# Enable LLVM stuff
-################################################################################
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
-
-################################################################################
 # Dependencies from git sub-modules
 ################################################################################
 add_subdirectory(third_party)


### PR DESCRIPTION
Resolves https://github.com/substrait-io/substrait-mlir-contrib/issues/103.