### PR TITLE
feat: implement short-hand form for types

### DIFF
--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -203,24 +203,24 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, !substrait.timestamp_tz> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>{{$}}
-// CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
+// CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, !substrait.timestamp_tz
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, timestamp, !substrait.timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    %1 = project %0 : rel<si1> -> rel<si1, timestamp, !substrait.timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
       yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
     }
-    yield %1 : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
+    yield %1 : rel<si1, timestamp, !substrait.timestamp_tz>
   }
 }
 

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -34,22 +34,22 @@
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_binary<10>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
-// CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
+// CHECK-NEXT:      yield %[[V2]] : fixed_binary<10>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_binary<10>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, fixed_binary<10>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
+    %1 = project %0 : rel<si1> -> rel<si1, fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal #substrait.fixed_binary<"8181818181">
-      yield %bytes : !substrait.fixed_binary<10>
+      yield %bytes : fixed_binary<10>
     }
-    yield %1 : rel<si1, !substrait.fixed_binary<10>>
+    yield %1 : rel<si1, fixed_binary<10>>
   }
 }
 
@@ -58,22 +58,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.var_char<6>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, var_char<6>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<6>
+// CHECK-NEXT:      yield %[[V2]] : var_char<6>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.var_char<6>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, var_char<6>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.var_char<6>> {
+    %1 = project %0 : rel<si1> -> rel<si1, var_char<6>> {
     ^bb0(%arg : tuple<si1>):
       %var_char = literal #substrait.var_char<"hello", 6>
-      yield %var_char : !substrait.var_char<6>
+      yield %var_char : var_char<6>
     }
-    yield %1 : rel<si1, !substrait.var_char<6>>
+    yield %1 : rel<si1, var_char<6>>
   }
 }
 
@@ -82,22 +82,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_char<5>> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
-// CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
+// CHECK-NEXT:      yield %[[V2]] : fixed_char<5>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_char<5>>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, fixed_char<5>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
+    %1 = project %0 : rel<si1> -> rel<si1, fixed_char<5>> {
     ^bb0(%arg : tuple<si1>):
       %fixed_char = literal #substrait.fixed_char<"hello">
-      yield %fixed_char : !substrait.fixed_char<5>
+      yield %fixed_char : fixed_char<5>
     }
-    yield %1 : rel<si1, !substrait.fixed_char<5>>
+    yield %1 : rel<si1, fixed_char<5>>
   }
 }
 
@@ -106,22 +106,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.uuid> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, uuid> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
-// CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
+// CHECK-NEXT:      yield %[[V2]] : uuid
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.uuid>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, uuid>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.uuid> {
+    %1 = project %0 : rel<si1> -> rel<si1, uuid> {
     ^bb0(%arg : tuple<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
-      yield %uuid : !substrait.uuid
+      yield %uuid : uuid
     }
-    yield %1 : rel<si1, !substrait.uuid>
+    yield %1 : rel<si1, uuid>
   }
 }
 
@@ -129,24 +129,24 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, interval_ym, interval_ds> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>{{$}}
-// CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
+// CHECK-NEXT:      yield %[[V2]], %[[V3]] : interval_ym, interval_ds
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, interval_ym, interval_ds>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    %1 = project %0 : rel<si1> -> rel<si1, interval_ym, interval_ds> {
     ^bb0(%arg : tuple<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
-      yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
+      yield %interval_year_month, %interval_day_second : interval_ym, interval_ds
     }
-    yield %1 : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+    yield %1 : rel<si1, interval_ym, interval_ds>
   }
 }
 
@@ -155,22 +155,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.time> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, time> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>{{$}}
-// CHECK-NEXT:      yield %[[V2]] : !substrait.time
+// CHECK-NEXT:      yield %[[V2]] : time
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.time>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, time>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.time> {
+    %1 = project %0 : rel<si1> -> rel<si1, time> {
     ^bb0(%arg : tuple<si1>):
       %time = literal #substrait.time<200000000us>
-      yield %time : !substrait.time
+      yield %time : time
     }
-    yield %1 : rel<si1, !substrait.time>
+    yield %1 : rel<si1, time>
   }
 }
 
@@ -179,22 +179,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.date> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, date> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>{{$}}
-// CHECK-NEXT:      yield %[[V2]] : !substrait.date
+// CHECK-NEXT:      yield %[[V2]] : date
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.date>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, date>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.date> {
+    %1 = project %0 : rel<si1> -> rel<si1, date> {
     ^bb0(%arg : tuple<si1>):
       %date = literal #substrait.date<200000000>
-      yield %date : !substrait.date
+      yield %date : date
     }
-    yield %1 : rel<si1, !substrait.date>
+    yield %1 : rel<si1, date>
   }
 }
 
