### PR TITLE
feat: relax the region constraint for the `Substrait.PlanOp`

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -238,7 +238,7 @@ def Substrait_PlanRelOp : Substrait_Op<"relation", [
     reprents the root of the query tree that this op contains.
   }];
   let arguments = (ins OptionalAttr<StringArrayAttr>:$fieldNames);
-  let regions = (region RegionOf<RelationBodyOp>:$body);
+  let regions = (region AnyRegion:$body);
   let assemblyFormat = "(`as` $fieldNames^)? attr-dict-with-keyword $body";
   let hasRegionVerifier = 1;
   let builders = [


### PR DESCRIPTION
The region of the `Substrait.PlanOp` is not strictly limited to the `RelationBodyOp`'s, it is not `AnyRegion`. This is done to enable dialect conversion between Substrait and GoogleSQL (which now happens over two passes - the first pass transforms Substrait relations to GoogleSQL scan ops, the second pass transforms Substrait plans (containing GoogleSQL ops) to pure GoogleSQL IR. This requires relaxing the region constraint such that the first pass can be successful. 