### PR TITLE
style: enable `clang-tidy`'s `misc-include-cleaner` check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,5 @@
 ---
 # Enable the same checks as MLIR, except for the following:
-#    misc-include-cleaner
 #    readability-braces-around-statements
 #    misc-use-anonymous-namespace
 # TODO(ingomueller): fix issues found by clang-tidy and enable checks.
@@ -17,7 +16,6 @@ Checks: >
     -misc-non-private-member-variables-in-classes,
     readability-braces-around-statements,
     readability-identifier-naming,
-    -misc-include-cleaner,
     -readability-braces-around-statements,
     -misc-use-anonymous-namespace
 

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -21,3 +21,6 @@ jobs:
         exclude: './third_party'
         extensions: 'h,cpp'
         clangFormatVersion: 18
+    - name: Check include styles
+      run: |
+        ! git grep -E '#include <(absl|google|llvm|mlir|substrait)(-c)?/' || (echo "error: wrong include style for LLVM or MLIR header" && exit 1)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,9 +6,9 @@
 #
 # ===----------------------------------------------------------------------=== #
 
-load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
-load("@llvm-project//mlir:build_defs.bzl", "mlir_c_api_cc_library")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load("@llvm-project//mlir:build_defs.bzl", "mlir_c_api_cc_library")
+load("@llvm-project//mlir:tblgen.bzl", "gentbl_cc_library", "gentbl_filegroup", "td_library")
 load("@rules_license//rules:license.bzl", "license")
 
 package(
@@ -205,6 +205,7 @@ cc_library(
     deps = [
         ":MLIRSubstraitDialect",
         ":MLIRSubstraitTransformsIncGen",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Rewrite",
@@ -232,6 +233,7 @@ cc_library(
     includes = ["include"],
     deps = [
         ":MLIRSubstraitDialect",
+        "@com_google_absl//absl/status",
         "@com_google_protobuf//:json_util",
         "@com_google_protobuf//:protobuf",
         "@llvm-project//llvm:Support",
@@ -262,7 +264,9 @@ mlir_c_api_cc_library(
     deps = [
         ":MLIRSubstraitDialect",
         ":MLIRTargetSubstraitPB",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
     ],
 )
 
@@ -300,6 +304,7 @@ cc_binary(
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MlirOptLib",
+        "@llvm-project//mlir:Support",
     ],
 )
 
@@ -316,6 +321,7 @@ cc_binary(
         "@llvm-project//mlir:AllPassesAndDialects",
         "@llvm-project//mlir:AllTranslations",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TranslateLib",
     ],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -150,6 +150,17 @@ gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 # gazelle_dependencies()
 
 http_archive(
+    name = "com_google_absl",
+    sha256 = "338420448b140f0dfd1a1ea3c3ce71b3bc172071f24f4d9a57d59b45037da440",
+    # Use the version used by com_google_protobuf.
+    strip_prefix = "abseil-cpp-20240116.0",
+    urls = [
+        "https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz",
+        "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.0.tar.gz",
+    ],
+)
+
+http_archive(
     name = "com_google_protobuf",
     sha256 = "3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568",
     strip_prefix = "protobuf-3.19.4",

--- a/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
+++ b/include/substrait-mlir/Dialect/Substrait/IR/Substrait.h
@@ -9,48 +9,48 @@
 #ifndef SUBSTRAIT_MLIR_DIALECT_SUBSTRAIT_IR_SUBSTRAIT_H
 #define SUBSTRAIT_MLIR_DIALECT_SUBSTRAIT_IR_SUBSTRAIT_H
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"         // IWYU: keep
-#include "mlir/IR/Dialect.h"                      // IWYU: keep
-#include "mlir/IR/OpImplementation.h"             // IWYU: keep
-#include "mlir/IR/SymbolTable.h"                  // IWYU: keep
-#include "mlir/Interfaces/CastInterfaces.h"       // IWYU: keep
-#include "mlir/Interfaces/InferTypeOpInterface.h" // IWYU: keep
+#include "mlir/Dialect/Func/IR/FuncOps.h"         // IWYU pragma: keep
+#include "mlir/IR/Dialect.h"                      // IWYU pragma: keep
+#include "mlir/IR/OpImplementation.h"             // IWYU pragma: keep
+#include "mlir/IR/SymbolTable.h"                  // IWYU pragma: keep
+#include "mlir/Interfaces/CastInterfaces.h"       // IWYU pragma: keep
+#include "mlir/Interfaces/InferTypeOpInterface.h" // IWYU pragma: keep
 
 //===----------------------------------------------------------------------===//
 // Substrait dialect
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsDialect.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsDialect.h.inc" // IWYU pragma: export
 
 //===----------------------------------------------------------------------===//
 // Substrait enums
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.h.inc" // IWYU pragma: export
 
 //===----------------------------------------------------------------------===//
 // Substrait types
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypeInterfaces.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypeInterfaces.h.inc" // IWYU pragma: export
 #define GET_TYPEDEF_CLASSES
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsTypes.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsTypes.h.inc" // IWYU pragma: export
 
 //===----------------------------------------------------------------------===//
 // Substrait attributes
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitAttrInterfaces.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitAttrInterfaces.h.inc" // IWYU pragma: export
 #define GET_ATTRDEF_CLASSES
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsAttrs.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsAttrs.h.inc" // IWYU pragma: export
 
 //===----------------------------------------------------------------------===//
 // Substrait ops
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpInterfaces.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpInterfaces.h.inc" // IWYU pragma: export
 #define GET_OP_CLASSES
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOps.h.inc" // IWYU: export
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOps.h.inc" // IWYU pragma: export
 
 namespace mlir::substrait {
 

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -13,12 +13,20 @@
 #include "substrait-mlir/Target/SubstraitPB/Import.h"
 #include "substrait-mlir/Target/SubstraitPB/Options.h"
 
-#include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/CAPI/Support.h"
+#include "mlir/CAPI/Wrap.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdint>
+#include <string>
 
 using namespace mlir;
 using namespace mlir::substrait;

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -23,20 +23,20 @@ using namespace mlir::substrait;
 // Substrait dialect
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsDialect.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsDialect.cpp.inc" // IWYU pragma: keep
 
 void SubstraitDialect::initialize() {
 #define GET_OP_LIST
   addOperations<
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOps.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOps.cpp.inc" // IWYU pragma: keep
       >();
   addTypes<
 #define GET_TYPEDEF_LIST
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsTypes.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsTypes.cpp.inc" // IWYU pragma: keep
       >();
   addAttributes<
 #define GET_ATTRDEF_LIST
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsAttrs.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsAttrs.cpp.inc" // IWYU pragma: keep
       >();
 }
 
@@ -271,15 +271,15 @@ ParseResult DecimalAttr::parseDecimalString(
 // Substrait enums
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.cpp.inc" // IWYU pragma: keep
 
 //===----------------------------------------------------------------------===//
 // Substrait interfaces
 //===----------------------------------------------------------------------===//
 
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitAttrInterfaces.cpp.inc"
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpInterfaces.cpp.inc"
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypeInterfaces.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitAttrInterfaces.cpp.inc" // IWYU pragma: keep
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpInterfaces.cpp.inc" // IWYU pragma: keep
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitTypeInterfaces.cpp.inc" // IWYU pragma: keep
 
 //===----------------------------------------------------------------------===//
 // Custom Parser and Printer for Substrait
@@ -525,7 +525,7 @@ static void printAggregateRegions(OpAsmPrinter &printer, AggregateOp op,
 } // namespace mlir
 
 #define GET_OP_CLASSES
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOps.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOps.cpp.inc" // IWYU pragma: keep
 
 namespace {
 
@@ -1292,7 +1292,7 @@ LogicalResult ProjectOp::verifyRegions() {
 //===----------------------------------------------------------------------===//
 
 #define GET_TYPEDEF_CLASSES
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsTypes.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsTypes.cpp.inc" // IWYU pragma: keep
 
 #define GET_ATTRDEF_CLASSES
-#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsAttrs.cpp.inc"
+#include "substrait-mlir/Dialect/Substrait/IR/SubstraitOpsAttrs.cpp.inc" // IWYU pragma: keep

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -8,13 +8,45 @@
 
 #include "substrait-mlir/Dialect/Substrait/IR/Substrait.h"
 
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectImplementation.h" // IWYU pragma: keep
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Region.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/TypeRange.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/ADT/TypeSwitch.h" // IWYU pragma: keep
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Regex.h"
+#include "llvm/Support/SMLoc.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
 
 using namespace mlir;
 using namespace mlir::substrait;

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -9,10 +9,32 @@
 #include "substrait-mlir/Dialect/Substrait/IR/Substrait.h"
 #include "substrait-mlir/Dialect/Substrait/Transforms/Passes.h"
 
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/Dominance.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Region.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/CSE.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/LogicalResult.h"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <tuple>
+#include <utility>
 
 namespace mlir::substrait {
 #define GEN_PASS_DEF_SUBSTRAITEMITDEDUPLICATIONPASS

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -9,12 +9,14 @@
 #include "ProtobufUtils.h"
 
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Location.h"
+#include "mlir/Support/LLVM.h"
 
 // TODO(ingomueller): Find a way to make `substrait-cpp` declare these headers
 // as system headers and remove the diagnostic fiddling here.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Weverything"
-#include <substrait/proto/algebra.pb.h>
+#include "substrait/proto/algebra.pb.h"
 #pragma clang diagnostic pop
 
 using namespace mlir;

--- a/tools/substrait-lsp-server/substrait-lsp-server.cpp
+++ b/tools/substrait-lsp-server/substrait-lsp-server.cpp
@@ -25,6 +25,8 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Signals.h"
 
+#include <string>
+
 using namespace mlir;
 
 static void registerSubstraitDialects(DialectRegistry &registry) {

--- a/tools/substrait-opt/substrait-opt.cpp
+++ b/tools/substrait-opt/substrait-opt.cpp
@@ -14,17 +14,15 @@
 #include "substrait-mlir/Dialect/Substrait/IR/Substrait.h"
 #include "substrait-mlir/Dialect/Substrait/Transforms/Passes.h"
 
-#include "mlir/IR/Dialect.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllExtensions.h"
 #include "mlir/InitAllPasses.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Signals.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/ToolOutputFile.h"
+
+#include <string>
 
 using namespace mlir;
 using namespace mlir::substrait;

--- a/tools/substrait-translate/substrait-translate.cpp
+++ b/tools/substrait-translate/substrait-translate.cpp
@@ -13,7 +13,7 @@
 #include "substrait-mlir/Target/SubstraitPB/Import.h"
 #include "substrait-mlir/Target/SubstraitPB/Options.h"
 
-#include "mlir/IR/BuiltinOps.h" // IWYU: keep
+#include "mlir/IR/BuiltinOps.h" // IWYU pragma: keep
 #include "mlir/IR/Operation.h"
 #include "mlir/InitAllTranslations.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"

--- a/tools/substrait-translate/substrait-translate.cpp
+++ b/tools/substrait-translate/substrait-translate.cpp
@@ -14,10 +14,15 @@
 #include "substrait-mlir/Target/SubstraitPB/Options.h"
 
 #include "mlir/IR/BuiltinOps.h" // IWYU pragma: keep
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/InitAllTranslations.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Tools/mlir-translate/Translation.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace mlir {


### PR DESCRIPTION
This PR depends on and, therefore, includes ~~#144 and~~ #142.

This may seem in contrast with the LLVM Coding Standards, which mandates to "include as little as possible." However, it does say that "[we] **must** include all of the header files that [we] are using," though it gives the freedom to do that "either directly or indirectly through another header file." The rule is, in fact, mainly targeted at forward declarations of classes that aren't "used" in the C++ sense with the goal of reducing compile time. Using the `misc-include-cleaner`, thus, seems like a good compromise: it allows to enforce removing unused headers, which improves compile time, at the expense of not being able to indirectly include other headers anymore, which is arguably a minor disadvantage.

This PR also adds a CI check that enforces the correct include style (`"." vs `<.>`) for the external libraries that we are using.