### PR TITLE
ci(clang-format): handle system headers with `-` and `_` correctly

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ IncludeCategories:
     Priority:        3
   - Regex:           '^"(substrait-mlir|substrait-mlir-c)/'
     Priority:        2
-  - Regex:           '<[[:alnum:].]+>'
+  - Regex:           '<[-[:alnum:]_.]+>'
     Priority:        5
   - Regex:           '.*'
     Priority:        0

--- a/lib/Target/SubstraitPB/ProtobufUtils.h
+++ b/lib/Target/SubstraitPB/ProtobufUtils.h
@@ -9,9 +9,9 @@
 #ifndef LIB_TARGET_SUBSTRAITPB_PROTOBUFUTILS_H
 #define LIB_TARGET_SUBSTRAITPB_PROTOBUFUTILS_H
 
-#include <type_traits>
-
 #include "mlir/IR/Location.h"
+
+#include <type_traits>
 
 namespace substrait::proto {
 class RelCommon;


### PR DESCRIPTION
The regex for defining the ordering for system headers did not contain the `-` and `_` characters to `#include <type_traits>` was not ordered correctly. This PR fixes that.