### PR TITLE
feat: add `advanced_extension` attribute to remaining `*Rel`s

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -542,7 +542,8 @@ def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
 }
 
 def Substrait_CrossOp : Substrait_RelOp<"cross", [
-    DeclareOpInterfaceMethods<InferTypeOpInterface>
+    DeclareOpInterfaceMethods<InferTypeOpInterface>,
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
   ]> {
   let summary = "Cross product operation";
   let description = [{
@@ -559,12 +560,19 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   }];
   let arguments = (ins
     Substrait_Relation:$left,
-    Substrait_Relation:$right
+    Substrait_Relation:$right,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $left `x` $right attr-dict `:` type($left) `x` type($right)
+    $left `x` $right (`advanced_extension` `` $advanced_extension^)?
+    attr-dict `:` type($left) `x` type($right)
   }];
+  let builders = [
+      OpBuilder<(ins "::mlir::Value":$left, "::mlir::Value":$right), [{
+        build($_builder, $_state, left, right, /*advanced_extension=*/{});
+      }]>,
+    ];
 }
 
 def Substrait_EmitOp : Substrait_RelOp<"emit", [

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -839,7 +839,8 @@ def Substrait_ProjectOp : Substrait_RelOp<"project", [
 
  //TODO(daliashaaban): Change type inference logic once nullability is supported.
 def Substrait_SetOp : Substrait_RelOp<"set", [
-    SameOperandsAndResultType
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
+    SameOperandsAndResultType,
   ]> {
   let summary = "set operation";
   let description = [{
@@ -851,13 +852,20 @@ def Substrait_SetOp : Substrait_RelOp<"set", [
 
   let arguments = (ins
     Variadic<Substrait_Relation>:$inputs,
-    SetOpKind:$kind
+    SetOpKind:$kind,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
 
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $kind $inputs attr-dict `:` type($result)
+    $kind $inputs (`advanced_extension` `` $advanced_extension^)?
+    attr-dict `:` type($result)
   }];
+  let builders = [
+      OpBuilder<(ins "::mlir::ValueRange":$inputs, "SetOpKind":$kind), [{
+        build($_builder, $_state, inputs, kind, /*advanced_extension=*/{});
+      }]>,
+    ];
 }
 
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITOPS

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -610,7 +610,9 @@ def Substrait_EmitOp : Substrait_RelOp<"emit", [
   }];
 }
 
-def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table"> {
+def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table", [
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
+  ]> {
   let summary = "Extension table operation (i.e., a `ReadRel` case)";
   let description = [{
     Represents a `ExtensionTable` message together with the `ReadRel` and `Rel`
@@ -626,11 +628,22 @@ def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table"> {
   }];
   let arguments = (ins
     StringArrayAttr:$field_names,
-    Substrait_AnyAttr:$detail
+    Substrait_AnyAttr:$detail,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
   let results = (outs Substrait_Relation:$result);
-  let assemblyFormat = "$detail `as` $field_names attr-dict `:` type($result)";
+  let assemblyFormat = [{
+    $detail `as` $field_names (`advanced_extension` `` $advanced_extension^)?
+    attr-dict `:` type($result)
+  }];
   let hasVerifier = true;
+  let builders = [
+      OpBuilder<(ins "::mlir::Type":$result, "::mlir::ArrayAttr":$field_names,
+                     "::mlir::StringAttr":$detail), [{
+        build($_builder, $_state, result, field_names, detail,
+              /*advanced_extension=*/{});
+      }]>,
+    ];
 }
 
 def Substrait_FetchOp : Substrait_RelOp<"fetch", [

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -468,8 +468,9 @@ class Substrait_RelOp<string mnemonic, list<Trait> traits = []> :
   ]>;
 
 def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
-    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
     SingleBlockImplicitTerminator<"::mlir::substrait::YieldOp">,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
     DeclareOpInterfaceMethods<InferTypeOpInterface>,
   ]> {
   let summary = "Aggregate operation";
@@ -512,7 +513,8 @@ def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
   }];
   let arguments = (ins
     Substrait_Relation:$input,
-    I64ArrayArrayAttr:$grouping_sets
+    I64ArrayArrayAttr:$grouping_sets,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
   let results = (outs Substrait_Relation:$result);
   let regions = (region
@@ -520,7 +522,8 @@ def Substrait_AggregateOp : Substrait_RelOp<"aggregate", [
     AnyRegion:$measures
   );
   let assemblyFormat = [{
-    $input attr-dict `:` type($input) `->` type($result)
+    $input (`advanced_extension` `` $advanced_extension^)?
+    attr-dict `:` type($input) `->` type($result)
     custom<AggregateRegions>($groupings, $measures, $grouping_sets)
   }];
   let hasRegionVerifier = 1;

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -751,6 +751,7 @@ def Substrait_JoinOp : Substrait_RelOp<"join", [
 }
 
 def Substrait_NamedTableOp : Substrait_RelOp<"named_table", [
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
   ]> {
   let summary = "Read operation of a named table";
   let description = [{
@@ -767,13 +768,23 @@ def Substrait_NamedTableOp : Substrait_RelOp<"named_table", [
   //                    `NamedStruct` type?
   let arguments = (ins
     SymbolRefAttr:$table_name,
-    StringArrayAttr:$field_names
+    StringArrayAttr:$field_names,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $table_name `as` $field_names attr-dict `:` type($result)
+    $table_name `as` $field_names
+    (`advanced_extension` `` $advanced_extension^)? attr-dict `:` type($result)
   }];
   let hasVerifier = true;
+  let builders = [
+      OpBuilder<(ins "::mlir::Type":$result_type,
+                     "::mlir::SymbolRefAttr":$table_name,
+                     "::mlir::ArrayAttr":$field_names), [{
+        build($_builder, $_state, result_type, table_name, field_names,
+              /*advanced_extension=*/{});
+      }]>,
+    ];
 }
 
 def Substrait_ProjectOp : Substrait_RelOp<"project", [

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -719,7 +719,10 @@ def Substrait_FilterOp : Substrait_RelOp<"filter", [
   }];
 }
 
-def Substrait_JoinOp : Substrait_RelOp<"join", [DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+def Substrait_JoinOp : Substrait_RelOp<"join", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface>,
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
+  ]> {
   let summary = "join operation";
   let description = [{
     Represents a `JoinRel` message together with the `RelCommon`, left and
@@ -730,12 +733,21 @@ def Substrait_JoinOp : Substrait_RelOp<"join", [DeclareOpInterfaceMethods<InferT
   let arguments = (ins
     Substrait_Relation:$left,
     Substrait_Relation:$right,
-    JoinType:$join_type
+    JoinType:$join_type,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
-    $join_type $left `,` $right attr-dict `:` type($left) `,` type($right) `->` type($result)
+    $join_type $left `,` $right (`advanced_extension` `` $advanced_extension^)?
+    attr-dict `:` type($left) `,` type($right) `->` type($result)
   }];
+  let builders = [
+      OpBuilder<(ins "::mlir::Value":$left, "::mlir::Value":$right,
+                     "JoinType":$join_type), [{
+        build($_builder, $_state, left, right, join_type,
+              /*advanced_extension=*/{});
+      }]>,
+    ];
 }
 
 def Substrait_NamedTableOp : Substrait_RelOp<"named_table", [

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -678,6 +678,7 @@ def Substrait_FetchOp : Substrait_RelOp<"fetch", [
 def Substrait_FilterOp : Substrait_RelOp<"filter", [
     SingleBlockImplicitTerminator<"::mlir::substrait::YieldOp">,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
     SameOperandsAndResultType
   ]> {
   let summary = "Filter operation";
@@ -696,14 +697,18 @@ def Substrait_FilterOp : Substrait_RelOp<"filter", [
     }
     ```
   }];
-  let arguments = (ins Substrait_Relation:$input);
+  let arguments = (ins
+    Substrait_Relation:$input,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
+  );
   let regions = (region AnyRegion:$condition);
   let results = (outs Substrait_Relation:$result);
   // TODO(ingomueller): We could elide/shorten the block argument from the
   //                    assembly by writing custom printers/parsers similar to
   //                    `scf.for` etc.
   let assemblyFormat = [{
-    $input attr-dict `:` type($input) $condition
+    $input (`advanced_extension` `` $advanced_extension^)?
+    attr-dict `:` type($input) $condition
   }];
   let hasRegionVerifier = 1;
   let extraClassDefinition = [{

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -647,7 +647,8 @@ def Substrait_ExtensionTableOp : Substrait_RelOp<"extension_table", [
 }
 
 def Substrait_FetchOp : Substrait_RelOp<"fetch", [
-    SameOperandsAndResultType
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
+    SameOperandsAndResultType,
   ]> {
   let summary = "Fetch operation";
   let description = [{
@@ -657,13 +658,21 @@ def Substrait_FetchOp : Substrait_RelOp<"fetch", [
   let arguments = (ins
     Substrait_Relation:$input,
     DefaultValuedAttr<ConfinedAttr<I64Attr, [IntNonNegative]>, "0">: $offset,
-    ConfinedAttr<I64Attr, [IntMinValue<-1>]>: $count
+    ConfinedAttr<I64Attr, [IntMinValue<-1>]>: $count,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
   );
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     custom<CountAsAll>($count) (`offset` $offset^)? `from` $input
-        attr-dict `:` type($input)
+    (`advanced_extension` `` $advanced_extension^)? attr-dict `:` type($input)
   }];
+  let builders = [
+      OpBuilder<(ins "::mlir::Value":$input, "int64_t":$offset,
+                      "int64_t":$count), [{
+        build($_builder, $_state, input, offset, count,
+              /*advanced_extension=*/{});
+      }]>,
+    ];
 }
 
 def Substrait_FilterOp : Substrait_RelOp<"filter", [

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -724,7 +724,8 @@ void AggregateOp::build(OpBuilder &builder, OperationState &result, Value input,
                                       returnTypes);
 
   // Call existing `build` function and move bodies into the new regions.
-  AggregateOp::build(builder, result, returnTypes, input, groupingSets);
+  AggregateOp::build(builder, result, returnTypes, input, groupingSets,
+                     /*advanced_extension=*/{});
   result.regions[0]->takeBody(*groupings);
   result.regions[1]->takeBody(*measures);
 }

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -351,7 +351,8 @@ struct PushDuplicatesThroughCrossPattern : public OpRewritePattern<CrossOp> {
 
     // Create new cross op with the two deduplicated inputs.
     auto newOp =
-        rewriter.create<CrossOp>(op.getLoc(), newLeftInput, newRightInput);
+        rewriter.create<CrossOp>(op.getLoc(), newLeftInput, newRightInput,
+                                 op.getAdvancedExtensionAttr());
 
     // Replace old cross op with emit op that maps back to old emit order.
     ArrayAttr reverseMappingAttr = rewriter.getI64ArrayAttr(reverseMapping);

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -573,6 +573,9 @@ SubstraitExporter::exportOperation(AggregateOp op) {
     }
   }
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *aggregateRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_aggregate(aggregateRel.release());

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -885,6 +885,9 @@ FailureOr<std::unique_ptr<Rel>> SubstraitExporter::exportOperation(FetchOp op) {
   fetchRel->set_offset(op.getOffset());
   fetchRel->set_count(op.getCount());
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *fetchRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_fetch(fetchRel.release());

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1553,6 +1553,9 @@ FailureOr<std::unique_ptr<Rel>> SubstraitExporter::exportOperation(SetOp op) {
     setRel->add_inputs()->CopyFrom(*inputRel->get());
   }
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *setRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_set(setRel.release());

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -793,6 +793,9 @@ SubstraitExporter::exportOperation(ExtensionTableOp op) {
   readRel->set_allocated_extension_table(extensionTable.release());
   readRel->set_allocated_base_schema(baseSchema->release());
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *readRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_read(readRel.release());

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -934,6 +934,9 @@ SubstraitExporter::exportOperation(FilterOp op) {
   filterRel->set_allocated_input(inputRel->release());
   filterRel->set_allocated_condition(condition->release());
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *filterRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_filter(filterRel.release());

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -747,6 +747,9 @@ FailureOr<std::unique_ptr<Rel>> SubstraitExporter::exportOperation(JoinOp op) {
   joinRel->set_allocated_right(rightRel->release());
   joinRel->set_type(static_cast<JoinRel::JoinType>(op.getJoinType()));
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *joinRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_join(joinRel.release());

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1153,6 +1153,9 @@ SubstraitExporter::exportOperation(NamedTableOp op) {
   readRel->set_allocated_base_schema(baseSchema->release());
   readRel->set_allocated_named_table(namedTable.release());
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *readRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_read(readRel.release());

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -666,6 +666,9 @@ FailureOr<std::unique_ptr<Rel>> SubstraitExporter::exportOperation(CrossOp op) {
   crossRel->set_allocated_left(leftRel->release());
   crossRel->set_allocated_right(rightRel->release());
 
+  // Attach the `AdvancedExtension` message if the attribute exists.
+  exportAdvancedExtension(op, *crossRel);
+
   // Build `Rel` message.
   auto rel = std::make_unique<Rel>();
   rel->set_allocated_cross(crossRel.release());

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -764,7 +764,13 @@ static mlir::FailureOr<FetchOp> importFetchRel(ImplicitLocOpBuilder builder,
 
   // Build `FetchOp`.
   Value inputVal = inputOp.value()->getResult(0);
-  return builder.create<FetchOp>(inputVal, fetchRel.offset(), fetchRel.count());
+  auto fetchOp =
+      builder.create<FetchOp>(inputVal, fetchRel.offset(), fetchRel.count());
+
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, fetchOp, fetchRel);
+
+  return fetchOp;
 }
 
 static mlir::FailureOr<FilterOp> importFilterRel(ImplicitLocOpBuilder builder,

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -453,7 +453,12 @@ static mlir::FailureOr<CrossOp> importCrossRel(ImplicitLocOpBuilder builder,
   Value leftVal = leftOp.value()->getResult(0);
   Value rightVal = rightOp.value()->getResult(0);
 
-  return builder.create<CrossOp>(leftVal, rightVal);
+  auto crossOp = builder.create<CrossOp>(leftVal, rightVal);
+
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, crossOp, crossRel);
+
+  return crossOp;
 }
 
 static mlir::FailureOr<SetOp> importSetRel(ImplicitLocOpBuilder builder,

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -620,7 +620,12 @@ static mlir::FailureOr<JoinOp> importJoinRel(ImplicitLocOpBuilder builder,
   if (!join_type)
     return mlir::emitError(builder.getLoc(), "unexpected 'operation' found");
 
-  return builder.create<JoinOp>(leftVal, rightVal, *join_type);
+  auto joinOp = builder.create<JoinOp>(leftVal, rightVal, *join_type);
+
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, joinOp, joinRel);
+
+  return joinOp;
 }
 
 static mlir::FailureOr<LiteralOp>

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -484,7 +484,12 @@ static mlir::FailureOr<SetOp> importSetRel(ImplicitLocOpBuilder builder,
   if (!kind)
     return mlir::emitError(builder.getLoc(), "unexpected 'operation' found");
 
-  return builder.create<SetOp>(inputsVal, *kind);
+  auto setOp = builder.create<SetOp>(inputsVal, *kind);
+
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, setOp, setRel);
+
+  return setOp;
 }
 
 static mlir::FailureOr<ExpressionOpInterface>

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -804,6 +804,9 @@ static mlir::FailureOr<FilterOp> importFilterRel(ImplicitLocOpBuilder builder,
     builder.create<YieldOp>(conditionOp.value()->getResult(0));
   }
 
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, filterOp, filterRel);
+
   return filterOp;
 }
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -404,6 +404,9 @@ importAggregateRel(ImplicitLocOpBuilder builder, const Rel &message) {
   auto aggregateOp = builder.create<AggregateOp>(
       inputVal, groupingSets, groupingsRegion.get(), measuresRegion.get());
 
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, aggregateOp, aggregateRel);
+
   return aggregateOp;
 }
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -534,6 +534,9 @@ importExtensionTable(ImplicitLocOpBuilder builder, const Rel &message) {
   auto extensionTableOp =
       builder.create<ExtensionTableOp>(resultType, fieldNamesAttr, detailAttr);
 
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, extensionTableOp, readRel);
+
   return extensionTableOp;
 }
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -875,6 +875,9 @@ importNamedTable(ImplicitLocOpBuilder builder, const Rel &message) {
   auto namedTableOp =
       builder.create<NamedTableOp>(resultType, tableName, fieldNamesAttr);
 
+  // Import advanced extension if it is present.
+  importAdvancedExtension(builder, namedTableOp, readRel);
+
   return namedTableOp;
 }
 

--- a/test/Dialect/Substrait/aggregate.mlir
+++ b/test/Dialect/Substrait/aggregate.mlir
@@ -306,3 +306,28 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
   }
 }
+
+// -----
+
+// Check op with advanced extension.
+
+// CHECK-LABEL: substrait.plan
+// CHECK:           aggregate %{{.*}} advanced_extension optimization = "\08*"
+// CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        : tuple
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32> -> tuple<si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2 : si1
+      }
+    yield %1 : tuple<si1>
+  }
+}

--- a/test/Dialect/Substrait/cross.mlir
+++ b/test/Dialect/Substrait/cross.mlir
@@ -17,3 +17,24 @@ substrait.plan version 0 : 42 : 1 {
     yield %2 : tuple<si32, si1>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:           cross %{{.*}} x %{{[^ ]*}}
+// CHECK-SAME:        advanced_extension optimization = "\08*"
+// CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        : tuple<si32> x tuple<si1>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si1>
+    %2 = cross %0 x %1
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32> x tuple<si1>
+    yield %2 : tuple<si32, si1>
+  }
+}

--- a/test/Dialect/Substrait/extension-table.mlir
+++ b/test/Dialect/Substrait/extension-table.mlir
@@ -16,3 +16,23 @@ substrait.plan version 0 : 42 : 1 {
     yield %0 : tuple<si32>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:           extension_table
+// CHECK-SAME:        "some detail" : !substrait.any<"some url"> as ["a"]
+// CHECK-SAME:        advanced_extension optimization = "\08*"
+// CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        : tuple<si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = extension_table
+           "some detail" : !substrait.any<"some url"> as ["a"]
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
+    yield %0 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/fetch.mlir
+++ b/test/Dialect/Substrait/fetch.mlir
@@ -83,3 +83,22 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si32>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:           fetch 3 from %{{[^ ]*}}
+// CHECK-SAME:        advanced_extension optimization = "\08*"
+// CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        : tuple<si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = fetch 3 from %0
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/filter.mlir
+++ b/test/Dialect/Substrait/filter.mlir
@@ -22,3 +22,25 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si32>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         filter %{{.*}} advanced_extension optimization = "\08*"
+// CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        : tuple<si32> {
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = filter %0
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal -1 : si1
+      yield %2 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/join.mlir
+++ b/test/Dialect/Substrait/join.mlir
@@ -150,3 +150,23 @@ substrait.plan version 0 : 42 : 1 {
     yield %2 : tuple<si1>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:           join inner %{{.*}}, %{{[^ ]*}}
+// CHECK-SAME:          advanced_extension optimization = "\08*"
+// CHECK-SAME:            : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:          : tuple<si32>, tuple<si32> -> tuple<si32, si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %2 = join inner %0, %1
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>, tuple<si32> -> tuple<si32, si32>
+    yield %2 : tuple<si32, si32>
+  }
+}

--- a/test/Dialect/Substrait/named-table.mlir
+++ b/test/Dialect/Substrait/named-table.mlir
@@ -70,3 +70,21 @@ substrait.plan version 0 : 42 : 1 {
     yield %0 : tuple<tuple<si32>>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         named_table @t1 as ["a"]
+// CHECK-SAME:        advanced_extension optimization = "\08*"
+// CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        : tuple<si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"]
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
+    yield %0 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/set.mlir
+++ b/test/Dialect/Substrait/set.mlir
@@ -133,3 +133,23 @@ substrait.plan version 0 : 42 : 1 {
     yield %2 : tuple<si32>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:           set union_all %{{.*}}, %{{[^ ]*}}
+// CHECK-SAME:        advanced_extension optimization = "\08*"
+// CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        : tuple<si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %2 = set union_all %0, %1
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
+    yield %2 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/aggregate.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate.mlir
@@ -243,7 +243,6 @@ substrait.plan version 0 : 42 : 1 {
   }
 }
 
-
 // -----
 
 // Check op with advanced extension.

--- a/test/Target/SubstraitPB/Export/aggregate.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate.mlir
@@ -242,3 +242,35 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si32, si32, si32, si32, si32, si32, si32>
   }
 }
+
+
+// -----
+
+// Check op with advanced extension.
+
+// CHECK:      relations {
+// CHECK:        rel {
+// CHECK:          aggregate {
+// CHECK:            groupings {
+// CHECK:            advanced_extension {
+// CHECK-NEXT:         optimization {
+// CHECK-NEXT:           type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:           value: "\010*"
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = aggregate %0
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32> -> tuple<si1>
+      groupings {
+      ^bb0(%arg : tuple<si32>):
+        %2 = literal 0 : si1
+        yield %2 : si1
+      }
+    yield %1 : tuple<si1>
+  }
+}

--- a/test/Target/SubstraitPB/Export/cross.mlir
+++ b/test/Target/SubstraitPB/Export/cross.mlir
@@ -1,9 +1,12 @@
-// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
 // RUN: | FileCheck %s
 
 // RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
 // RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: relations {
@@ -24,5 +27,28 @@ substrait.plan version 0 : 42 : 1 {
     %1 = named_table @t2 as ["b"] : tuple<si32>
     %2 = cross %0 x %1 : tuple<si32> x tuple<si32>
     yield %2 : tuple<si32, si32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      cross {
+// CHECK:             advanced_extension {
+// CHECK-NEXT:          optimization {
+// CHECK-NEXT:            type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:            value: "\010*"
+// CHECK-NEXT:          }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si1>
+    %2 = cross %0 x %1
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32> x tuple<si1>
+    yield %2 : tuple<si32, si1>
   }
 }

--- a/test/Target/SubstraitPB/Export/extension-table.mlir
+++ b/test/Target/SubstraitPB/Export/extension-table.mlir
@@ -9,40 +9,61 @@
 // RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | FileCheck %s
 
-// CHECK:      relations {
-// CHECK-NEXT:   rel {
-// CHECK-NEXT:     read {
-// CHECK-NEXT:       common {
-// CHECK-NEXT:         direct {
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:       base_schema {
-// CHECK-NEXT:         names: "a"
-// CHECK-NEXT:         struct {
-// CHECK-NEXT:           types {
-// CHECK-NEXT:             i32 {
-// CHECK-NEXT:               nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:             }
-// CHECK-NEXT:           }
-// CHECK-NEXT:           nullability: NULLABILITY_REQUIRED
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:       extension_table {
-// CHECK-NEXT:         detail {
-// CHECK-NEXT:           type_url: "type.googleapis.com/google.protobuf.Int32Value"
-// CHECK-NEXT:           value: "\010*"
-// CHECK-NEXT:         }
-// CHECK-NEXT:       }
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: version {
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        base_schema {
+// CHECK-NEXT:          names: "a"
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              i32 {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        extension_table {
+// CHECK-NEXT:          detail {
+// CHECK-NEXT:            type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:            value: "\010*"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// CHECK-NEXT:  version {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = extension_table
            "\08*" : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
            as ["a"] : tuple<si32>
+    yield %0 : tuple<si32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK:         extension_table {
+// CHECK:           advanced_extension {
+// CHECK-NEXT:        optimization {
+// CHECK-NEXT:          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:          value: "\010*"
+// CHECK-NEXT:        }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = extension_table
+           "some detail" : !substrait.any<"some url"> as ["a"]
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
     yield %0 : tuple<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/fetch.mlir
+++ b/test/Target/SubstraitPB/Export/fetch.mlir
@@ -1,9 +1,12 @@
-// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
 // RUN: | FileCheck %s
 
 // RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
 // RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: relations {
@@ -22,6 +25,28 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = fetch 5 offset 3 from %0 : tuple<si32>
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      fetch {
+// CHECK:             advanced_extension {
+// CHECK-NEXT:          optimization {
+// CHECK-NEXT:            type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:            value: "\010*"
+// CHECK-NEXT:          }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = fetch 3 from %0
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
     yield %1 : tuple<si32>
   }
 }

--- a/test/Target/SubstraitPB/Export/filter.mlir
+++ b/test/Target/SubstraitPB/Export/filter.mlir
@@ -1,9 +1,12 @@
-// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
 // RUN: | FileCheck %s
 
 // RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
 // RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: relations {
@@ -20,6 +23,32 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
     %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal -1 : si1
+      yield %2 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      filter {
+// CHECK:             advanced_extension {
+// CHECK-NEXT:          optimization {
+// CHECK-NEXT:            type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:            value: "\010*"
+// CHECK-NEXT:          }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = filter %0
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32> {
     ^bb0(%arg : tuple<si32>):
       %2 = literal -1 : si1
       yield %2 : si1

--- a/test/Target/SubstraitPB/Export/join.mlir
+++ b/test/Target/SubstraitPB/Export/join.mlir
@@ -199,3 +199,25 @@ substrait.plan version 0 : 42 : 1 {
   }
 }
 
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      join {
+// CHECK:             advanced_extension {
+// CHECK-NEXT:          optimization {
+// CHECK-NEXT:            type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:            value: "\010*"
+// CHECK-NEXT:          }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %2 = join inner %0, %1
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>, tuple<si32> -> tuple<si32, si32>
+    yield %2 : tuple<si32, si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/named-table.mlir
+++ b/test/Target/SubstraitPB/Export/named-table.mlir
@@ -191,3 +191,23 @@ substrait.plan version 0 : 42 : 1 {
     yield %0 : tuple<tuple<si32>>
   }
 }
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK:         named_table {
+// CHECK:           advanced_extension {
+// CHECK-NEXT:        optimization {
+// CHECK-NEXT:          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:          value: "\010*"
+// CHECK-NEXT:        }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"]
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
+    yield %0 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/set.mlir
+++ b/test/Target/SubstraitPB/Export/set.mlir
@@ -174,3 +174,26 @@ substrait.plan version 0 : 42 : 1 {
     yield %2 : tuple<si32>
   }
 }
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      set {
+// CHECK:             advanced_extension {
+// CHECK-NEXT:          optimization {
+// CHECK-NEXT:            type_url: "type.googleapis.com/google.protobuf.Int32Value"
+// CHECK-NEXT:            value: "\010*"
+// CHECK-NEXT:          }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = named_table @t2 as ["b"] : tuple<si32>
+    %2 = set union_all %0, %1
+            advanced_extension optimization = "\08*"
+              : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+            : tuple<si32>
+    yield %2 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Import/aggregate.textpb
+++ b/test/Target/SubstraitPB/Import/aggregate.textpb
@@ -581,3 +581,62 @@ version {
   minor_number: 42
   patch_number: 1
 }
+
+# -----
+
+# Check op with advanced extension.
+
+# CHECK-LABEL: substrait.plan
+# CHECK:           aggregate %{{.*}} advanced_extension optimization = "\08*"
+# CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:        : tuple
+
+relations {
+  rel {
+    aggregate {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      groupings {
+        grouping_expressions {
+          literal {
+            boolean: false
+          }
+        }
+      }
+      advanced_extension {
+        optimization {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}

--- a/test/Target/SubstraitPB/Import/cross.textpb
+++ b/test/Target/SubstraitPB/Import/cross.textpb
@@ -1,9 +1,13 @@
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
 # RUN: | FileCheck %s
 
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
 # RUN: | substrait-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | FileCheck %s
 
 # CHECK-LABEL: substrait.plan
@@ -63,6 +67,80 @@ relations {
           named_table {
             names: "t2"
           }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK:         relation
+# CHECK:           cross %{{.*}} x %{{[^ ]*}}
+# CHECK-SAME:        advanced_extension optimization = "\08*"
+# CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:        : tuple<si32> x tuple<si1>
+
+relations {
+  rel {
+    cross {
+      common {
+        direct {
+        }
+      }
+      left {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      right {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "b"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t2"
+          }
+        }
+      }
+      advanced_extension {
+        optimization {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
         }
       }
     }

--- a/test/Target/SubstraitPB/Import/extension-table.textpb
+++ b/test/Target/SubstraitPB/Import/extension-table.textpb
@@ -1,9 +1,13 @@
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
 # RUN: | FileCheck %s
 
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
 # RUN: | substrait-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | FileCheck %s
 
 # CHECK-LABEL: substrait.plan
@@ -33,6 +37,53 @@ relations {
       }
       extension_table {
         detail {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK:           extension_table
+# CHECK-SAME:        "some detail" : !substrait.any<"some url"> as ["a"]
+# CHECK-SAME:        advanced_extension optimization = "\08*"
+# CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:        : tuple<si32>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      extension_table {
+        detail {
+          type_url: "some url"
+          value: "some detail"
+        }
+      }
+      advanced_extension {
+        optimization {
           type_url: "type.googleapis.com/google.protobuf.Int32Value"
           value: "\010*"
         }

--- a/test/Target/SubstraitPB/Import/fetch.textpb
+++ b/test/Target/SubstraitPB/Import/fetch.textpb
@@ -1,9 +1,13 @@
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
 # RUN: | FileCheck %s
 
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
 # RUN: | substrait-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | FileCheck %s
 
 # CHECK-LABEL: substrait.plan
@@ -44,6 +48,57 @@ relations {
       }
       offset: 3
       count: 5
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK:           fetch 3 from %{{.*}} advanced_extension optimization = "\08*"
+# CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:        : tuple<si32>
+
+relations {
+  rel {
+    fetch {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      count: 3
+      advanced_extension {
+        optimization {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
+        }
+      }
     }
   }
 }

--- a/test/Target/SubstraitPB/Import/filter.textpb
+++ b/test/Target/SubstraitPB/Import/filter.textpb
@@ -1,9 +1,13 @@
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
 # RUN: | FileCheck %s
 
 # RUN: substrait-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | substrait-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
 # RUN: | substrait-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | FileCheck %s
 
 # CHECK-LABEL: substrait.plan
@@ -48,6 +52,61 @@ relations {
       condition {
         literal {
           boolean: true
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK:         filter {{.*}} advanced_extension optimization = "\08*"
+# CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:        : tuple<si32> {
+
+relations {
+  rel {
+    filter {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      condition {
+        literal {
+          boolean: true
+        }
+      }
+      advanced_extension {
+        optimization {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
         }
       }
     }

--- a/test/Target/SubstraitPB/Import/join.textpb
+++ b/test/Target/SubstraitPB/Import/join.textpb
@@ -558,3 +558,77 @@ version {
   minor_number: 42
   patch_number: 1
 }
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK:           join inner %{{.*}}, %{{[^ ]*}}
+# CHECK-SAME:          advanced_extension optimization = "\08*"
+# CHECK-SAME:            : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:          : tuple<si32>, tuple<si32> -> tuple<si32, si32>
+
+relations {
+  rel {
+    join {
+      common {
+        direct {
+        }
+      }
+      left {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      right {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "b"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t2"
+          }
+        }
+      }
+      type: JOIN_TYPE_INNER
+      advanced_extension {
+        optimization {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}

--- a/test/Target/SubstraitPB/Import/named-table.textpb
+++ b/test/Target/SubstraitPB/Import/named-table.textpb
@@ -199,3 +199,46 @@ version {
   minor_number: 42
   patch_number: 1
 }
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK:         named_table @t1 as ["a"]
+# CHECK-SAME:        advanced_extension optimization = "\08*"
+# CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:        : tuple<si32>
+
+relations {
+  rel {
+    read {
+      common {
+        direct {
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+      advanced_extension {
+        optimization {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}

--- a/test/Target/SubstraitPB/Import/set.textpb
+++ b/test/Target/SubstraitPB/Import/set.textpb
@@ -489,3 +489,77 @@ version {
   minor_number: 42
   patch_number: 1
 }
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK:           set union_all %{{.*}}, %{{[^ ]*}}
+# CHECK-SAME:        advanced_extension optimization = "\08*"
+# CHECK-SAME:          : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+# CHECK-SAME:        : tuple<si32>
+
+relations {
+  rel {
+    set {
+      common {
+        direct {
+        }
+      }
+      inputs {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      inputs {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "b"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t2"
+          }
+        }
+      }
+      op: SET_OP_UNION_ALL
+      advanced_extension {
+        optimization {
+          type_url: "type.googleapis.com/google.protobuf.Int32Value"
+          value: "\010*"
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
This PR adds the `advanced_extension` to the remaining ops corresponding to `*Rel` message types by adding the corresponding attribute, extending the assembly format, and adding custom builders to be able to skip the new attribute.