### PR TITLE
feat: refuse to import/export `ProjectOp` without expressions

### DIFF
--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1449,6 +1449,8 @@ SubstraitExporter::exportOperation(ProjectOp op) {
   // Build `Expression` messages.
   auto yieldOp =
       llvm::cast<YieldOp>(op.getExpressions().front().getTerminator());
+  if (yieldOp->getNumOperands() == 0)
+    return op->emitOpError("not supported for export: no expressions");
   for (Value val : yieldOp.getValue()) {
     // Make sure the yielded value was produced by an expression op.
     auto exprRootOp =

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -1078,6 +1078,7 @@ static FailureOr<PlanVersionOp> importTopLevel(ImplicitLocOpBuilder builder,
 
 static mlir::FailureOr<ProjectOp> importProjectRel(ImplicitLocOpBuilder builder,
                                                    const Rel &message) {
+  Location loc = builder.getLoc();
   const ProjectRel &projectRel = message.project();
 
   // Import input op.
@@ -1094,6 +1095,9 @@ static mlir::FailureOr<ProjectOp> importProjectRel(ImplicitLocOpBuilder builder,
   // Fill `expressions` block with expression trees.
   YieldOp yieldOp;
   {
+    if (projectRel.expressions_size() == 0)
+      return emitError(loc) << "`ProjectRel` must have at least one expression";
+
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToEnd(conditionBlock.get());
 

--- a/test/Target/SubstraitPB/Export/project-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/project-invalid.mlir
@@ -1,0 +1,16 @@
+// RUN: substrait-translate -verify-diagnostics -split-input-file %s \
+// RUN:   -substrait-to-protobuf
+
+// Empty project op: the export can't deal with that.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : rel<si32>
+    // expected-error@+1 {{'substrait.project' op not supported for export: no expressions}}
+    %1 = project %0 : rel<si32> -> rel<si32> {
+    ^bb0(%arg0: tuple<si32>):
+      yield
+    }
+    yield %1 : rel<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -60,10 +60,11 @@ substrait.plan version 0 : 42 : 1 {
     %1 = project %0
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
-            : rel<si32> -> rel<si32> {
+            : rel<si32> -> rel<si32, si32> {
     ^bb0(%arg0: tuple<si32>):
-      yield
+      %2 = field_reference %arg0[0] : tuple<si32>
+      yield %2 : si32
     }
-    yield %1 : rel<si32>
+    yield %1 : rel<si32, si32>
   }
 }

--- a/test/Target/SubstraitPB/Import/project-invalid.textpb
+++ b/test/Target/SubstraitPB/Import/project-invalid.textpb
@@ -1,0 +1,42 @@
+# RUN: substrait-translate -verify-diagnostics -split-input-file %s \
+# RUN:   -protobuf-to-substrait
+
+# Empty project op: the import can't deal with that.
+# expected-error@unknown {{`ProjectRel` must have at least one expression}}
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}

--- a/test/Target/SubstraitPB/Import/project.textpb
+++ b/test/Target/SubstraitPB/Import/project.textpb
@@ -105,6 +105,16 @@ relations {
           }
         }
       }
+      expressions {
+        selection {
+          direct_reference {
+            struct_field {
+            }
+          }
+          root_reference {
+          }
+        }
+      }
       advanced_extension {
         optimization {
           type_url: "type.googleapis.com/google.protobuf.Int32Value"


### PR DESCRIPTION
The [Substrait spec](https://substrait.io/relations/logical_relations/#project-operation) requires at least one expression in `ProjectRel`. However, it may be useful to allow empty `ProjectOp`s, for example, as an intermediate state of emit deduplication, where one pattern may remove the last expression and another pattern remove the resulting empty `ProjectOp`. This PR, thus, introduces checks during import and exports that refuse to import or export `Project(Op|Rel)`s without expressions but continues to allow them in the IR otherwise. This resolves #156.

I believe that this is a better alternative to #164.