### PR TITLE
feat: verify that `ProjectOp` has at least one expression

### DIFF
--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -1316,6 +1316,10 @@ LogicalResult ProjectOp::verifyRegions() {
            << yieldOp.getOperandTypes() << ")";
   }
 
+  // Verify that there is at least one value yielded.
+  if (yieldOp.getNumOperands() == 0)
+    return emitOpError() << "has 'expressions' region that yields no values";
+
   return success();
 }
 

--- a/test/Dialect/Substrait/project-invalid.mlir
+++ b/test/Dialect/Substrait/project-invalid.mlir
@@ -57,3 +57,17 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : rel<si32, si1>
   }
 }
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    // expected-error@+1 {{'substrait.project' op has 'expressions' region that yields no values}}
+    %1 = project %0 : rel<si32> -> rel<si32> {
+    ^bb0(%arg : tuple<si32>):
+      yield
+    }
+    yield %1 : rel<si32>
+  }
+}


### PR DESCRIPTION
This is a required condition [as per the spec](https://substrait.io/relations/logical_relations/#project-operation). This resolves #156.