### PR TITLE
feat: dyn_cast_or_null EmitOp's input defining op

### DIFF
--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -883,7 +883,8 @@ OpFoldResult EmitOp::fold(FoldAdaptor adaptor) {
   Type i64 = IntegerType::get(context, 64);
 
   // If the input is also an `emit`, fold it into this op.
-  if (auto previousEmit = dyn_cast<EmitOp>(getInput().getDefiningOp())) {
+  if (auto previousEmit =
+          dyn_cast_or_null<EmitOp>(getInput().getDefiningOp())) {
     // Compute new mapping.
     ArrayAttr previousMapping = previousEmit.getMapping();
     SmallVector<Attribute> newMapping;


### PR DESCRIPTION
... in case the defining op is a block argument, which in turn would previously result in a crash.