@@ -203,24 +203,24 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, !substrait.timestamp_tz> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>{{$}}
-// CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, !substrait.timestamp_tz
+// CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, timestamp_tz
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, timestamp, timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, timestamp, !substrait.timestamp_tz> {
+    %1 = project %0 : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
-      yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
+      yield %timestamp, %timestamp_tz : timestamp, timestamp_tz
     }
-    yield %1 : rel<si1, timestamp, !substrait.timestamp_tz>
+    yield %1 : rel<si1, timestamp, timestamp_tz>
   }
 }
 
@@ -229,22 +229,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.binary> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, binary> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
-// CHECK-NEXT:      yield %[[V2]] : !substrait.binary
+// CHECK-NEXT:      yield %[[V2]] : binary
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.binary>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.binary> {
+    %1 = project %0 : rel<si1> -> rel<si1, binary> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
-      yield %bytes : !substrait.binary
+      yield %bytes : binary
     }
-    yield %1 : rel<si1, !substrait.binary>
+    yield %1 : rel<si1, binary>
   }
 }
 
@@ -253,22 +253,22 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:      substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
-// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.string> {
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, string> {
 // CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
-// CHECK-NEXT:      yield %[[V2]] : !substrait.string
+// CHECK-NEXT:      yield %[[V2]] : string
 // CHECK-NEXT:    }
-// CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.string>
+// CHECK-NEXT:    yield %[[V1]] : rel<si1, string>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.string> {
+    %1 = project %0 : rel<si1> -> rel<si1, string> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal "hi" : !substrait.string
-      yield %hi : !substrait.string
+      yield %hi : string
     }
-    yield %1 : rel<si1, !substrait.string>
+    yield %1 : rel<si1, string>
   }
 }
 

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -52,7 +52,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]]
 // CHECK-SAME:      advanced_extension optimization = "\08*" :
-// CHECK-SAME:        !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
+// CHECK-SAME:        any<"type.googleapis.com/google.protobuf.Int32Value">
 // CHECK-SAME:      rel<si32> -> rel<si32> {
 
 substrait.plan version 0 : 42 : 1 {

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -10,8 +10,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : !substrait.relation<si1>
-    yield %0 : !substrait.relation<si1>
+    %0 = named_table @t1 as ["a"] : rel<si1>
+    yield %0 : rel<si1>
   }
 }
 
@@ -129,13 +129,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.timestamp, !substrait.timestamp_tz>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<timestamp, !substrait.timestamp_tz>
+// CHECK-NEXT:    yield %[[V0]] : rel<timestamp, !substrait.timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : rel<!substrait.timestamp, !substrait.timestamp_tz>
+    yield %0 : rel<timestamp, !substrait.timestamp_tz>
   }
 }
 

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -17,13 +17,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.decimal<12, 2>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<decimal<12, 2>>
+// CHECK-NEXT:    yield %[[V0]] : rel<decimal<12, 2>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
-    yield %0 : rel<!substrait.decimal<12, 2>>
+    %0 = named_table @t1 as ["a"] : rel<decimal<12, 2>>
+    yield %0 : rel<decimal<12, 2>>
   }
 }
 
@@ -31,13 +31,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.fixed_binary<4>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<fixed_binary<4>>
+// CHECK-NEXT:    yield %[[V0]] : rel<fixed_binary<4>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
-    yield %0 : rel<!substrait.fixed_binary<4>>
+    %0 = named_table @t1 as ["a"] : rel<fixed_binary<4>>
+    yield %0 : rel<fixed_binary<4>>
   }
 }
 
@@ -45,13 +45,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.var_char<6>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<var_char<6>>
+// CHECK-NEXT:    yield %[[V0]] : rel<var_char<6>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
-    yield %0 : rel<!substrait.var_char<6>>
+    %0 = named_table @t1 as ["a"] : rel<var_char<6>>
+    yield %0 : rel<var_char<6>>
   }
 }
 
@@ -59,13 +59,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.fixed_char<5>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<fixed_char<5>>
+// CHECK-NEXT:    yield %[[V0]] : rel<fixed_char<5>>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
-    yield %0 : rel<!substrait.fixed_char<5>>
+    %0 = named_table @t1 as ["a"] : rel<fixed_char<5>>
+    yield %0 : rel<fixed_char<5>>
   }
 }
 
