### PR TITLE
feat: enable stack printing signal handler in opt builds

### DIFF
--- a/tools/substrait-lsp-server/substrait-lsp-server.cpp
+++ b/tools/substrait-lsp-server/substrait-lsp-server.cpp
@@ -36,11 +36,9 @@ void registerSubstraitDialects(DialectRegistry &registry) {
 } // namespace
 
 int main(int argc, char **argv) {
-#ifndef NDEBUG
   static std::string executable =
       llvm::sys::fs::getMainExecutable(nullptr, nullptr);
   llvm::sys::PrintStackTraceOnErrorSignal(executable);
-#endif
 
   registerAllPasses();
 

--- a/tools/substrait-opt/substrait-opt.cpp
+++ b/tools/substrait-opt/substrait-opt.cpp
@@ -34,11 +34,9 @@ void registerSubstraitDialects(DialectRegistry &registry) {
 } // namespace
 
 int main(int argc, char **argv) {
-#ifndef NDEBUG
   static std::string executable =
       llvm::sys::fs::getMainExecutable(nullptr, nullptr);
   llvm::sys::PrintStackTraceOnErrorSignal(executable);
-#endif
 
   registerAllPasses();
   registerSubstraitPasses();

--- a/tools/substrait-translate/substrait-translate.cpp
+++ b/tools/substrait-translate/substrait-translate.cpp
@@ -22,7 +22,11 @@
 #include "mlir/Tools/mlir-translate/Translation.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Signals.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include <string>
 
 using namespace mlir;
 using namespace mlir::substrait;
@@ -85,6 +89,10 @@ void registerProtobufToSubstraitPlanVersionTranslation() {
 } // namespace
 
 int main(int argc, char **argv) {
+  static std::string executable =
+      llvm::sys::fs::getMainExecutable(nullptr, nullptr);
+  llvm::sys::PrintStackTraceOnErrorSignal(executable);
+
   mlir::registerAllTranslations();
   registerSubstraitToProtobufTranslation();
   registerProtobufToSubstraitPlanTranslation();


### PR DESCRIPTION
This PR enables the signal handler that prints a stack trace on error in release builds (and even if assertions are disabled). Previously, the signal handler was only installed if `NDEBUG` was set. However, that lead to warnings about unused includes. I also don't see a good reason why the handlers shouldn't be enabled in release mode as well. Finally, `substrait-translate` did not have the logic for the system handlers, yet, so this PR also adds them there.