### PR TITLE
build: enable `readability-identifier-naming` check of `clang-tidy`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 # Enable the same checks as MLIR, except for the following:
 #    misc-include-cleaner
 #    readability-braces-around-statements
-#    readability-identifier-naming
 #    misc-use-anonymous-namespace
 # TODO(ingomueller): fix issues found by clang-tidy and enable checks.
 Checks: >
@@ -20,7 +19,6 @@ Checks: >
     readability-identifier-naming,
     -misc-include-cleaner,
     -readability-braces-around-statements,
-    -readability-identifier-naming,
     -misc-use-anonymous-namespace
 
 CheckOptions:

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -73,8 +73,8 @@ LogicalResult mlir::substrait::FixedCharAttr::verify(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError, StringAttr value,
     Type type) {
   FixedCharType fixedCharType = mlir::dyn_cast<FixedCharType>(type);
-  int32_t value_length = value.size();
-  if (fixedCharType != nullptr && value_length != fixedCharType.getLength())
+  int32_t valueLength = value.size();
+  if (fixedCharType != nullptr && valueLength != fixedCharType.getLength())
     return emitError() << "value length must be " << fixedCharType.getLength()
                        << " characters.";
   return success();
@@ -86,8 +86,8 @@ LogicalResult mlir::substrait::FixedBinaryAttr::verify(
   FixedBinaryType fixedBinaryType = mlir::dyn_cast<FixedBinaryType>(type);
   if (fixedBinaryType == nullptr)
     return emitError() << "expected a fixed binary type";
-  int32_t value_length = value.size();
-  if (value_length != fixedBinaryType.getLength())
+  int32_t valueLength = value.size();
+  if (valueLength != fixedBinaryType.getLength())
     return emitError() << "value length must be " << fixedBinaryType.getLength()
                        << " characters.";
   return success();
@@ -119,8 +119,8 @@ LogicalResult mlir::substrait::IntervalDaySecondAttr::verify(
 LogicalResult mlir::substrait::VarCharAttr::verify(
     llvm::function_ref<mlir::InFlightDiagnostic()> emitError, StringAttr value,
     VarCharType type) {
-  int32_t value_length = value.size();
-  if (value_length > type.getLength())
+  int32_t valueLength = value.size();
+  if (valueLength > type.getLength())
     return emitError() << "value length must be at most " << type.getLength()
                        << " characters.";
   return success();
@@ -160,9 +160,9 @@ LogicalResult mlir::substrait::DecimalAttr::verify(
 
   // Max `P` digits.
   size_t nDigits = countDigits(value.getValue());
-  size_t P = type.getPrecision();
-  if (nDigits > P)
-    return emitError() << "value must have at most " << P
+  size_t p = type.getPrecision();
+  if (nDigits > p)
+    return emitError() << "value must have at most " << p
                        << " digits as per the type " << type << " but got "
                        << nDigits;
 
@@ -1048,11 +1048,11 @@ JoinOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 
   // Get accessor to `join_type`.
   Adaptor adaptor(operands, attributes, properties, regions);
-  JoinType join_type = adaptor.getJoinType();
+  JoinType joinType = adaptor.getJoinType();
 
   SmallVector<mlir::Type> fieldTypes;
 
-  switch (join_type) {
+  switch (joinType) {
   case JoinType::unspecified:
   case JoinType::inner:
   case JoinType::outer:

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1103,19 +1103,19 @@ SubstraitExporter::exportNamedStruct(Location loc, ArrayAttr fieldNames,
                                      TupleType relationType) {
 
   // Build `Struct` message.
-  auto struct_ = std::make_unique<proto::Type::Struct>();
-  struct_->set_nullability(
+  auto structMsg = std::make_unique<proto::Type::Struct>();
+  structMsg->set_nullability(
       Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED);
   for (mlir::Type fieldType : relationType.getTypes()) {
     FailureOr<std::unique_ptr<proto::Type>> type = exportType(loc, fieldType);
     if (failed(type))
       return (failure());
-    *struct_->add_types() = *std::move(type.value());
+    *structMsg->add_types() = *std::move(type.value());
   }
 
   // Build `NamedStruct` message.
   auto namedStruct = std::make_unique<NamedStruct>();
-  namedStruct->set_allocated_struct_(struct_.release());
+  namedStruct->set_allocated_struct_(structMsg.release());
   for (Attribute attr : fieldNames) {
     namedStruct->add_names(mlir::cast<StringAttr>(attr).getValue().str());
   }

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1274,9 +1274,9 @@ FailureOr<std::unique_ptr<Plan>> SubstraitExporter::exportOperation(PlanOp op) {
 
   // Add `expected_type_urls` to plan if present.
   if (op.getExpectedTypeUrls()) {
-    ArrayAttr expected_type_urls = op.getExpectedTypeUrls().value();
-    for (auto expected_type_url : expected_type_urls.getAsRange<StringAttr>())
-      plan->add_expected_type_urls(expected_type_url.str());
+    ArrayAttr expectedTypeUrls = op.getExpectedTypeUrls().value();
+    for (auto expectedTypeUrl : expectedTypeUrls.getAsRange<StringAttr>())
+      plan->add_expected_type_urls(expectedTypeUrl.str());
   }
 
   // Add `extension_uris` to plan.

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -834,10 +834,10 @@ importNamedStruct(ImplicitLocOpBuilder builder, const NamedStruct &message) {
   auto fieldNamesAttr = ArrayAttr::get(context, fieldNames);
 
   // Assemble field types from schema.
-  const proto::Type::Struct &struct_ = message.struct_();
+  const proto::Type::Struct &structMsg = message.struct_();
   llvm::SmallVector<mlir::Type> resultTypes;
-  resultTypes.reserve(struct_.types_size());
-  for (const proto::Type &type : struct_.types()) {
+  resultTypes.reserve(structMsg.types_size());
+  for (const proto::Type &type : structMsg.types()) {
     FailureOr<mlir::Type> mlirType = importType(context, type);
     if (failed(mlirType))
       return failure();

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -496,8 +496,8 @@ static mlir::FailureOr<ExpressionOpInterface>
 importExpression(ImplicitLocOpBuilder builder, const Expression &message) {
   Location loc = builder.getLoc();
 
-  Expression::RexTypeCase rex_type = message.rex_type_case();
-  switch (rex_type) {
+  Expression::RexTypeCase rexType = message.rex_type_case();
+  switch (rexType) {
   case Expression::kCast:
     return importCast(builder, message.cast());
   case Expression::kLiteral:
@@ -510,7 +510,7 @@ importExpression(ImplicitLocOpBuilder builder, const Expression &message) {
     return emitError(loc) << Twine("expression type not set");
   default: {
     const pb::FieldDescriptor *desc =
-        Expression::GetDescriptor()->FindFieldByNumber(rex_type);
+        Expression::GetDescriptor()->FindFieldByNumber(rexType);
     return emitError(loc) << Twine("unsupported expression type: ") +
                                  desc->name();
   }
@@ -619,13 +619,13 @@ static mlir::FailureOr<JoinOp> importJoinRel(ImplicitLocOpBuilder builder,
   Value leftVal = leftOp.value()->getResult(0);
   Value rightVal = rightOp.value()->getResult(0);
 
-  std::optional<JoinType> join_type = static_cast<JoinType>(joinRel.type());
+  std::optional<JoinType> joinType = static_cast<JoinType>(joinRel.type());
 
   // Check for unsupported set operations.
-  if (!join_type)
+  if (!joinType)
     return mlir::emitError(builder.getLoc(), "unexpected 'operation' found");
 
-  auto joinOp = builder.create<JoinOp>(leftVal, rightVal, *join_type);
+  auto joinOp = builder.create<JoinOp>(leftVal, rightVal, *joinType);
 
   // Import advanced extension if it is present.
   importAdvancedExtension(builder, joinOp, joinRel);
@@ -715,9 +715,9 @@ importLiteral(ImplicitLocOpBuilder builder,
     APInt var(128, 0);
     llvm::LoadIntFromMemory(
         var, reinterpret_cast<const uint8_t *>(message.uuid().data()), 16);
-    IntegerAttr integer_attr =
+    IntegerAttr integerAttr =
         IntegerAttr::get(IntegerType::get(context, 128), var);
-    auto attr = UUIDAttr::get(context, integer_attr);
+    auto attr = UUIDAttr::get(context, integerAttr);
     return builder.create<LiteralOp>(attr);
   }
   case Expression::Literal::LiteralTypeCase::kFixedChar: {
@@ -908,12 +908,12 @@ static FailureOr<PlanOp> importTopLevel(ImplicitLocOpBuilder builder,
   planOp.getBody().push_back(new Block());
 
   // Import `expected_type_urls` if present.
-  SmallVector<Attribute> expected_type_urls;
-  for (const std::string &expected_type_url : message.expected_type_urls()) {
-    expected_type_urls.push_back(StringAttr::get(context, expected_type_url));
+  SmallVector<Attribute> expectedTypeUrls;
+  for (const std::string &expectedTypeUrl : message.expected_type_urls()) {
+    expectedTypeUrls.push_back(StringAttr::get(context, expectedTypeUrl));
   }
-  if (!expected_type_urls.empty()) {
-    planOp.setExpectedTypeUrlsAttr(ArrayAttr::get(context, expected_type_urls));
+  if (!expectedTypeUrls.empty()) {
+    planOp.setExpectedTypeUrlsAttr(ArrayAttr::get(context, expectedTypeUrls));
   }
 
   // Import advanced extension if it is present.


### PR DESCRIPTION
That flag was disabled when `clang-tidy` was set up initially in #140 because it failed in too many places. This PR enables it and applies the automatic fixes such that identifier naming will be enforced in the future.