### PR TITLE
build: remove wrong and unused `ibis` Python requirement

### DIFF
--- a/requirements-unfrozen.txt
+++ b/requirements-unfrozen.txt
@@ -4,7 +4,6 @@
 # Testing.
 datafusion==32.0.0
 duckdb==1.1.3
-ibis==3.3.0
 ibis-framework==8.0.0
 ibis-substrait==3.2.0
 json5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cycler==0.12.1
 datafusion==32.0.0
 duckdb==1.1.3
 fonttools==4.55.8
-ibis==3.3.0
 ibis-framework==8.0.0
 ibis-substrait==3.2.0
 json5==0.10.0


### PR DESCRIPTION
Turns out that that package has nothing to do with Apache Ibis, which we use in some integration tests. It's some templating engine that happens to have the same name and must have ended up in `requirements.txt` by accident. Since recent CI runs broke due to not finding that package and we don't need it, this PR removes that package.