### PR TITLE
test: add tooling for new `Round-Trip` test type

### DIFF
--- a/requirements-unfrozen.txt
+++ b/requirements-unfrozen.txt
@@ -7,6 +7,7 @@ duckdb==1.1.3
 ibis==3.3.0
 ibis-framework==8.0.0
 ibis-substrait==3.2.0
+json5
 pyarrow
 pyright
 yapf

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ fonttools==4.55.8
 ibis==3.3.0
 ibis-framework==8.0.0
 ibis-substrait==3.2.0
+json5==0.10.0
 kiwisolver==1.4.8
 markdown-it-py==3.0.0
 matplotlib==3.10.0

--- a/test/Target/SubstraitPB/Round-Trip/simple.json
+++ b/test/Target/SubstraitPB/Round-Trip/simple.json
@@ -2,7 +2,7 @@
 // RUN: normalize-json -i %s | \
 // RUN:   json-to-substrait | substrait-to-json | \
 // RUN:   normalize-json > %{t:stem}.mlir.json
-// RUN: diff -pu %{t:stem}.orig.json %{t:stem}.mlir.json
+// RUN: diff %{t:stem}.orig.json %{t:stem}.mlir.json
 {
   "version": {
     "minorNumber": 42,

--- a/test/Target/SubstraitPB/Round-Trip/simple.json
+++ b/test/Target/SubstraitPB/Round-Trip/simple.json
@@ -1,0 +1,253 @@
+// RUN: normalize-json -i %s > %{t:stem}.orig.json
+// RUN: normalize-json -i %s | \
+// RUN:   substrait-translate \
+// RUN:     --split-input-file  --output-split-marker="// ""-----" \
+// RUN:     --protobuf-to-substrait --substrait-protobuf-format=json | \
+// RUN:   substrait-translate \
+// RUN:     --substrait-to-protobuf --substrait-protobuf-format=pretty-json \
+// RUN:     --split-input-file  --output-split-marker="// ""-----" | \
+// RUN:   normalize-json > %{t:stem}.mlir.json
+// RUN: diff -pu %{t:stem}.orig.json %{t:stem}.mlir.json
+{
+  "version": {
+    "minorNumber": 42,
+    "patchNumber": 1,
+    "gitHash": "hash",
+    "producer": "producer"
+  }
+}
+// -----
+{
+  "relations": [
+    {
+      "rel": {
+        "read": {
+          "common": {
+            "direct": {}
+          },
+          "baseSchema": {
+            "names": [
+              "a",
+              "b"
+            ],
+            "struct": {
+              "types": [
+                {
+                  "i32": {
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                {
+                  "i32": {
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                }
+              ],
+              "nullability": "NULLABILITY_REQUIRED"
+            }
+          },
+          "namedTable": {
+            "names": [
+              "foo",
+              "bar"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 42,
+    "patchNumber": 1
+  }
+}
+// -----
+{
+  "relations": [
+    {
+      "rel": {
+        "read": {
+          "common": {
+            "direct": {}
+          },
+          "baseSchema": {
+            "names": [
+              "a",
+              "b"
+            ],
+            "struct": {
+              "types": [
+                {
+                  "i32": {
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                {
+                  "i32": {
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                }
+              ],
+              "nullability": "NULLABILITY_REQUIRED"
+            }
+          },
+          "namedTable": {
+            "names": [
+              "foo",
+              "bar"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "rel": {
+        "read": {
+          "common": {
+            "direct": {}
+          },
+          "baseSchema": {
+            "names": [
+              "a",
+              "b"
+            ],
+            "struct": {
+              "types": [
+                {
+                  "i32": {
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                {
+                  "i32": {
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                }
+              ],
+              "nullability": "NULLABILITY_REQUIRED"
+            }
+          },
+          "namedTable": {
+            "names": [
+              "foo",
+              "bar"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 42,
+    "patchNumber": 1
+  }
+}
+// -----
+{
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "read": {
+            "common": {
+              "direct": {}
+            },
+            "baseSchema": {
+              "names": [
+                "a",
+                "b",
+                "c"
+              ],
+              "struct": {
+                "types": [
+                  {
+                    "i32": {
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  {
+                    "struct": {
+                      "types": [
+                        {
+                          "i32": {
+                            "nullability": "NULLABILITY_REQUIRED"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "nullability": "NULLABILITY_REQUIRED"
+              }
+            },
+            "namedTable": {
+              "names": [
+                "t"
+              ]
+            }
+          }
+        },
+        "names": [
+          "x",
+          "y",
+          "z"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 42,
+    "patchNumber": 1
+  }
+}
+// -----
+{
+  "extensionUris": [
+    {
+      "uri": "http://some.url/with/extensions.yml"
+    },
+    {
+      "extensionUriAnchor": 1,
+      "uri": "http://other.url/with/more/extensions.yml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "name": "somefunc"
+      }
+    },
+    {
+      "extensionType": {
+        "name": "sometype"
+      }
+    },
+    {
+      "extensionTypeVariation": {
+        "name": "sometypevar"
+      }
+    },
+    {
+      "extensionFunction": {
+        "extensionUriReference": 1,
+        "functionAnchor": 1,
+        "name": "someotherfunc"
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 42,
+    "patchNumber": 1
+  }
+}
+// -----
+{
+  "expectedTypeUrls": [
+    "http://some.url/with/type.proto",
+    "http://other.url/with/type.proto"
+  ],
+  "version": {
+    "minorNumber": 42,
+    "patchNumber": 1
+  }
+}

--- a/test/Target/SubstraitPB/Round-Trip/simple.json
+++ b/test/Target/SubstraitPB/Round-Trip/simple.json
@@ -1,11 +1,6 @@
 // RUN: normalize-json -i %s > %{t:stem}.orig.json
 // RUN: normalize-json -i %s | \
-// RUN:   substrait-translate \
-// RUN:     --split-input-file  --output-split-marker="// ""-----" \
-// RUN:     --protobuf-to-substrait --substrait-protobuf-format=json | \
-// RUN:   substrait-translate \
-// RUN:     --substrait-to-protobuf --substrait-protobuf-format=pretty-json \
-// RUN:     --split-input-file  --output-split-marker="// ""-----" | \
+// RUN:   json-to-substrait | substrait-to-json | \
 // RUN:   normalize-json > %{t:stem}.mlir.json
 // RUN: diff -pu %{t:stem}.orig.json %{t:stem}.mlir.json
 {

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -79,9 +79,27 @@ def add_runtime(name):
 mlir_async_runtime = add_runtime("mlir_async_runtime")
 mlir_c_runner_utils = add_runtime("mlir_c_runner_utils")
 mlir_runner_utils = add_runtime("mlir_runner_utils")
+
+# Define substituations for round-trip tests.
 normalize_json = ToolSubst(
     "normalize-json",
     config.substrait_mlir_main_src_dir + "/tools/scripts/normalize_json.py")
+json_to_substrait = ToolSubst("json-to-substrait",
+                              'substrait-translate',
+                              extra_args=[
+                                  "--split-input-file",
+                                  "--output-split-marker='// -----'",
+                                  "--protobuf-to-substrait",
+                                  "--substrait-protobuf-format=json"
+                              ])
+substrait_to_json = ToolSubst("substrait-to-json",
+                              'substrait-translate',
+                              extra_args=[
+                                  "--split-input-file",
+                                  "--output-split-marker='// -----'",
+                                  "--substrait-to-protobuf",
+                                  "--substrait-protobuf-format=pretty-json"
+                              ])
 
 config.environment['MLIR_ASYNC_RUNTIME_LIB'] = mlir_async_runtime.command
 config.environment['MLIR_C_RUNNER_UTILS_LIB'] = mlir_c_runner_utils.command
@@ -95,6 +113,8 @@ tools = [
     mlir_c_runner_utils,
     mlir_runner_utils,
     normalize_json,
+    json_to_substrait,
+    substrait_to_json,
     'substrait-opt',
     ToolSubst('%mlir_lib_dir', config.mlir_lib_dir),
 ]

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -120,6 +120,7 @@ tools = [
     substrait_to_json,
     'substrait-opt',
     ToolSubst('%mlir_lib_dir', config.mlir_lib_dir),
+    ToolSubst('diff', 'diff', extra_args=[] if os.name == 'nt' else ['-u']),
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -81,6 +81,8 @@ mlir_c_runner_utils = add_runtime("mlir_c_runner_utils")
 mlir_runner_utils = add_runtime("mlir_runner_utils")
 
 # Define substituations for round-trip tests.
+# TODO(ingomueller,mortbopet): Consider replacing these substitutions and the
+#   Python script with the ideas outlined in #111, which seem more robust.
 normalize_json = ToolSubst("normalize-json",
                            sys.executable,
                            extra_args=[

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -81,9 +81,12 @@ mlir_c_runner_utils = add_runtime("mlir_c_runner_utils")
 mlir_runner_utils = add_runtime("mlir_runner_utils")
 
 # Define substituations for round-trip tests.
-normalize_json = ToolSubst(
-    "normalize-json",
-    config.substrait_mlir_main_src_dir + "/tools/scripts/normalize_json.py")
+normalize_json = ToolSubst("normalize-json",
+                           sys.executable,
+                           extra_args=[
+                               config.substrait_mlir_main_src_dir +
+                               "/tools/scripts/normalize_json.py"
+                           ])
 json_to_substrait = ToolSubst("json-to-substrait",
                               'substrait-translate',
                               extra_args=[

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -22,7 +22,7 @@ config.name = 'Substrait MLIR'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.mlir', '.textpb', '.py']
+config.suffixes = ['.json', '.mlir', '.textpb', '.py']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
@@ -56,6 +56,10 @@ config.excludes = [
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+llvm_config.with_environment('PATH',
+                             config.substrait_mlir_main_src_dir +
+                             "/tools/scripts/",
+                             append_path=True)
 
 
 # Copied from `third_party/llvm-project/mlir/test/lit.cfg.py`.
@@ -75,6 +79,9 @@ def add_runtime(name):
 mlir_async_runtime = add_runtime("mlir_async_runtime")
 mlir_c_runner_utils = add_runtime("mlir_c_runner_utils")
 mlir_runner_utils = add_runtime("mlir_runner_utils")
+normalize_json = ToolSubst(
+    "normalize-json",
+    config.substrait_mlir_main_src_dir + "/tools/scripts/normalize_json.py")
 
 config.environment['MLIR_ASYNC_RUNTIME_LIB'] = mlir_async_runtime.command
 config.environment['MLIR_C_RUNNER_UTILS_LIB'] = mlir_c_runner_utils.command
@@ -87,6 +94,7 @@ tools = [
     mlir_async_runtime,
     mlir_c_runner_utils,
     mlir_runner_utils,
+    normalize_json,
     'substrait-opt',
     ToolSubst('%mlir_lib_dir', config.mlir_lib_dir),
 ]

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -7,6 +7,7 @@ config.mlir_obj_dir = "@MLIR_BINARY_DIR@"
 config.mlir_lib_dir = "@MLIR_LIB_DIR@"
 config.enable_bindings_python = @MLIR_ENABLE_BINDINGS_PYTHON@
 config.substrait_mlir_build_root = "@SUBSTRAIT_MLIR_BINARY_DIR@"
+config.substrait_mlir_main_src_dir = "@SUBSTRAIT_MLIR_MAIN_SRC_DIR@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/tools/scripts/normalize_json.py
+++ b/tools/scripts/normalize_json.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 
+# ===-- normalize_json.py - Tool to normalize JSON files ------------------=== #
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------=== #
+
 import argparse
 import json
 import sys

--- a/tools/scripts/normalize_json.py
+++ b/tools/scripts/normalize_json.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from typing import Generator, IO
+
+import json5
+
+
+# Reads the given `file`` line by line until a stripped line is exactly equal to
+# the `separator` and yields every chunk between the separators (or the
+# beginning and end of the file).
+def split_file(file: IO, separator: str) -> Generator[str, None, None]:
+  chunk: list[str] = []
+  for line in file:
+    if line.strip() == separator:
+      yield ''.join(chunk)
+      chunk = []
+    else:
+      chunk.append(line)
+  yield ''.join(chunk)
+
+
+def main(argv: list[str]):
+  # Set up argument parser.
+  parser = argparse.ArgumentParser(
+      prog='normalize_python',
+      description='Brings a possibly split JSON file into a normalized file',
+  )
+  parser.add_argument('-i',
+                      '--input',
+                      default='-',
+                      help='Input JSON file. Use - for stdin.')
+  parser.add_argument('-s',
+                      '--separator',
+                      default='// -----',
+                      help='String that separates "splits" in the input file.')
+  args = parser.parse_args()
+
+  # Open file, then read, normalize, and print each chunk.
+  input_file = open(args.input, 'r') if args.input != '-' else sys.stdin
+  is_first_chunk = True
+  for chunk in split_file(input_file, args.separator):
+    if not is_first_chunk:
+      print(args.separator)
+    is_first_chunk = False
+    normalized = json.dumps(json5.loads(chunk), sort_keys=True, indent=2)
+    print(normalized)
+
+
+if __name__ == '__main__':
+  main(sys.argv)


### PR DESCRIPTION
This PR adds some infrastructure for testing that Substrait plans round-trip through `substrait-mlir` without loosing any information. This is currently based on the JSON format and consist in comparing (1) a normalized version of the input plan with (2) a normalized version of the plan after round-tripping it through `substrait-mlir`. JSON is maybe the format that makes this easiest and most robust since normalizing JSON can be done with mature tools (deserialize from and reserialize to JSON). The PR also extends LIT to run these tests and adds a test case that exercises the round-trip testing infrastructure on a couple of plans based on the `plan.mlir` cases from the current dialect tests.