### PR TITLE
build: enable `misc-use-anonymous-namespace` check of `clang-tidy`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,6 @@
 ---
 # Enable the same checks as MLIR, except for the following:
 #    readability-braces-around-statements
-#    misc-use-anonymous-namespace
 # TODO(ingomueller): fix issues found by clang-tidy and enable checks.
 Checks: >
     -*,
@@ -16,8 +15,7 @@ Checks: >
     -misc-non-private-member-variables-in-classes,
     readability-braces-around-statements,
     readability-identifier-naming,
-    -readability-braces-around-statements,
-    -misc-use-anonymous-namespace
+    -readability-braces-around-statements
 
 CheckOptions:
 - key: llvm-namespace-comment.ShortNamespaceLines

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -27,10 +27,12 @@ namespace mlir::substrait::protobuf_utils {
 
 namespace pb = ::google::protobuf;
 
+namespace {
 template <typename RelType>
 static const RelCommon *getCommon(const RelType &rel) {
   return &rel.common();
 }
+} // namespace
 
 FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
   Rel::RelTypeCase relType = rel.rel_type_case();
@@ -58,10 +60,12 @@ FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
   }
 }
 
+namespace {
 template <typename RelType>
 static RelCommon *getMutableCommon(RelType *rel) {
   return rel->mutable_common();
 }
+} // namespace
 
 FailureOr<RelCommon *> getMutableCommon(Rel *rel, Location loc) {
   Rel::RelTypeCase relType = rel->rel_type_case();

--- a/tools/substrait-lsp-server/substrait-lsp-server.cpp
+++ b/tools/substrait-lsp-server/substrait-lsp-server.cpp
@@ -29,9 +29,11 @@
 
 using namespace mlir;
 
-static void registerSubstraitDialects(DialectRegistry &registry) {
+namespace {
+void registerSubstraitDialects(DialectRegistry &registry) {
   registry.insert<mlir::substrait::SubstraitDialect>();
 }
+} // namespace
 
 int main(int argc, char **argv) {
 #ifndef NDEBUG

--- a/tools/substrait-opt/substrait-opt.cpp
+++ b/tools/substrait-opt/substrait-opt.cpp
@@ -27,9 +27,11 @@
 using namespace mlir;
 using namespace mlir::substrait;
 
-static void registerSubstraitDialects(DialectRegistry &registry) {
+namespace {
+void registerSubstraitDialects(DialectRegistry &registry) {
   registry.insert<mlir::substrait::SubstraitDialect>();
 }
+} // namespace
 
 int main(int argc, char **argv) {
 #ifndef NDEBUG

--- a/tools/substrait-translate/substrait-translate.cpp
+++ b/tools/substrait-translate/substrait-translate.cpp
@@ -22,11 +22,15 @@
 #include "mlir/Tools/mlir-translate/Translation.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
-namespace mlir {
-namespace substrait {
+using namespace mlir;
+using namespace mlir::substrait;
+
+namespace {
+void registerSubstraitDialects(DialectRegistry &registry) {
+  registry.insert<mlir::substrait::SubstraitDialect>();
+}
 
 llvm::cl::opt<SerdeFormat> substraitProtobufFormat(
     "substrait-protobuf-format", llvm::cl::ValueRequired,
@@ -39,10 +43,6 @@ llvm::cl::opt<SerdeFormat> substraitProtobufFormat(
         clEnumValN(SerdeFormat::kPrettyJson, "pretty-json",
                    "JSON format with new lines")),
     llvm::cl::init(SerdeFormat::kText));
-
-static void registerSubstraitDialects(DialectRegistry &registry) {
-  registry.insert<mlir::substrait::SubstraitDialect>();
-}
 
 void registerSubstraitToProtobufTranslation() {
   TranslateFromMLIRRegistration registration(
@@ -82,15 +82,13 @@ void registerProtobufToSubstraitPlanVersionTranslation() {
       },
       registerSubstraitDialects);
 }
-
-} // namespace substrait
-} // namespace mlir
+} // namespace
 
 int main(int argc, char **argv) {
   mlir::registerAllTranslations();
-  mlir::substrait::registerSubstraitToProtobufTranslation();
-  mlir::substrait::registerProtobufToSubstraitPlanTranslation();
-  mlir::substrait::registerProtobufToSubstraitPlanVersionTranslation();
+  registerSubstraitToProtobufTranslation();
+  registerProtobufToSubstraitPlanTranslation();
+  registerProtobufToSubstraitPlanVersionTranslation();
 
   return failed(
       mlir::mlirTranslateMain(argc, argv, "MLIR Translation Testing Tool"));


### PR DESCRIPTION
That flag was disabled when `clang-tidy` was set up initially in #140 because it failed in too many places. This PR enables it and fixes all instances found by `clang-tidy` such that the style will be enforced in the future.