### PR TITLE
style: clean up import statements in Python files

### DIFF
--- a/python/substrait_mlir/dialects/substrait.py
+++ b/python/substrait_mlir/dialects/substrait.py
@@ -14,8 +14,7 @@ from .._mlir_libs._substraitDialects.substrait import *
 
 try:
   from .. import ir
-  from ._ods_common import (
-      _cext as _ods_cext,)
+  from ._ods_common import _cext as _ods_cext
 except ImportError as e:
   raise RuntimeError("Error loading imports from extension module") from e
 

--- a/test/python/dialects/substrait/translate.py
+++ b/test/python/dialects/substrait/translate.py
@@ -11,7 +11,8 @@
 import json
 from typing import cast
 
-from substrait_mlir.dialects import substrait as ss, arith
+from substrait_mlir.dialects import substrait as ss
+from substrait_mlir.dialects import arith
 from substrait_mlir.ir import Context, Location
 
 JSON_PLAN = '''


### PR DESCRIPTION
This PR cleans up two import statements that made Google-internal usages more complicated than necessary. The clean-ups also represent real improvements, independent of that use case, though: in `substrait.py` an import statement importing a single module used the multi-line syntax (with parentheses) and in `translate.py`, an import statement imported two submodules (which is less readable than separate import statement per module).