### PR TITLE
test: unbuffer Python with CLI flag rather than lit config

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -41,11 +41,6 @@ config.substitutions.extend([
     ("%PYTHON", sys.executable),
 ])
 
-# Deactivate Python's output buffering. Otherwise, output on stdout from Python
-# gets delayed with respect to output from native libraries (such as the MLIR
-# Python bindings) such that order is not preserved and FileCheck checks fail.
-config.environment['PYTHONUNBUFFERED'] = '1'
-
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.

--- a/test/python/dialects/substrait/translate.py
+++ b/test/python/dialects/substrait/translate.py
@@ -6,7 +6,7 @@
 #
 # ===----------------------------------------------------------------------=== #
 
-# RUN: %PYTHON %s 2>&1 | FileCheck %s
+# RUN: %PYTHON -u %s 2>&1 | FileCheck %s
 
 import json
 from typing import cast


### PR DESCRIPTION
This PR moves the disabling of Python's output buffering to a `-u` flag in the `RUN` line of each individual lit test. Without this configuration, the output on stdout from Python gets delayed with respect to the output from native libraries (such as the MLIR Python bindings) such that the order is not preserved and `FileCheck` checks fail. Previously, the configuration was don in `lit.cfg.py` but that file may not be used by other test runners.