### PR TITLE
test: use valid URLs and values for extension test cases

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -609,7 +609,7 @@ def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table"> {
 
     ```mlir
     %0 = extension_table
-           "some detail" : !substrait.any<"some url">
+           "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
            as ["a"] : tuple<si32>
     ```
   }];

--- a/test/Dialect/Substrait/extension-table.mlir
+++ b/test/Dialect/Substrait/extension-table.mlir
@@ -4,14 +4,14 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:           %[[V0:.*]] = extension_table
-// CHECK-SAME:        "some detail" : !substrait.any<"some url">
+// CHECK-SAME:         "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 // CHECK-SAME:        as ["a"] : tuple<si32>
 // CHECK-NEXT:      yield %[[V0]] : tuple<si32>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
-           "some detail" : !substrait.any<"some url">
+           "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
            as ["a"] : tuple<si32>
     yield %0 : tuple<si32>
   }

--- a/test/Dialect/Substrait/plan.mlir
+++ b/test/Dialect/Substrait/plan.mlir
@@ -91,14 +91,14 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK:      substrait.plan
 // CHECK-SAME:   advanced_extension
-// CHECK-SAME:     optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
-// CHECK-SAME:     enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+// CHECK-SAME:     optimization = "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:     enhancement = "\08\01" : !substrait.any<"type.googleapis.com/google.protobuf.BoolValue">
 // CHECK-NEXT: }
 
 substrait.plan version 0 : 42 : 1
     advanced_extension
-      optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
-      enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+      optimization = "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+      enhancement = "\08\01" : !substrait.any<"type.googleapis.com/google.protobuf.BoolValue">
 {}
 
 // -----

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -51,14 +51,16 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]]
-// CHECK-SAME:      advanced_extension optimization = "foo" : !substrait.any<"bar">
+// CHECK-SAME:      advanced_extension optimization = "\08*" :
+// CHECK-SAME:        !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 // CHECK-SAME:      tuple<si32> -> tuple<si32> {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = project %0
-            advanced_extension optimization = "foo" : !substrait.any<"bar">
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : tuple<si32> -> tuple<si32> {
     ^bb0(%arg0: tuple<si32>):
       yield

--- a/test/Target/SubstraitPB/Export/extension-table.mlir
+++ b/test/Target/SubstraitPB/Export/extension-table.mlir
@@ -29,8 +29,8 @@
 // CHECK-NEXT:       }
 // CHECK-NEXT:       extension_table {
 // CHECK-NEXT:         detail {
-// CHECK-NEXT:           type_url: "some url"
-// CHECK-NEXT:           value: "some detail"
+// CHECK-NEXT:           type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:           value: "\010*"
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }
@@ -41,7 +41,7 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
-           "some detail" : !substrait.any<"some url">
+           "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
            as ["a"] : tuple<si32>
     yield %0 : tuple<si32>
   }

