### PR TITLE
chore(deps): update to latest version of `nanobind`

### DIFF
--- a/requirements-unfrozen.txt
+++ b/requirements-unfrozen.txt
@@ -1,5 +1,6 @@
 # MLIR dependencies.
 -r third_party/llvm-project/mlir/python/requirements.txt
+nanobind>=2.7.0
 
 # Testing.
 datafusion==32.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ matplotlib==3.10.0
 mdurl==0.1.2
 ml_dtypes==0.5.0
 multipledispatch==1.0.0
-nanobind==2.5.0
+nanobind==2.7.0
 nodeenv==1.9.1
 numpy==1.26.4
 packaging==24.2


### PR DESCRIPTION
This includes wjakob/nanobind#939 and wjakob/nanobind#940, which fixes an issue I encountered while working on #78, so we need the new version of `nanobind` for CI to pass and stub generation to be correct for that.