### PR TITLE
refactor: move format handling from nanobind to Python

### DIFF
--- a/include/substrait-mlir-c/Dialects.h
+++ b/include/substrait-mlir-c/Dialects.h
@@ -34,12 +34,14 @@ MlirType mlirSubstraitRelationTypeGet(MlirContext context, intptr_t numFields,
                                       MlirType *fieldTypes);
 
 /// Serialization/deserialization format for exporting/importing Substrait
-/// plans. This corresponds to `::mlir::substrait::SerdeFormat`.
-typedef enum MlirSubstraitSerdeFormat {
-  MlirSubstraitTextSerdeFormat,
-  MlirSubstraitBinarySerdeFormat,
-  MlirSubstraitJsonSerdeFormat,
-  MlirSubstraitPrettyJsonSerdeFormat
+/// plans. The enum values correspond exactly to those in
+/// `mlir::substrait::SerializationFromat`, i.e., conversion through integers
+/// is possible.
+typedef enum MlirSubstraitSerializationFormat {
+  MlirSubstraitTextFormat,
+  MlirSubstraitBinaryFormat,
+  MlirSubstraitJsonFormat,
+  MlirSubstraitPrettyJsonFormat
 } MlirSubstraitSerdeFormat;
 
 /// Imports a `Plan` message from `input`, which must be in the specified

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -76,6 +76,18 @@ def JoinType : I32EnumAttr<"JoinType", "", [
   let cppNamespace = "::mlir::substrait";
 }
 
+/// Serialization format for Substrait query plans (after export/befor import).
+def SerializationFormat : I32EnumAttr<"SerializationFormat", "", [
+    // clang-format off
+    I32EnumAttrCase<"text", 0>,
+    I32EnumAttrCase<"binary", 1>,
+    I32EnumAttrCase<"json", 2>,
+    I32EnumAttrCase<"prettyjson", 3>,
+    // clang-format on
+  ]> {
+  let cppNamespace = "::mlir::substrait";
+}
+
 /// Represents the `SetOp` protobuf enum.
 ///
 /// The enum values correspond exactly to those in the `SetRel.SetOp` enum,

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -76,18 +76,6 @@ def JoinType : I32EnumAttr<"JoinType", "", [
   let cppNamespace = "::mlir::substrait";
 }
 
-/// Serialization format for Substrait query plans (after export/befor import).
-def SerializationFormat : I32EnumAttr<"SerializationFormat", "", [
-    // clang-format off
-    I32EnumAttrCase<"text", 0>,
-    I32EnumAttrCase<"binary", 1>,
-    I32EnumAttrCase<"json", 2>,
-    I32EnumAttrCase<"prettyjson", 3>,
-    // clang-format on
-  ]> {
-  let cppNamespace = "::mlir::substrait";
-}
-
 /// Represents the `SetOp` protobuf enum.
 ///
 /// The enum values correspond exactly to those in the `SetRel.SetOp` enum,

--- a/include/substrait-mlir/Target/SubstraitPB/Options.h
+++ b/include/substrait-mlir/Target/SubstraitPB/Options.h
@@ -9,11 +9,12 @@
 #ifndef SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_OPTIONS_H
 #define SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_OPTIONS_H
 
-#include "substrait-mlir/Dialect/Substrait/IR/Substrait.h"
-
 namespace mlir {
 namespace substrait {
 
+/// Serialization formats for serialization and deserialization to and from
+/// protobuf messages.
+enum class SerializationFormat { kText, kBinary, kJson, kPrettyJson };
 struct ImportExportOptions {
   /// Specifies which serialization formats is used for serialization and
   /// deserialization to and from protobuf messages.

--- a/include/substrait-mlir/Target/SubstraitPB/Options.h
+++ b/include/substrait-mlir/Target/SubstraitPB/Options.h
@@ -9,17 +9,15 @@
 #ifndef SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_OPTIONS_H
 #define SUBSTRAIT_MLIR_TARGET_SUBSTRAITPB_OPTIONS_H
 
+#include "substrait-mlir/Dialect/Substrait/IR/Substrait.h"
+
 namespace mlir {
 namespace substrait {
-
-/// Serialization formats for serialization and deserialization to and from
-/// protobuf messages.
-enum class SerdeFormat { kText, kBinary, kJson, kPrettyJson };
 
 struct ImportExportOptions {
   /// Specifies which serialization formats is used for serialization and
   /// deserialization to and from protobuf messages.
-  SerdeFormat serdeFormat;
+  SerializationFormat serializationFormat;
 };
 
 } // namespace substrait

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -48,25 +48,10 @@ MlirType mlirSubstraitRelationTypeGet(MlirContext context, intptr_t numFields,
   return wrap(RelationType::get(unwrap(context), typesRef));
 }
 
-/// Converts the provided enum value into the equivalent value from
-/// `::mlir::substrait::SerdeFormat`.
-SerdeFormat convertSerdeFormat(MlirSubstraitSerdeFormat format) {
-  switch (format) {
-  case MlirSubstraitBinarySerdeFormat:
-    return SerdeFormat::kBinary;
-  case MlirSubstraitTextSerdeFormat:
-    return SerdeFormat::kText;
-  case MlirSubstraitJsonSerdeFormat:
-    return SerdeFormat::kJson;
-  case MlirSubstraitPrettyJsonSerdeFormat:
-    return SerdeFormat::kPrettyJson;
-  }
-}
-
 MlirModule mlirSubstraitImportPlan(MlirContext context, MlirStringRef input,
                                    MlirSubstraitSerdeFormat format) {
   ImportExportOptions options;
-  options.serdeFormat = convertSerdeFormat(format);
+  options.serializationFormat = static_cast<SerializationFormat>(format);
   OwningOpRef<ModuleOp> owning =
       translateProtobufToSubstraitPlan(unwrap(input), unwrap(context), options);
   if (!owning)
@@ -79,7 +64,7 @@ MlirAttribute mlirSubstraitExportPlan(MlirOperation op,
   std::string str;
   llvm::raw_string_ostream stream(str);
   ImportExportOptions options;
-  options.serdeFormat = convertSerdeFormat(format);
+  options.serializationFormat = static_cast<SerializationFormat>(format);
   if (failed(translateSubstraitToProtobuf(unwrap(op), stream, options)))
     return wrap(Attribute());
   MLIRContext *context = unwrap(op)->getContext();

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1660,22 +1660,22 @@ mlir::LogicalResult mlir::substrait::translateSubstraitToProtobuf(
 
   std::string out;
   switch (options.serializationFormat) {
-  case SerializationFormat::text:
+  case SerializationFormat::kText:
     if (!::google::protobuf::TextFormat::PrintToString(*result.value(), &out)) {
       op->emitOpError("could not be serialized to text format");
       return failure();
     }
     break;
-  case SerializationFormat::binary:
+  case SerializationFormat::kBinary:
     if (!result->get()->SerializeToString(&out)) {
       op->emitOpError("could not be serialized to binary format");
       return failure();
     }
     break;
-  case SerializationFormat::json:
-  case SerializationFormat::prettyjson: {
+  case SerializationFormat::kJson:
+  case SerializationFormat::kPrettyJson: {
     ::google::protobuf::util::JsonPrintOptions jsonOptions;
-    if (options.serializationFormat == SerializationFormat::prettyjson)
+    if (options.serializationFormat == SerializationFormat::kPrettyJson)
       jsonOptions.add_whitespace = true;
     absl::Status status = ::google::protobuf::util::MessageToJsonString(
         *result.value(), &out, jsonOptions);

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1659,23 +1659,23 @@ mlir::LogicalResult mlir::substrait::translateSubstraitToProtobuf(
     return failure();
 
   std::string out;
-  switch (options.serdeFormat) {
-  case substrait::SerdeFormat::kText:
+  switch (options.serializationFormat) {
+  case SerializationFormat::text:
     if (!::google::protobuf::TextFormat::PrintToString(*result.value(), &out)) {
       op->emitOpError("could not be serialized to text format");
       return failure();
     }
     break;
-  case substrait::SerdeFormat::kBinary:
+  case SerializationFormat::binary:
     if (!result->get()->SerializeToString(&out)) {
       op->emitOpError("could not be serialized to binary format");
       return failure();
     }
     break;
-  case substrait::SerdeFormat::kJson:
-  case substrait::SerdeFormat::kPrettyJson: {
+  case SerializationFormat::json:
+  case SerializationFormat::prettyjson: {
     ::google::protobuf::util::JsonPrintOptions jsonOptions;
-    if (options.serdeFormat == SerdeFormat::kPrettyJson)
+    if (options.serializationFormat == SerializationFormat::prettyjson)
       jsonOptions.add_whitespace = true;
     absl::Status status = ::google::protobuf::util::MessageToJsonString(
         *result.value(), &out, jsonOptions);

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -1279,23 +1279,23 @@ OwningOpRef<ModuleOp> translateProtobufToSubstraitTopLevel(
   Location loc = UnknownLoc::get(context);
 
   // Parse from serialized form into desired protobuf `MessageType`.
-  switch (options.serdeFormat) {
-  case SerdeFormat::kText:
+  switch (options.serializationFormat) {
+  case SerializationFormat::text:
     if (!pb::TextFormat::ParseFromString(input.str(), &message)) {
       emitError(loc) << "could not parse string as '" << message.GetTypeName()
                      << "' message.";
       return {};
     }
     break;
-  case SerdeFormat::kBinary:
+  case SerializationFormat::binary:
     if (!message.ParseFromString(input.str())) {
       emitError(loc) << "could not deserialize input as '"
                      << message.GetTypeName() << "' message.";
       return {};
     }
     break;
-  case SerdeFormat::kJson:
-  case SerdeFormat::kPrettyJson: {
+  case SerializationFormat::json:
+  case SerializationFormat::prettyjson: {
     absl::Status status = pb::util::JsonStringToMessage(input.str(), &message);
     if (!status.ok()) {
       emitError(loc) << "could not deserialize JSON as '"

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -1280,22 +1280,22 @@ OwningOpRef<ModuleOp> translateProtobufToSubstraitTopLevel(
 
   // Parse from serialized form into desired protobuf `MessageType`.
   switch (options.serializationFormat) {
-  case SerializationFormat::text:
+  case SerializationFormat::kText:
     if (!pb::TextFormat::ParseFromString(input.str(), &message)) {
       emitError(loc) << "could not parse string as '" << message.GetTypeName()
                      << "' message.";
       return {};
     }
     break;
-  case SerializationFormat::binary:
+  case SerializationFormat::kBinary:
     if (!message.ParseFromString(input.str())) {
       emitError(loc) << "could not deserialize input as '"
                      << message.GetTypeName() << "' message.";
       return {};
     }
     break;
-  case SerializationFormat::json:
-  case SerializationFormat::prettyjson: {
+  case SerializationFormat::kJson:
+  case SerializationFormat::kPrettyJson: {
     absl::Status status = pb::util::JsonStringToMessage(input.str(), &message);
     if (!status.ok()) {
       emitError(loc) << "could not deserialize JSON as '"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -89,6 +89,7 @@ nanobind_add_stub(
   MODULE substrait_mlir._mlir_libs._substraitDialects.substrait
   OUTPUT "${SUBSTRAIT_MLIR_BINARY_DIR}/python_packages/substrait_mlir/_mlir_libs/_substraitDialects/substrait.pyi"
   PYTHON_PATH "${SUBSTRAIT_MLIR_BINARY_DIR}/python_packages/"
+  PATTERN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/stubgen.patterns"
   DEPENDS SubstraitMLIRPythonModules
 )
 

--- a/python/SubstraitDialects.cpp
+++ b/python/SubstraitDialects.cpp
@@ -18,6 +18,9 @@
 namespace nb = nanobind;
 using namespace mlir::python::nanobind_adaptors;
 
+#define SERIALIZATION_FORMAT                                                   \
+  "substrait_mlir._mlir_libs._substraitDialects.substrait.SerializationFormat"
+
 NB_MODULE(_substraitDialects, mainModule) {
 #ifndef NDEBUG
   static std::string executable =
@@ -44,7 +47,7 @@ NB_MODULE(_substraitDialects, mainModule) {
       },
       nb::arg("context").none() = nb::none(), nb::arg("load") = true,
       nb::sig("def register_dialect("
-              "context: Optional[substrait_mlir.ir.Context] = None,"
+              "context: Optional[substrait_mlir.ir.Context] = None, "
               "load: bool = True) -> None"),
       "Register and optionally load the dialect with the given context");
 
@@ -84,7 +87,7 @@ NB_MODULE(_substraitDialects, mainModule) {
   // Import
   //
   substraitModule.def(
-      "import_",
+      "from_protobuf",
       [&](const nb::bytes &input, MlirSubstraitSerializationFormat format,
           MlirContext context) {
         MlirStringRef mlirInput{reinterpret_cast<const char *>(input.data()),
@@ -96,9 +99,9 @@ NB_MODULE(_substraitDialects, mainModule) {
       },
       nb::arg("input"), nb::arg("format") = MlirSubstraitTextFormat,
       nb::arg("context") = nb::none(),
-      nb::sig("def import_(input: bytes, "
-              "format: typing.Optional[SerializationFormat] ="
-              " SerializationFormat.text, "
+      nb::sig("def from_protobuf(input: bytes, "
+              "format: typing.Optional[" SERIALIZATION_FORMAT
+              "] = " SERIALIZATION_FORMAT ".text, "
               "context: typing.Optional[substrait_mlir.ir.Context] = None)"
               "-> substrait_mlir.ir.Module"),
       "Import the Substrait plan in the given serialization format");
@@ -108,7 +111,7 @@ NB_MODULE(_substraitDialects, mainModule) {
   //
 
   substraitModule.def(
-      "export",
+      "to_protobuf",
       [&](MlirOperation op, MlirSubstraitSerializationFormat format) {
         MlirAttribute attr = mlirSubstraitExportPlan(op, format);
         if (mlirAttributeIsNull(attr))
@@ -118,10 +121,10 @@ NB_MODULE(_substraitDialects, mainModule) {
         return nb::bytes(sv.data(), sv.size());
       },
       nb::arg("op"), nb::arg("format") = MlirSubstraitTextFormat,
-      nb::sig("def export("
+      nb::sig("def to_protobuf("
               "op: typing.Optional[substrait_mlir.ir.Operation] = None, "
-              "format: typing.Optional[SerializationFormat] ="
-              " SerializationFormat.text)"
+              "format: typing.Optional[" SERIALIZATION_FORMAT
+              "] = " SERIALIZATION_FORMAT ".text)"
               "-> bytes"),
       "Export the Substrait plan into the given format");
 }

--- a/python/SubstraitDialects.cpp
+++ b/python/SubstraitDialects.cpp
@@ -49,6 +49,18 @@ NB_MODULE(_substraitDialects, mainModule) {
       "Register and optionally load the dialect with the given context");
 
   //
+  // Enums
+  //
+
+  nb::enum_<MlirSubstraitSerializationFormat>(
+      substraitModule, "SerializationFormat", nb::is_arithmetic(),
+      nb::is_flag())
+      .value("text", MlirSubstraitTextFormat)
+      .value("binary", MlirSubstraitBinaryFormat)
+      .value("json", MlirSubstraitJsonFormat)
+      .value("pretty_json", MlirSubstraitPrettyJsonFormat);
+
+  //
   // Types
   //
 
@@ -71,102 +83,45 @@ NB_MODULE(_substraitDialects, mainModule) {
   //
   // Import
   //
-
-  static const auto importSubstraitPlan = [](MlirStringRef input,
-                                             MlirContext context,
-                                             MlirSubstraitSerdeFormat format) {
-    MlirModule module = mlirSubstraitImportPlan(context, input, format);
-    if (mlirModuleIsNull(module))
-      throw std::invalid_argument("Could not import Substrait plan");
-    return module;
-  };
-
   substraitModule.def(
-      "from_binpb",
-      [&](const nb::bytes &input, MlirContext context) {
+      "import_",
+      [&](const nb::bytes &input, MlirSubstraitSerializationFormat format,
+          MlirContext context) {
         MlirStringRef mlirInput{reinterpret_cast<const char *>(input.data()),
                                 input.size()};
-        return importSubstraitPlan(mlirInput, context,
-                                   MlirSubstraitBinarySerdeFormat);
+        MlirModule module = mlirSubstraitImportPlan(context, mlirInput, format);
+        if (mlirModuleIsNull(module))
+          throw std::invalid_argument("Could not import Substrait plan");
+        return module;
       },
-      nb::arg("input") = nb::none(), nb::arg("context") = nb::none(),
-      nb::sig("def from_binpb(input: bytes,"
+      nb::arg("input"), nb::arg("format") = MlirSubstraitTextFormat,
+      nb::arg("context") = nb::none(),
+      nb::sig("def import_(input: bytes, "
+              "format: typing.Optional[SerializationFormat] ="
+              " SerializationFormat.text, "
               "context: typing.Optional[substrait_mlir.ir.Context] = None)"
               "-> substrait_mlir.ir.Module"),
-      "Import a Substrait plan in the binary protobuf format");
-
-  substraitModule.def(
-      "from_textpb",
-      [&](const std::string &input, MlirContext context) {
-        return importSubstraitPlan({input.data(), input.size()}, context,
-                                   MlirSubstraitTextSerdeFormat);
-      },
-      nb::arg("input") = nb::none(), nb::arg("context") = nb::none(),
-      nb::sig("def from_textpb(input: str,"
-              "context: typing.Optional[substrait_mlir.ir.Context] = None)"
-              "-> substrait_mlir.ir.Module"),
-      "Import a Substrait plan in the textual protobuf format");
-
-  substraitModule.def(
-      "from_json",
-      [&](const std::string &input, MlirContext context) {
-        return importSubstraitPlan({input.data(), input.size()}, context,
-                                   MlirSubstraitJsonSerdeFormat);
-      },
-      nb::arg("input") = nb::none(), nb::arg("context") = nb::none(),
-      nb::sig("def from_json(input: str,"
-              "context: typing.Optional[substrait_mlir.ir.Context] = None)"
-              "-> substrait_mlir.ir.Module"),
-      "Import a Substrait plan in the JSON format");
+      "Import the Substrait plan in the given serialization format");
 
   //
   // Export
   //
 
-  static const auto exportSubstraitPlan = [](MlirOperation op,
-                                             MlirSubstraitSerdeFormat format) {
-    MlirAttribute attr = mlirSubstraitExportPlan(op, format);
-    if (mlirAttributeIsNull(attr))
-      throw std::invalid_argument("Could not export Substrait plan");
-    MlirStringRef strRef = mlirStringAttrGetValue(attr);
-    std::string_view str(strRef.data, strRef.length);
-    return str;
-  };
-
   substraitModule.def(
-      "to_binpb",
-      [&](MlirOperation op) {
-        std::string_view sv =
-            exportSubstraitPlan(op, MlirSubstraitBinarySerdeFormat);
+      "export",
+      [&](MlirOperation op, MlirSubstraitSerializationFormat format) {
+        MlirAttribute attr = mlirSubstraitExportPlan(op, format);
+        if (mlirAttributeIsNull(attr))
+          throw std::invalid_argument("Could not export Substrait plan");
+        MlirStringRef strRef = mlirStringAttrGetValue(attr);
+        std::string_view sv(strRef.data, strRef.length);
         return nb::bytes(sv.data(), sv.size());
       },
-      nb::arg("op"),
-      nb::sig("def to_binpb("
-              "op: typing.Optional[substrait_mlir.ir.Operation] = None)"
+      nb::arg("op"), nb::arg("format") = MlirSubstraitTextFormat,
+      nb::sig("def export("
+              "op: typing.Optional[substrait_mlir.ir.Operation] = None, "
+              "format: typing.Optional[SerializationFormat] ="
+              " SerializationFormat.text)"
               "-> bytes"),
-      "Export a Substrait plan into the binary protobuf format");
-
-  substraitModule.def(
-      "to_textpb",
-      [&](MlirOperation op) {
-        return exportSubstraitPlan(op, MlirSubstraitTextSerdeFormat);
-      },
-      nb::arg("op"),
-      nb::sig(
-          "def to_textpb("
-          "op: typing.Optional[substrait_mlir.ir.Operation] = None) -> str"),
-      "Export a Substrait plan into the textual protobuf format");
-
-  substraitModule.def(
-      "to_json",
-      [&](MlirOperation op, bool pretty) {
-        auto format = pretty ? MlirSubstraitPrettyJsonSerdeFormat
-                             : MlirSubstraitJsonSerdeFormat;
-        return exportSubstraitPlan(op, format);
-      },
-      nb::arg("op"), nb::arg("pretty") = false,
-      nb::sig("def to_json("
-              "op: typing.Optional[substrait_mlir.ir.Operation] = None,"
-              "pretty: typing.Optional[bool] = False) -> str"),
-      "Export a Substrait plan into the JSON format");
+      "Export the Substrait plan into the given format");
 }

--- a/python/stubgen.patterns
+++ b/python/stubgen.patterns
@@ -1,0 +1,3 @@
+# Remove the `__str__` type stub from `SerializationFormat` because it produces
+# an invalid assignment.
+SerializationFormat\.__str__:

--- a/python/substrait_mlir/dialects/substrait.py
+++ b/python/substrait_mlir/dialects/substrait.py
@@ -19,6 +19,38 @@ except ImportError as e:
   raise RuntimeError("Error loading imports from extension module") from e
 
 
+def from_textpb(input: str, ctx: ir.Context = None) -> ir.Module:
+  """Import the Substrait plan from the textual protobuf format"""
+  return import_(input.encode(), SerializationFormat.text, ctx)
+
+
+def from_binpb(input: bytes, ctx: ir.Context = None) -> ir.Module:
+  """Import the Substrait plan from the binary protobuf format"""
+  return import_(input, SerializationFormat.binary, ctx)
+
+
+def from_json(input: str, ctx: ir.Context = None) -> ir.Module:
+  """Import the Substrait plan from the JSON protobuf format"""
+  return import_(input.encode(), SerializationFormat.json, ctx)
+
+
+def to_textpb(op: ir.Operation) -> str:
+  """Export the Substrait plan into the textual protobuf format"""
+  return export(op, SerializationFormat.text).decode()
+
+
+def to_binpb(op: ir.Operation) -> bytes:
+  """Export the Substrait plan into the binary protobuf format"""
+  return export(op, SerializationFormat.binary)
+
+
+def to_json(op: ir.Operation, pretty: bool = False) -> str:
+  """Export the Substrait plan into the JSON protobuf format"""
+  if pretty:
+    return export(op, SerializationFormat.pretty_json).decode()
+  return export(op, SerializationFormat.json).decode()
+
+
 @_ods_cext.register_operation(_Dialect, replace=True)
 class PlanOp(PlanOp):
 

--- a/python/substrait_mlir/dialects/substrait.py
+++ b/python/substrait_mlir/dialects/substrait.py
@@ -19,36 +19,36 @@ except ImportError as e:
   raise RuntimeError("Error loading imports from extension module") from e
 
 
-def from_textpb(input: str, ctx: ir.Context = None) -> ir.Module:
+def from_textpb(input: str, context: Optional[ir.Context] = None) -> ir.Module:
   """Import the Substrait plan from the textual protobuf format"""
-  return import_(input.encode(), SerializationFormat.text, ctx)
+  return from_protobuf(input.encode(), SerializationFormat.text, context)
 
 
-def from_binpb(input: bytes, ctx: ir.Context = None) -> ir.Module:
+def from_binpb(input: bytes, context: Optional[ir.Context] = None) -> ir.Module:
   """Import the Substrait plan from the binary protobuf format"""
-  return import_(input, SerializationFormat.binary, ctx)
+  return from_protobuf(input, SerializationFormat.binary, context)
 
 
-def from_json(input: str, ctx: ir.Context = None) -> ir.Module:
+def from_json(input: str, context: Optional[ir.Context] = None) -> ir.Module:
   """Import the Substrait plan from the JSON protobuf format"""
-  return import_(input.encode(), SerializationFormat.json, ctx)
+  return from_protobuf(input.encode(), SerializationFormat.json, context)
 
 
 def to_textpb(op: ir.Operation) -> str:
   """Export the Substrait plan into the textual protobuf format"""
-  return export(op, SerializationFormat.text).decode()
+  return to_protobuf(op, SerializationFormat.text).decode()
 
 
 def to_binpb(op: ir.Operation) -> bytes:
   """Export the Substrait plan into the binary protobuf format"""
-  return export(op, SerializationFormat.binary)
+  return to_protobuf(op, SerializationFormat.binary)
 
 
 def to_json(op: ir.Operation, pretty: bool = False) -> str:
   """Export the Substrait plan into the JSON protobuf format"""
   if pretty:
-    return export(op, SerializationFormat.pretty_json).decode()
-  return export(op, SerializationFormat.json).decode()
+    return to_protobuf(op, SerializationFormat.pretty_json).decode()
+  return to_protobuf(op, SerializationFormat.json).decode()
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)

--- a/test/python/dialects/substrait/translate.py
+++ b/test/python/dialects/substrait/translate.py
@@ -36,7 +36,8 @@ def run(f):
 # CHECK-LABEL: TEST: testJsonFormat
 @run
 def testJsonFormat():
-  plan_module = ss.import_(JSON_PLAN.encode(), ss.SerializationFormat.json)
+  plan_module = ss.from_protobuf(JSON_PLAN.encode(),
+                                 ss.SerializationFormat.json)
   print(plan_module)
   # CHECK: substrait.plan version
 
@@ -48,8 +49,8 @@ def testJsonFormat():
   print(json_plan)
   # CHECK: {"version":{"minorNumber":42,"patchNumber":1}}
 
-  json_plan = ss.export(plan_module.operation,
-                        ss.SerializationFormat.json).decode()
+  json_plan = ss.to_protobuf(plan_module.operation,
+                             ss.SerializationFormat.json).decode()
   print(json_plan)
   # CHECK: {"version":{"minorNumber":42,"patchNumber":1}}
 

--- a/test/python/dialects/substrait/translate.py
+++ b/test/python/dialects/substrait/translate.py
@@ -36,11 +36,20 @@ def run(f):
 # CHECK-LABEL: TEST: testJsonFormat
 @run
 def testJsonFormat():
+  plan_module = ss.import_(JSON_PLAN.encode(), ss.SerializationFormat.json)
+  print(plan_module)
+  # CHECK: substrait.plan version
+
   plan_module = ss.from_json(JSON_PLAN)
   print(plan_module)
   # CHECK: substrait.plan version
 
   json_plan = ss.to_json(plan_module.operation)
+  print(json_plan)
+  # CHECK: {"version":{"minorNumber":42,"patchNumber":1}}
+
+  json_plan = ss.export(plan_module.operation,
+                        ss.SerializationFormat.json).decode()
   print(json_plan)
   # CHECK: {"version":{"minorNumber":42,"patchNumber":1}}
 

--- a/tools/substrait-translate/substrait-translate.cpp
+++ b/tools/substrait-translate/substrait-translate.cpp
@@ -36,24 +36,26 @@ void registerSubstraitDialects(DialectRegistry &registry) {
   registry.insert<mlir::substrait::SubstraitDialect>();
 }
 
+using SerdeFormat = mlir::substrait::SerializationFormat;
+
 llvm::cl::opt<SerdeFormat> substraitProtobufFormat(
     "substrait-protobuf-format", llvm::cl::ValueRequired,
     llvm::cl::desc(
         "Serialization format used when translating Substrait plans."),
     llvm::cl::values(
-        clEnumValN(SerdeFormat::kText, "text", "human-readable text format"),
-        clEnumValN(SerdeFormat::kBinary, "binary", "binary wire format"),
-        clEnumValN(SerdeFormat::kJson, "json", "compact JSON format"),
-        clEnumValN(SerdeFormat::kPrettyJson, "pretty-json",
+        clEnumValN(SerdeFormat::text, "text", "human-readable text format"),
+        clEnumValN(SerdeFormat::binary, "binary", "binary wire format"),
+        clEnumValN(SerdeFormat::json, "json", "compact JSON format"),
+        clEnumValN(SerdeFormat::prettyjson, "pretty-json",
                    "JSON format with new lines")),
-    llvm::cl::init(SerdeFormat::kText));
+    llvm::cl::init(SerdeFormat::text));
 
 void registerSubstraitToProtobufTranslation() {
   TranslateFromMLIRRegistration registration(
       "substrait-to-protobuf", "translate from Substrait MLIR to protobuf",
       [&](mlir::Operation *op, llvm::raw_ostream &output) {
         ImportExportOptions options;
-        options.serdeFormat = substraitProtobufFormat.getValue();
+        options.serializationFormat = substraitProtobufFormat.getValue();
         return translateSubstraitToProtobuf(op, output, options);
       },
       registerSubstraitDialects);
@@ -68,7 +70,7 @@ void registerProtobufToSubstraitPlanTranslation() {
         "translate a protobuf 'Plan' to Substrait MLIR",
         [&](llvm::StringRef input, mlir::MLIRContext *context) {
           ImportExportOptions options;
-          options.serdeFormat = substraitProtobufFormat.getValue();
+          options.serializationFormat = substraitProtobufFormat.getValue();
           return translateProtobufToSubstraitPlan(input, context, options);
         },
         registerSubstraitDialects);
@@ -81,7 +83,7 @@ void registerProtobufToSubstraitPlanVersionTranslation() {
       "translate a protobuf 'PlanVersion' to Substrait MLIR",
       [&](llvm::StringRef input, mlir::MLIRContext *context) {
         ImportExportOptions options;
-        options.serdeFormat = substraitProtobufFormat.getValue();
+        options.serializationFormat = substraitProtobufFormat.getValue();
         return translateProtobufToSubstraitPlanVersion(input, context, options);
       },
       registerSubstraitDialects);

--- a/tools/substrait-translate/substrait-translate.cpp
+++ b/tools/substrait-translate/substrait-translate.cpp
@@ -43,12 +43,12 @@ llvm::cl::opt<SerdeFormat> substraitProtobufFormat(
     llvm::cl::desc(
         "Serialization format used when translating Substrait plans."),
     llvm::cl::values(
-        clEnumValN(SerdeFormat::text, "text", "human-readable text format"),
-        clEnumValN(SerdeFormat::binary, "binary", "binary wire format"),
-        clEnumValN(SerdeFormat::json, "json", "compact JSON format"),
-        clEnumValN(SerdeFormat::prettyjson, "pretty-json",
+        clEnumValN(SerdeFormat::kText, "text", "human-readable text format"),
+        clEnumValN(SerdeFormat::kBinary, "binary", "binary wire format"),
+        clEnumValN(SerdeFormat::kJson, "json", "compact JSON format"),
+        clEnumValN(SerdeFormat::kPrettyJson, "pretty-json",
                    "JSON format with new lines")),
-    llvm::cl::init(SerdeFormat::text));
+    llvm::cl::init(SerdeFormat::kText));
 
 void registerSubstraitToProtobufTranslation() {
   TranslateFromMLIRRegistration registration(


### PR DESCRIPTION
This PR refactors the handling of the various serialization formats of the Substrait protobuf messages, in particular, on a Python level. Previously, the various `to_*` and `from_*` functions where implemented in C++ using `nanobind`, which is arguable cumbersome. The new implementation only implements a single import and export function, repsepectively, which gets an enum argument for the format. For that purpose, the PR also exposes that enum via `nanobind`. The previously existing import and export functions are now implemented in Python, where they are essentially one-liners calling the new functions.