@@ -73,13 +73,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.uuid>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.uuid>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<uuid>
+// CHECK-NEXT:    yield %[[V0]] : rel<uuid>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.uuid>
-    yield %0 : rel<!substrait.uuid>
+    %0 = named_table @t1 as ["a"] : rel<uuid>
+    yield %0 : rel<uuid>
   }
 }
 
@@ -87,13 +87,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<interval_ym, interval_ds>
+// CHECK-NEXT:    yield %[[V0]] : rel<interval_ym, interval_ds>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
-    yield %0 : rel<!substrait.interval_year_month, !substrait.interval_day_second>
+    %0 = named_table @t1 as ["a", "b"] : rel<interval_ym, interval_ds>
+    yield %0 : rel<interval_ym, interval_ds>
   }
 }
 
@@ -101,13 +101,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.time>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.time>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<time>
+// CHECK-NEXT:    yield %[[V0]] : rel<time>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.time>
-    yield %0 : rel<!substrait.time>
+    %0 = named_table @t1 as ["a"] : rel<time>
+    yield %0 : rel<time>
   }
 }
 
@@ -115,13 +115,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.date>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.date>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<date>
+// CHECK-NEXT:    yield %[[V0]] : rel<date>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.date>
-    yield %0 : rel<!substrait.date>
+    %0 = named_table @t1 as ["a"] : rel<date>
+    yield %0 : rel<date>
   }
 }
 
@@ -129,13 +129,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<timestamp, !substrait.timestamp_tz>
-// CHECK-NEXT:    yield %[[V0]] : rel<timestamp, !substrait.timestamp_tz>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<timestamp, timestamp_tz>
+// CHECK-NEXT:    yield %[[V0]] : rel<timestamp, timestamp_tz>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : rel<timestamp, !substrait.timestamp_tz>
+    %0 = named_table @t1 as ["a", "b"] : rel<timestamp, timestamp_tz>
+    yield %0 : rel<timestamp, timestamp_tz>
   }
 }
 
@@ -143,13 +143,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.binary>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.binary>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<binary>
+// CHECK-NEXT:    yield %[[V0]] : rel<binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
-    yield %0 : rel<!substrait.binary>
+    %0 = named_table @t1 as ["a"] : rel<binary>
+    yield %0 : rel<binary>
   }
 }
 
@@ -157,13 +157,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.binary>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.binary>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<binary>
+// CHECK-NEXT:    yield %[[V0]] : rel<binary>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
-    yield %0 : rel<!substrait.binary>
+    %0 = named_table @t1 as ["a"] : rel<binary>
+    yield %0 : rel<binary>
   }
 }
 
@@ -171,13 +171,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<!substrait.string>
-// CHECK-NEXT:    yield %[[V0]] : rel<!substrait.string>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a"] : rel<string>
+// CHECK-NEXT:    yield %[[V0]] : rel<string>
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.string>
-    yield %0 : rel<!substrait.string>
+    %0 = named_table @t1 as ["a"] : rel<string>
+    yield %0 : rel<string>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -28,12 +28,12 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.decimal<9, 2>> {
+    %1 = project %0 : rel<si1> -> rel<si1, decimal<9, 2>> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal #substrait.decimal<"0.05", P = 9, S = 2>
-      yield %hi : !substrait.decimal<9, 2>
+      yield %hi : decimal<9, 2>
     }
-    yield %1 : rel<si1, !substrait.decimal<9, 2>>
+    yield %1 : rel<si1, decimal<9, 2>>
   }
 }
 
@@ -55,12 +55,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
+    %1 = project %0 : rel<si1> -> rel<si1, fixed_binary<10>> {
     ^bb0(%arg : tuple<si1>):
       %fixed_binary = literal #substrait.fixed_binary<"8181818181">
-      yield %fixed_binary : !substrait.fixed_binary<10>
+      yield %fixed_binary : fixed_binary<10>
     }
-    yield %1 : rel<si1, !substrait.fixed_binary<10>>
+    yield %1 : rel<si1, fixed_binary<10>>
   }
 }
 
@@ -86,12 +86,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.var_char<6>> {
+    %1 = project %0 : rel<si1> -> rel<si1, var_char<6>> {
     ^bb0(%arg0: tuple<si1>):
       %2 = literal #substrait.var_char<"hello", 6>
-      yield %2 : !substrait.var_char<6>
+      yield %2 : var_char<6>
     }
-    yield %1 : rel<si1, !substrait.var_char<6>>
+    yield %1 : rel<si1, var_char<6>>
   }
 }
 
