### PR TITLE
build: set up clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,45 @@
+---
+# Enable the same checks as MLIR, except for the following:
+#    misc-include-cleaner
+#    readability-braces-around-statements
+#    readability-identifier-naming
+#    misc-use-anonymous-namespace
+# TODO(ingomueller): fix issues found by clang-tidy and enable checks.
+Checks: >
+    -*,
+    -google-*,
+    llvm-*,
+    -llvm-twine-local,
+    misc-*,
+    -misc-const-correctness,
+    -misc-confusable-identifiers,
+    -misc-no-recursion,
+    -misc-unused-parameters,
+    -misc-non-private-member-variables-in-classes,
+    readability-braces-around-statements,
+    readability-identifier-naming,
+    -misc-include-cleaner,
+    -readability-braces-around-statements,
+    -readability-identifier-naming,
+    -misc-use-anonymous-namespace
+
+CheckOptions:
+- key: llvm-namespace-comment.ShortNamespaceLines
+  value: 3
+- key: readability-braces-around-statements.ShortStatementLines
+  value: 2
+- key: readability-identifier-naming.ClassCase
+  value: CamelCase
+- key: readability-identifier-naming.EnumCase
+  value: CamelCase
+- key: readability-identifier-naming.FunctionCase
+  value: camelBack
+- key: readability-identifier-naming.MemberCase
+  value: camelBack
+- key: readability-identifier-naming.ParameterCase
+  value: camelBack
+- key: readability-identifier-naming.UnionCase
+  value: CamelCase
+- key: readability-identifier-naming.VariableCase
+  value: camelBack
+...

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,6 +86,8 @@ jobs:
           -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
           -DMLIR_ENABLE_PYTHON_BENCHMARKS=ON \
           -DSUBSTRAIT_MLIR_COMPILE_WARNING_AS_ERROR=ON \
+          -DSUBSTRAIT_MLIR_CLANG_TIDY_PATH=$(which clang-tidy) \
+          -DSUBSTRAIT_MLIR_ENABLE_CLANG_TIDY=ON \
           -S${SUBSTRAIT_MLIR_MAIN_SRC_DIR}/third_party/llvm-project/llvm \
           -B${SUBSTRAIT_MLIR_MAIN_BINARY_DIR} -G Ninja
         echo "PYTHONPATH=${PYTHONPATH}:${SUBSTRAIT_MLIR_MAIN_BINARY_DIR}/tools/substrait_mlir/python_packages" | tee -a $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,41 @@ set(SUBSTRAIT_MLIR_TABLEGEN_OUTPUT_DIR ${SUBSTRAIT_MLIR_BINARY_DIR}/include)
 message(STATUS "Substrait MLIR build directory: ${SUBSTRAIT_MLIR_BINARY_DIR}")
 
 ################################################################################
+# Set up clang-tidy
+################################################################################
+
+option(SUBSTRAIT_MLIR_ENABLE_CLANG_TIDY
+       "Enable clang-tidy static analysis on Substrait MLIR targets"
+       OFF)
+option(SUBSTRAIT_MLIR_CLANG_TIDY_PATH "path to 'clang-tidy' executable")
+
+if(SUBSTRAIT_MLIR_ENABLE_CLANG_TIDY)
+  # Find `clang-tidy` executable.
+  get_filename_component(CLANG_TIDY_NAME
+    "${SUBSTRAIT_MLIR_CLANG_TIDY_PATH}" NAME)
+  get_filename_component(CLANG_TIDY_DIR
+    "${SUBSTRAIT_MLIR_CLANG_TIDY_PATH}" DIRECTORY)
+  find_program(CLANG_TIDY_EXE
+    HINTS ${CLANG_TIDY_DIR}
+    NAMES "clang-tidy" "${CLANG_TIDY_NAME}"
+    REQUIRED)
+  if("${CLANG_TIDY_EXE}" STREQUAL "")
+    message(FATAL_ERROR "failed to find clang-tidy executable")
+  endif()
+
+  # Assemble command line.
+  set(CLANG_TIDY_CONFIG_FILE "${SUBSTRAIT_MLIR_MAIN_SRC_DIR}/.clang-tidy")
+  set(CLANG_TIDY_COMMAND
+    "${CLANG_TIDY_EXE};--config-file=${CLANG_TIDY_CONFIG_FILE}")
+  if (${SUBSTRAIT_MLIR_COMPILE_WARNING_AS_ERROR})
+    set(CLANG_TIDY_COMMAND "${CLANG_TIDY_COMMAND};--warnings-as-errors=*")
+  endif()
+  set(CMAKE_CXX_CLANG_TIDY_EXPORT_FIXES_DIR
+    "${SUBSTRAIT_MLIR_BINARY_DIR}/clang-tidy-fixes")
+  message(STATUS "clang-tidy enabled, command: ${CLANG_TIDY_COMMAND}")
+endif(SUBSTRAIT_MLIR_ENABLE_CLANG_TIDY)
+
+################################################################################
 # Set include paths
 ################################################################################
 include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
