### PR TITLE
build: add direct CMake dependencies and order alphabetically

### DIFF
--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -3,7 +3,8 @@ add_mlir_public_c_api_library(SubstraitMLIRCAPI
 
   LINK_LIBS PUBLIC
     MLIRCAPIIR
+    MLIRIR
+    MLIRPass
     MLIRSubstraitDialect
     MLIRTargetSubstraitPB
-    MLIRPass
 )

--- a/lib/Dialect/Substrait/IR/CMakeLists.txt
+++ b/lib/Dialect/Substrait/IR/CMakeLists.txt
@@ -1,10 +1,15 @@
 add_mlir_dialect_library(MLIRSubstraitDialect
   Substrait.cpp
 
+  LINK_COMPONENTS
+  Support
+
   LINK_LIBS PUBLIC
   MLIRCastInterfaces
+  MLIRFuncDialect
   MLIRInferTypeOpInterface
   MLIRIR
+  MLIRSupport
 
   DEPENDS
   MLIRSubstraitIncGen

--- a/lib/Target/SubstraitPB/CMakeLists.txt
+++ b/lib/Target/SubstraitPB/CMakeLists.txt
@@ -3,6 +3,9 @@ add_mlir_translation_library(MLIRTargetSubstraitPB
   Import.cpp
   ProtobufUtils.cpp
 
+  LINK_COMPONENTS
+  Support
+
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRSubstraitDialect

--- a/tools/substrait-lsp-server/CMakeLists.txt
+++ b/tools/substrait-lsp-server/CMakeLists.txt
@@ -16,9 +16,10 @@ target_link_libraries(substrait-lsp-server
   ${extension_libs}
   ${dialect_libs}
   ${test_libs}
+  LLVMSupport
+  MLIRIR
   MLIRLspServerLib
   MLIRSupport
-  MLIRIR
 )
 
 mlir_check_all_link_libraries(substrait-lsp-server)

--- a/tools/substrait-opt/CMakeLists.txt
+++ b/tools/substrait-opt/CMakeLists.txt
@@ -16,16 +16,9 @@ target_link_libraries(substrait-opt
   ${extension_libs}
   ${dialect_libs}
   ${test_libs}
-  MLIRAffineAnalysis
-  MLIRAnalysis
-  MLIRDialect
-  MLIROptLib
-  MLIRParser
-  MLIRPass
-  MLIRTransforms
-  MLIRTransformUtils
-  MLIRSupport
   MLIRIR
+  MLIROptLib
+  MLIRSupport
 )
 
 mlir_check_all_link_libraries(substrait-opt)

--- a/tools/substrait-translate/CMakeLists.txt
+++ b/tools/substrait-translate/CMakeLists.txt
@@ -14,9 +14,8 @@ target_link_libraries(substrait-translate
   PRIVATE
   ${dialect_libs}
   ${translation_libs}
+  LLVMSupport
   MLIRIR
-  MLIRParser
-  MLIRPass
   MLIRTargetSubstraitPB
   MLIRTranslateLib
   MLIRSupport


### PR DESCRIPTION
While preparing the BUILD files for bazel, I ran into missing direct dependencies. Bazel can notice if a build target uses a particular dependency but only declares that dependency *indirectyl*, i.e., there is a dependency a -> b -> c, even though a uses c directly. This often works but may break if the dependencies of the intermediate target change, so it is better to always declare all dependencies directly.