@@ -115,12 +115,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
+    %1 = project %0 : rel<si1> -> rel<si1, fixed_char<5>> {
     ^bb0(%arg0: tuple<si1>):
       %2 = literal #substrait.fixed_char<"hello">
-      yield %2 : !substrait.fixed_char<5>
+      yield %2 : fixed_char<5>
     }
-    yield %1 : rel<si1, !substrait.fixed_char<5>>
+    yield %1 : rel<si1, fixed_char<5>>
   }
 }
 
@@ -142,12 +142,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.uuid> {
+    %1 = project %0 : rel<si1> -> rel<si1, uuid> {
     ^bb0(%arg : tuple<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
-      yield %uuid : !substrait.uuid
+      yield %uuid : uuid
     }
-    yield %1 : rel<si1, !substrait.uuid>
+    yield %1 : rel<si1, uuid>
   }
 }
 
@@ -179,13 +179,13 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+    %1 = project %0 : rel<si1> -> rel<si1, interval_ym, interval_ds> {
     ^bb0(%arg : tuple<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
-      yield %interval_year_month, %interval_day_second : !substrait.interval_year_month, !substrait.interval_day_second
+      yield %interval_year_month, %interval_day_second : interval_ym, interval_ds
     }
-    yield %1 : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+    yield %1 : rel<si1, interval_ym, interval_ds>
   }
 }
 
@@ -209,12 +209,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.time> {
+    %1 = project %0 : rel<si1> -> rel<si1, time> {
     ^bb0(%arg : tuple<si1>):
       %time = literal #substrait.time<200000000us>
-      yield %time : !substrait.time
+      yield %time : time
     }
-    yield %1 : rel<si1, !substrait.time>
+    yield %1 : rel<si1, time>
   }
 }
 
@@ -236,12 +236,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.date> {
+    %1 = project %0 : rel<si1> -> rel<si1, date> {
     ^bb0(%arg : tuple<si1>):
       %date = literal #substrait.date<200000000>
-      yield %date : !substrait.date
+      yield %date : date
     }
-    yield %1 : rel<si1, !substrait.date>
+    yield %1 : rel<si1, date>
   }
 }
 
@@ -268,13 +268,13 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+    %1 = project %0 : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
     ^bb0(%arg : tuple<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
-      yield %timestamp, %timestamp_tz : !substrait.timestamp, !substrait.timestamp_tz
+      yield %timestamp, %timestamp_tz : timestamp, timestamp_tz
     }
-    yield %1 : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
+    yield %1 : rel<si1, timestamp, timestamp_tz>
   }
 }
 
@@ -296,12 +296,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.binary> {
+    %1 = project %0 : rel<si1> -> rel<si1, binary> {
     ^bb0(%arg : tuple<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
-      yield %bytes : !substrait.binary
+      yield %bytes : binary
     }
-    yield %1 : rel<si1, !substrait.binary>
+    yield %1 : rel<si1, binary>
   }
 }
 
@@ -323,12 +323,12 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
-    %1 = project %0 : rel<si1> -> rel<si1, !substrait.string> {
+    %1 = project %0 : rel<si1> -> rel<si1, string> {
     ^bb0(%arg : tuple<si1>):
       %hi = literal "hi" : !substrait.string
-      yield %hi : !substrait.string
+      yield %hi : string
     }
-    yield %1 : rel<si1, !substrait.string>
+    yield %1 : rel<si1, string>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -29,8 +29,8 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.decimal<12, 2>>
-    yield %0 : rel<!substrait.decimal<12, 2>>
+    %0 = named_table @t1 as ["a"] : rel<decimal<12, 2>>
+    yield %0 : rel<decimal<12, 2>>
   }
 }
 
@@ -55,8 +55,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_binary<4>>
-    yield %0 : rel<!substrait.fixed_binary<4>>
+    %0 = named_table @t1 as ["a"] : rel<fixed_binary<4>>
+    yield %0 : rel<fixed_binary<4>>
   }
 }
 
@@ -81,8 +81,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.var_char<6>>
-    yield %0 : rel<!substrait.var_char<6>>
+    %0 = named_table @t1 as ["a"] : rel<var_char<6>>
+    yield %0 : rel<var_char<6>>
   }
 }
 
@@ -107,8 +107,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.fixed_char<5>>
-    yield %0 : rel<!substrait.fixed_char<5>>
+    %0 = named_table @t1 as ["a"] : rel<fixed_char<5>>
+    yield %0 : rel<fixed_char<5>>
   }
 }
 