--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -143,20 +143,20 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK:       advanced_extensions {
 // CHECK-NEXT:    optimization {
-// CHECK-NEXT:      type_url: "http://some.url/with/type.proto"
-// CHECK-NEXT:      value: "protobuf message"
+// CHECK-NEXT:      type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:      value: "\010*"
 // CHECK-NEXT:    }
 // CHECK-NEXT:    enhancement {
-// CHECK-NEXT:      type_url: "http://other.url/with/type.proto"
-// CHECK-NEXT:      value: "other protobuf message"
+// CHECK-NEXT:      type_url: "type.googleapis.com/google.protobuf.BoolValue"
+// CHECK-NEXT:      value: "\010\001"
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  version
 
 substrait.plan version 0 : 42 : 1
     advanced_extension
-      optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
-      enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+      optimization = "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+      enhancement = "\08\01" : !substrait.any<"type.googleapis.com/google.protobuf.BoolValue">
 {}
 
 // -----
@@ -168,7 +168,7 @@ substrait.plan version 0 : 42 : 1
 
 substrait.plan version 0 : 42 : 1
     advanced_extension
-      optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+      optimization = "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 {}
 
 // -----
@@ -180,7 +180,7 @@ substrait.plan version 0 : 42 : 1
 
 substrait.plan version 0 : 42 : 1
     advanced_extension
-      enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+      enhancement = "\08\01" : !substrait.any<"type.googleapis.com/google.protobuf.BoolValue">
 {}
 
 // -----

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -49,8 +49,8 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:             input {
 // CHECK:             advanced_extension {
 // CHECK-NEXT:        optimization {
-// CHECK-NEXT:          type_url: "bar"
-// CHECK-NEXT:          value: "foo"
+// CHECK-NEXT:          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:          value: "\010*"
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 
@@ -58,7 +58,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = project %0
-            advanced_extension optimization = "foo" : !substrait.any<"bar">
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : tuple<si32> -> tuple<si32> {
     ^bb0(%arg0: tuple<si32>):
       yield

--- a/test/Target/SubstraitPB/Import/extension-table.textpb
+++ b/test/Target/SubstraitPB/Import/extension-table.textpb
@@ -9,7 +9,7 @@
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = extension_table
-# CHECK-SAME:        "some detail" : !substrait.any<"some url">
+# CHECK-SAME:          "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 # CHECK-SAME:        as ["a"] : tuple<si32>
 # CHECK-NEXT:      yield %[[V0]] : tuple<si32>
 
@@ -33,8 +33,8 @@ relations {
       }
       extension_table {
         detail {
-          type_url: "some url"
-          value: "some detail"
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
         }
       }
     }

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -192,18 +192,18 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK-SAME:   advanced_extension
-# CHECK-SAME:     optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
-# CHECK-SAME:     enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+# CHECK-SAME:     optimization = "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:     enhancement = "\08\01" : !substrait.any<"type.googleapis.com/google.protobuf.BoolValue">
 # CHECK-NEXT: }
 
 advanced_extensions {
   optimization {
-    type_url: "http://some.url/with/type.proto"
-    value: "protobuf message"
+    type_url: "type.googleapis.com/google.protobuf.Int32Value"
+    value: "\010*"
   }
   enhancement {
-    type_url: "http://other.url/with/type.proto"
-    value: "other protobuf message"
+    type_url: "type.googleapis.com/google.protobuf.BoolValue"
+    value: "\010\01"
   }
 }
 version {
@@ -214,14 +214,14 @@ version {
 # -----
 
 # CHECK-LABEL: substrait.plan
-# CHECK-SAME:   advanced_extension
-# CHECK-SAME:     optimization = "protobuf message" : !substrait.any<"http://some.url/with/type.proto">
+# CHECK-SAME:   advanced_extension optimization
+# CHECK-SAME:     "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 # CHECK-NEXT: }
 
 advanced_extensions {
   optimization {
-    type_url: "http://some.url/with/type.proto"
-    value: "protobuf message"
+    type_url: "type.googleapis.com/google.protobuf.Int32Value"
+    value: "\010*"
   }
 }
 version {
@@ -232,14 +232,14 @@ version {
 # -----
 
 # CHECK-LABEL: substrait.plan
-# CHECK-SAME:   advanced_extension
-# CHECK-SAME:     enhancement = "other protobuf message" : !substrait.any<"http://other.url/with/type.proto">
+# CHECK-SAME:   advanced_extension enhancement
+# CHECK-SAME:     "\08\01" : !substrait.any<"type.googleapis.com/google.protobuf.BoolValue">
 # CHECK-NEXT: }
 
 advanced_extensions {
   enhancement {
-    type_url: "http://other.url/with/type.proto"
-    value: "other protobuf message"
+    type_url: "type.googleapis.com/google.protobuf.BoolValue"
+    value: "\010\01"
   }
 }
 version {

--- a/test/Target/SubstraitPB/Import/project.textpb
+++ b/test/Target/SubstraitPB/Import/project.textpb
@@ -74,7 +74,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]]
-# CHECK-SAME:      advanced_extension optimization = "foo" : !substrait.any<"bar">
+# CHECK-SAME:      "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
 
 relations {
   rel {
@@ -107,8 +107,8 @@ relations {
       }
       advanced_extension {
         optimization {
-          type_url: "bar"
-          value: "foo"
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
         }
       }
     }


### PR DESCRIPTION
Substrait represents several types of extensions as `google.protobuf.any` messages, which consist of a value, which a byte sequence of a binary Protobuf message, and a URL. Turns out that `some protobuf message` is not a valid binary Protobuf message and `some url` is not a valid Protobuf schema URL. This wans't a problem for round-tripping between our dialect and Protobufs in either text or binary format but the JSON format requires both to be valid (and known, in the case of the URL).

This PR, thus, changes the URL and value fields of all `any` messages and the corresponding type and detail fields of the extension attributes in the test cases in order to allow for round-tripping them through JSON.