@@ -63,8 +98,14 @@ add_custom_target(substrait-mlir-all)
 # Set default value for COMPILE_WARNING_AS_ERROR for our targets.
 set(CMAKE_COMPILE_WARNING_AS_ERROR ${SUBSTRAIT_MLIR_COMPILE_WARNING_AS_ERROR})
 
+# Enable clang-tidy for our targets.
+set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND})
+
 add_subdirectory(lib)
 add_subdirectory(include)
 add_subdirectory(python)
 add_subdirectory(test)
 add_subdirectory(tools)
+
+# Disable clang-tidy for everything that may came after.
+unset(CMAKE_CXX_CLANG_TIDY)

--- a/README.md
+++ b/README.md
@@ -275,7 +275,8 @@ Run the command below to set up the build system, possibly adapting it to your
 needs. For example, you may choose not to compile `clang`, `clang-tools-extra`,
 `lld`, and/or the examples to save compilation time, or use a different variant
 than `Debug`. Similarly, you may want to set `DLLVM_ENABLE_LLD=OFF` on some Macs
-that don't have `lld`.
+that don't have `lld` or disable `clang-tidy` if this slows down your builds too
+much or you don't have that tool installed.
 
 ```bash
 cmake \
@@ -298,6 +299,8 @@ cmake \
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
   -DMLIR_ENABLE_PYTHON_BENCHMARKS=ON \
   -DSUBSTRAIT_MLIR_COMPILE_WARNING_AS_ERROR=ON \
+  -DSUBSTRAIT_MLIR_CLANG_TIDY_PATH=$(which clang-tidy) \
+  -DSUBSTRAIT_MLIR_ENABLE_CLANG_TIDY=ON \
   -S${SUBSTRAIT_MLIR_SOURCE_DIR}/third_party/llvm-project/llvm \
   -B${SUBSTRAIT_MLIR_BUILD_DIR} \
   -G Ninja
@@ -347,3 +350,16 @@ ${SUBSTRAIT_MLIR_BUILD_DIR}/bin/mlir-pdll-lsp-server
 
 In VS Code, this is done via the `mlir.server_path`, `mlir.pdll_server_path`,
 and `mlir.tablegen_server_path` properties in `settings.json`.
+
+## Applying fixes from `clang-tidy`
+
+If you have enabled `clang-tidy` in your CMake configuration (see above), some
+code style related checks may fail on new code. In that case, `clang-tidy`
+generates automated fixes for some of its checks. You can apply them by running
+the following command:
+
+```bash
+cd ${SUBSTRAIT_MLIR_SOURCE_DIR} && \
+  clang-apply-replacements --format \
+  ${SUBSTRAIT_MLIR_BUILD_DIR}$/tools/substrait_mlir/clang-tidy-fixes
+```

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -42,6 +42,10 @@ declare_mlir_python_sources(SubstraitMLIRPythonSources.MLIRLibs
 # ###############################################################################
 # Common CAPI
 # ###############################################################################
+
+# Disable clang-tidy because it also builds upstream sources.
+unset(CMAKE_CXX_CLANG_TIDY)
+
 add_mlir_python_common_capi_library(SubstraitMLIRPythonCAPI
   INSTALL_COMPONENT SubstraitMLIRPythonModules
   INSTALL_DESTINATION python_packages/substrait_mlir/_mlir_libs
@@ -55,9 +59,15 @@ add_mlir_python_common_capi_library(SubstraitMLIRPythonCAPI
   MLIRPythonSources.ExecutionEngine
 )
 
+set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND}) # Re-enable clang-tidy.
+
 # ###############################################################################
 # Instantiation of all Python modules
 # ###############################################################################
+
+# Disable clang-tidy because it also builds upstream sources.
+unset(CMAKE_CXX_CLANG_TIDY)
+
 add_mlir_python_modules(SubstraitMLIRPythonModules
   ROOT_PREFIX "${SUBSTRAIT_MLIR_BINARY_DIR}/python_packages/substrait_mlir"
   INSTALL_PREFIX "python_packages/substrait_mlir"
@@ -71,6 +81,8 @@ add_mlir_python_modules(SubstraitMLIRPythonModules
   COMMON_CAPI_LINK_LIBS
   SubstraitMLIRPythonCAPI
 )
+
+set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND}) # Re-enable clang-tidy.
 
 nanobind_add_stub(
   SubstraitMLIRPythonModuleStubs


### PR DESCRIPTION
This PR sets up clang-tidy to be run by CMake on our targets. Currently
all checks that fail are disabled such that CI continues to pass.
