### PR TITLE
style: suppress warning of unused variable without assertions

### DIFF
--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1233,6 +1233,7 @@ public:
     }
     anchors.insert(anchor);
     auto [_, hasInserted] = anchorsByOp.try_emplace(op, anchor);
+    (void)hasInserted;
     assert(hasInserted && "op had already been assigned an anchor");
     return anchor;
   }


### PR DESCRIPTION
This PR suppresses a warning of an unused variable that only surfaces if built without assertions (because that variable is only used in an assertion). Since #160, we test building without assertions in CI as a post-merge check, which currently fails. Fixing this resolves #158.