### PR TITLE
ci(dependabot): try different syntax for module filtering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - dependency-name: "llvm-project"
+      - dependency-name: "third_party/llvm-project"
 
   # All other git submodules.
   - package-ecosystem: "gitsubmodule"
@@ -14,4 +14,4 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "llvm-project"
+      - dependency-name: "third_party/llvm-project"


### PR DESCRIPTION
The intention of the dependabot configuration is to update LLVM weekly and everything else daily. This was achieved with the `allow` and `ignore` tags, which take the dependency name as an argument. Apparently, what I tried first (`llvm-project`) does not correspond to the expected format since we now see daily updates for LLVM. This PR changes the syntax to the string in quotes in `.gitmodules`.