### PR TITLE
fix: print make command instead of executing it in failure message

### DIFF
--- a/.github/workflows/coverage_stats.yml
+++ b/.github/workflows/coverage_stats.yml
@@ -39,4 +39,4 @@ jobs:
         make -C docs/stats
 
     - name: Ensure stats are up-to-date
-      run: git diff --exit-code || (echo "Please update the coverage status using `make -C docs/stats`, add them to this PR, and run CI again."; false)
+      run: git diff --exit-code || (echo 'Please update the coverage status using `make -C docs/stats`, add them to this PR, and run CI again.'; false)


### PR DESCRIPTION
This PR fixes the GH workflow that ensures that the coverage stats are up-to-date. The workflow is supposed to print a message in case the stats need to be updated including the command that the developer should run to update them. Due to wrong quoting, that command was actually executed rather than being printed, so this PR changes to quotes to protect the command.





