### PR TITLE
style(clang-tidy): fix issues found in clang-tidy in header files

### DIFF
--- a/include/substrait-mlir-c/Dialects.h
+++ b/include/substrait-mlir-c/Dialects.h
@@ -12,6 +12,8 @@
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/substrait-mlir/Dialect/Substrait/Transforms/Passes.h
+++ b/include/substrait-mlir/Dialect/Substrait/Transforms/Passes.h
@@ -11,11 +11,17 @@
 
 #include "mlir/Pass/Pass.h"
 
+#include <memory>
+
+namespace mlir {
+class RewritePatternSet;
+}
+
 namespace mlir {
 namespace substrait {
 
 #define GEN_PASS_DECL
-#include "substrait-mlir/Dialect/Substrait/Transforms/Passes.h.inc"
+#include "substrait-mlir/Dialect/Substrait/Transforms/Passes.h.inc" // IWYU pragma: export
 
 /// Create a pass to eliminate duplicate fields in `emit` ops.
 std::unique_ptr<Pass> createEmitDeduplicationPass();
@@ -25,7 +31,7 @@ void populateEmitDeduplicationPatterns(RewritePatternSet &patterns);
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
-#include "substrait-mlir/Dialect/Substrait/Transforms/Passes.h.inc"
+#include "substrait-mlir/Dialect/Substrait/Transforms/Passes.h.inc" // IWYU pragma: export
 
 } // namespace substrait
 } // namespace mlir

--- a/include/substrait-mlir/Target/SubstraitPB/Options.h
+++ b/include/substrait-mlir/Target/SubstraitPB/Options.h
@@ -9,8 +9,6 @@
 #ifndef SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_OPTIONS_H
 #define SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_OPTIONS_H
 
-#include "llvm/ADT/StringRef.h"
-
 namespace mlir {
 namespace substrait {
 


### PR DESCRIPTION
Unforuntately, CMake isn't able to run clang-tidy on header files and I have not been able to make clang-tidy report errors in our header files using its `--header-filter` argument, so we don't get reports on issues in the header files through our CI or running CMake locally. However, I have run clang-tidy against this code base using Google tooling and found a few minor issues. This PR fixes them.