### PR TITLE
ci(dependabot): try yet another format for `ignore`/`allow`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     allow:
-      - dependency-name: "third_party/llvm-project"
+      - dependency-name: "llvm-project"
 
   # All other git submodules.
   - package-ecosystem: "gitsubmodule"


### PR DESCRIPTION
This PR tries again another format for repositories in the `ignore` field of the configuration of dependabot. What isn't clearly documented is whether this is a *name*  (as specified in `.gitmodule`), a path, or a pattern/regex. The initial configuration only put the folder name (without `third_party` prefix) but that did not work for ignoring the `llvm-project` dependency (which was specified for the `/` directory. #151 then tried to prepend `third_party/` everywhere, but this seems to
have broken the `allow` field of the `llvm-project` dependency, which is given in the `third_party/` folder. My best now is that the `ignore` and `allow` fields are interpreted relative to the `directory`, which would explain both previously observed breakages. If that interpretation is correct, we should now (finally!) get weekly updates for LLVM and daily updates for everything else.