@@ -132,8 +132,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.uuid>
-    yield %0 : rel<!substrait.uuid>
+    %0 = named_table @t1 as ["a"] : rel<uuid>
+    yield %0 : rel<uuid>
   }
 }
 
@@ -163,8 +163,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.interval_year_month, !substrait.interval_day_second>
-    yield %0 : rel<!substrait.interval_year_month, !substrait.interval_day_second>
+    %0 = named_table @t1 as ["a", "b"] : rel<interval_ym, interval_ds>
+    yield %0 : rel<interval_ym, interval_ds>
   }
 }
 
@@ -188,8 +188,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.time>
-    yield %0 : rel<!substrait.time>
+    %0 = named_table @t1 as ["a"] : rel<time>
+    yield %0 : rel<time>
   }
 }
 
@@ -213,8 +213,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.date>
-    yield %0 : rel<!substrait.date>
+    %0 = named_table @t1 as ["a"] : rel<date>
+    yield %0 : rel<date>
   }
 }
 
@@ -244,8 +244,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : rel<!substrait.timestamp, !substrait.timestamp_tz>
-    yield %0 : rel<!substrait.timestamp, !substrait.timestamp_tz>
+    %0 = named_table @t1 as ["a", "b"] : rel<timestamp, timestamp_tz>
+    yield %0 : rel<timestamp, timestamp_tz>
   }
 }
 
@@ -269,8 +269,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.binary>
-    yield %0 : rel<!substrait.binary>
+    %0 = named_table @t1 as ["a"] : rel<binary>
+    yield %0 : rel<binary>
   }
 }
 
@@ -294,8 +294,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a"] : rel<!substrait.string>
-    yield %0 : rel<!substrait.string>
+    %0 = named_table @t1 as ["a"] : rel<string>
+    yield %0 : rel<string>
   }
 }
 

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -13,12 +13,12 @@
 # CHECK:   substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:           relation {
 # CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : rel<f32>
-# CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : rel<f32> -> rel<f32, !substrait.decimal<3, 2>> {
+# CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : rel<f32> -> rel<f32, decimal<3, 2>> {
 # CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<f32>):
 # CHECK-NEXT:               %[[VAL_3:.*]] = literal #substrait.decimal<"0.05", P = 3, S = 2>
-# CHECK-NEXT:               yield %[[VAL_3]] : !substrait.decimal<3, 2>
+# CHECK-NEXT:               yield %[[VAL_3]] : decimal<3, 2>
 # CHECK-NEXT:             }
