### PR TITLE
ci: use `ubuntu-24.04` for all CI jobs on Linux

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   ubuntu-build-and-test:
     name: Ubuntu build and test (Release Asserts)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-14/bin/llvm-symbolizer
     steps:

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Run clang-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/coverage_stats.yml
+++ b/.github/workflows/coverage_stats.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   coverage-stats:
     name: Ensure coverage stats are up-to-date
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Compute substrait-mlir base path
       run: |

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   license:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Run markdownlint-cli2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   commitlint:
     name: Check that commit message forms a "Semantic Commit"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   formatting-check:
     name: Run yapf
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - name: run YAPF to test if python code is correctly formatted


### PR DESCRIPTION
This PR makes all CI jobs use `ubuntu-24.04` as the runner image. Previously, either `ubuntu-22.04` or `ubuntu-latest` was used; the former is a bit outdated and the latter is prone to breaking CI jobs due to an image update.