### PR TITLE
fix: `llvm-prefer-static-over-anonymous-namespace` [WIP]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,8 @@ Checks: >
     -misc-unused-parameters,
     -misc-non-private-member-variables-in-classes,
     readability-braces-around-statements,
-    readability-identifier-naming
+    readability-identifier-naming,
+    llvm-prefer-static-over-anonymous-namespace,
 
 CheckOptions:
 - key: llvm-namespace-comment.ShortNamespaceLines

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -56,6 +56,8 @@ struct SubstraitEmitDeduplicationPass
   void runOnOperation() override;
 };
 
+} // namespace
+
 void SubstraitEmitDeduplicationPass::runOnOperation() {
   mlir::RewritePatternSet patterns(&getContext());
   populateEmitDeduplicationPatterns(patterns);
@@ -74,7 +76,7 @@ void SubstraitEmitDeduplicationPass::runOnOperation() {
 /// populates `reverseMapping` with the mapping that re-establishes the original
 /// order of the fields from the deduplicated order and returns the number of
 /// fields after deduplication and whether the `input` was deduplicated.
-std::tuple<Value, int64_t, bool>
+static std::tuple<Value, int64_t, bool>
 createDeduplicatingEmit(Value input, SmallVector<int64_t> &reverseMapping,
                         PatternRewriter &rewriter) {
   // Handles the bases cases where the input either has no `emit` op or an
@@ -149,8 +151,9 @@ createDeduplicatingEmit(Value input, SmallVector<int64_t> &reverseMapping,
 /// argument to work on the deduplicated type.
 // TODO(ingomueller): We could add an overload for this function that computes
 // `newElementType` from the type of the region argument and the mapping.
-void deduplicateRegionArgs(Region &region, ArrayAttr newMapping,
-                           Type newElementType, PatternRewriter &rewriter) {
+static void deduplicateRegionArgs(Region &region, ArrayAttr newMapping,
+                                  Type newElementType,
+                                  PatternRewriter &rewriter) {
   assert(region.getNumArguments() == 1 &&
          "only regions with 1 argument are supported");
   auto oldElementType = cast<TupleType>(region.getArgument(0).getType());
@@ -511,8 +514,6 @@ struct PushDuplicatesThroughProjectPattern
     return failure();
   }
 };
-
-} // namespace
 
 namespace mlir {
 namespace substrait {

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -27,12 +27,10 @@ namespace mlir::substrait::protobuf_utils {
 
 namespace pb = ::google::protobuf;
 
-namespace {
 template <typename RelType>
 static const RelCommon *getCommon(const RelType &rel) {
   return &rel.common();
 }
-} // namespace
 
 FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
   Rel::RelTypeCase relType = rel.rel_type_case();
@@ -60,12 +58,10 @@ FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
   }
 }
 
-namespace {
 template <typename RelType>
 static RelCommon *getMutableCommon(RelType *rel) {
   return rel->mutable_common();
 }
-} // namespace
 
 FailureOr<RelCommon *> getMutableCommon(Rel *rel, Location loc) {
   Rel::RelTypeCase relType = rel->rel_type_case();


### PR DESCRIPTION
Use the static keyword to restrict the visibility of functions to the current file instead of putting them into an anonymous namespace. Update `.clang-tidy` to `llvm-prefer-static-over-anonymous-namespace`.

This PR makes this change for all .cpp files (EXCEPT import.cpp). 
Addresses[ issue 169](https://github.com/substrait-io/substrait-mlir-contrib/issues/169).