-# CHECK-NEXT:             yield %[[VAL_1]] : rel<f32, !substrait.decimal<3, 2>>
+# CHECK-NEXT:             yield %[[VAL_1]] : rel<f32, decimal<3, 2>>
 
 relations {
   rel {
@@ -71,12 +71,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_binary<10>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_binary<10>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
-# CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_binary<10>
+# CHECK-NEXT:      yield %[[V2]] : fixed_binary<10>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_binary<10>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, fixed_binary<10>
 
 relations {
   rel {
@@ -125,12 +125,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.var_char<5>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, var_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.var_char<5>
+# CHECK-NEXT:      yield %[[V2]] : var_char<5>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.var_char<5>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, var_char<5>
 
 relations {
   rel {
@@ -181,12 +181,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.fixed_char<5>> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_char<5>> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
-# CHECK-NEXT:      yield %[[V2]] : !substrait.fixed_char<5>
+# CHECK-NEXT:      yield %[[V2]] : fixed_char<5>
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.fixed_char<5>>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, fixed_char<5>>
 
 relations {
   rel {
@@ -235,12 +235,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.uuid> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, uuid> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.uuid
+# CHECK-NEXT:      yield %[[V2]] : uuid
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.uuid>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, uuid>
 
 relations {
   rel {
@@ -289,13 +289,13 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.interval_year_month, !substrait.interval_day_second> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, interval_ym, interval_ds> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>
-# CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.interval_year_month, !substrait.interval_day_second
+# CHECK-NEXT:      yield %[[V2]], %[[V3]] : interval_ym, interval_ds
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.interval_year_month, !substrait.interval_day_second>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, interval_ym, interval_ds>
 
 relations {
   rel {
@@ -355,12 +355,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.time> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, time> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.time
+# CHECK-NEXT:      yield %[[V2]] : time
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.time>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, time>
 
 relations {
   rel {
@@ -409,12 +409,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.date> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, date> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>
-# CHECK-NEXT:      yield %[[V2]] : !substrait.date
+# CHECK-NEXT:      yield %[[V2]] : date
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.date>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, date>
 
 relations {
   rel {
@@ -463,13 +463,13 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, !substrait.timestamp_tz> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>
-# CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, !substrait.timestamp_tz
+# CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, timestamp_tz
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, timestamp, !substrait.timestamp_tz>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, timestamp, timestamp_tz>
 
 relations {
   rel {
@@ -523,12 +523,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.binary> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, binary> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
-# CHECK-NEXT:      yield %[[V2]] : !substrait.binary
+# CHECK-NEXT:      yield %[[V2]] : binary
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.binary>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, binary>
 
 relations {
   rel {
@@ -577,12 +577,12 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.string> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, string> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
-# CHECK-NEXT:      yield %[[V2]] : !substrait.string
+# CHECK-NEXT:      yield %[[V2]] : string
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.string>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, string>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -463,13 +463,13 @@ version {
 # CHECK:      substrait.plan version 0 : 42 : 1 {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
-# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, !substrait.timestamp, !substrait.timestamp_tz> {
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, !substrait.timestamp_tz> {
 # CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>
-# CHECK-NEXT:      yield %[[V2]], %[[V3]] : !substrait.timestamp, !substrait.timestamp_tz
+# CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, !substrait.timestamp_tz
 # CHECK-NEXT:    }
-# CHECK-NEXT:    yield %[[V1]] : rel<si1, !substrait.timestamp, !substrait.timestamp_tz>
+# CHECK-NEXT:    yield %[[V1]] : rel<si1, timestamp, !substrait.timestamp_tz>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -319,7 +319,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.timestamp, !substrait.timestamp_tz>
+# CHECK-SAME:       : rel<timestamp, !substrait.timestamp_tz>
 
 relations {
   rel {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -13,7 +13,7 @@
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.decimal<12, 3>>
+# CHECK-SAME:       : rel<decimal<12, 3>>
 
 relations {
   rel {
@@ -51,7 +51,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.fixed_binary<5>>
+# CHECK-SAME:       : rel<fixed_binary<5>>
 
 relations {
   rel {
@@ -88,7 +88,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.var_char<6>>
+# CHECK-SAME:       : rel<var_char<6>>
 
 relations {
   rel {
@@ -125,7 +125,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.fixed_char<5>>
+# CHECK-SAME:       : rel<fixed_char<5>>
 
 relations {
   rel {
@@ -170,7 +170,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.uuid>
+# CHECK-SAME:       : rel<uuid>
 
 relations {
   rel {
@@ -206,7 +206,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.interval_year_month, !substrait.interval_day_second>
+# CHECK-SAME:       : rel<interval_ym, interval_ds>
 
 relations {
   rel {
@@ -248,7 +248,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<!substrait.time>
+# CHECK-SAME:       : rel<time>
 
 relations {
   rel {
@@ -283,7 +283,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : rel<!substrait.date>
+# CHECK-NEXT:     named_table {{.*}} : rel<date>
 
 relations {
   rel {
@@ -319,7 +319,7 @@ version {
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<timestamp, !substrait.timestamp_tz>
+# CHECK-SAME:       : rel<timestamp, timestamp_tz>
 
 relations {
   rel {
@@ -360,7 +360,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : rel<!substrait.binary>
+# CHECK-NEXT:     named_table {{.*}} : rel<binary>
 
 relations {
   rel {
@@ -395,7 +395,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : rel<!substrait.string>
+# CHECK-NEXT:     named_table {{.*}} : rel<string>
 
 relations {
   rel {


### PR DESCRIPTION
This PR adds a short-hand version for the assymbly format of the types in the Substrait dialect and adapts the tests accordingly.  The implementation follows the same pattern as the one in the [LLVMIR dialect](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp) upstream. With that format, we can write `interval_ds` instead of `!substrait.interval_day_second`, for example. The short-hand versions mainly consist of just the op name e.g., `date` instead of `!substrait.date` but a few short-hand versions are shortend further (like `interval_ds`). The short-hand versions can be used everywhere were the custom `SubstraitType` printer and parser is used. For now, this includes all `RelOp`s, the `YieldOp`, as well as types tested inside `RelationType`, which covers all occurrences of types in the test suite except for the types of `StringAttr`s, such as in `literal "foo" : !substrait.string`.  This PR does also not change the assembly format of attributes, which have a similar source of redundancy that we may want to remove in follow-up work.