### PR TITLE
feat: `SortRel` mlir implementation

### DIFF
--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitEnums.td
@@ -94,4 +94,22 @@ def SetOpKind : I32EnumAttr<"SetOpKind", "", [
   let cppNamespace = "::mlir::substrait";
 }
 
+/// Represents the `SortField.SortDirection` protobuf enum.
+///
+/// The enum values correspond exactly to those in the
+/// `SortField.SortDirection` enum, i.e., conversion through integers is
+/// possible.
+def SortFieldComparisonType : I32EnumAttr<"SortFieldComparisonType", "", [
+    // clang-format off
+    I32EnumAttrCase<"UNSPECIFIED", 0>,
+    I32EnumAttrCase<"ASC_NULLS_FIRST", 1>,
+    I32EnumAttrCase<"ASC_NULLS_LAST", 2>,
+    I32EnumAttrCase<"DESC_NULLS_FIRST", 3>,
+    I32EnumAttrCase<"DESC_NULLS_LAST", 4>,
+    I32EnumAttrCase<"CLUSTERED", 5>,
+    // clang-format on
+  ]> {
+  let cppNamespace = "::mlir::substrait";
+}
+
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITENUMS

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitOps.td
@@ -260,7 +260,8 @@ def Substrait_YieldOp : Substrait_Op<"yield", [
       "::mlir::substrait::AggregateOp",
       "::mlir::substrait::FilterOp",
       "::mlir::substrait::PlanRelOp",
-      "::mlir::substrait::ProjectOp"
+      "::mlir::substrait::ProjectOp",
+      "::mlir::substrait::SortOp"
     ]>
   ]> {
   let summary = "Yields the result of a `PlanRelOp`";
@@ -876,6 +877,83 @@ def Substrait_SetOp : Substrait_RelOp<"set", [
         build($_builder, $_state, inputs, kind, /*advanced_extension=*/{});
       }]>,
     ];
+}
+
+def Substrait_SortFieldComparisonOp : Substrait_Op<"sort_field_compare", [
+    Pure
+  ]> {
+  let summary = "Sort field comparison operation";
+  let description = [{
+    Represents a comparison between two values for sorting purposes.
+  }];
+  let arguments = (ins
+    SortFieldComparisonType:$comparison_type,
+    AnyType:$left,
+    AnyType:$right
+  );
+  let results = (outs SI8:$result);
+  let assemblyFormat = [{
+    $comparison_type $left `,` $right attr-dict `:` `(` type($left) `,` type($right) `)` `->` type($result)
+  }];
+}
+
+def Substrait_SortOp : Substrait_RelOp<"sort", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    DeclareOpInterfaceMethods<Substrait_ExtensibleOpInterface>,
+    SameOperandsAndResultType
+  ]> {
+  let summary = "Sort operation";
+  let description = [{
+    Represents a `SortRel` message.
+
+    The repeated `sorts` field from the message is represented by the `sorts`
+    region. Each basic block in the `sorts` region corresponds to one `SortField`.
+    Each block takes two arguments, representing the two rows being compared
+    (LHS and RHS). The block must yield a single `si8` value (produced by a
+    `sort_field_compare` op) indicating the comparison result.
+
+    Example:
+
+    ```mlir
+    %0 = ...
+    %1 = sort %0 : rel<si32, si32> by {
+      // Sort by the first column in ascending order.
+      ^bb0(%arg0 : tuple<si32, si32>, %arg1 : tuple<si32, si32>):
+        %2 = field_reference %arg0[0] : tuple<si32, si32>
+        %3 = field_reference %arg1[0] : tuple<si32, si32>
+        %4 = sort_field_compare asc_nulls_first %2, %3: (si32, si32) -> si8
+        yield %4 : si8
+      // Then sort by the second column in descending order.
+      ^bb1(%arg2 : tuple<si32, si32>, %arg3 : tuple<si32, si32>):
+        %5 = field_reference %arg2[1] : tuple<si32, si32>
+        %6 = field_reference %arg3[1] : tuple<si32, si32>
+        %7 = sort_field_compare desc_nulls_last %5, %6: (si32, si32) -> si8
+        yield %7 : si8
+    }
+    ```
+  }];
+  let arguments = (ins
+    Substrait_Relation:$input,
+    OptionalAttr<Substrait_AdvancedExtensionAttr>:$advanced_extension
+  );
+  let results = (outs Substrait_Relation:$result);
+  let regions = (region AnyRegion:$sorts);
+  let assemblyFormat = [{
+    $input (`advanced_extension` `` $advanced_extension^)? attr-dict
+    `:` custom<SubstraitType>(type($input)) `by` $sorts
+  }];
+  let hasRegionVerifier = 1;
+  let builders = [
+      OpBuilder<(ins "::mlir::Value":$input), [{
+        build($_builder, $_state, input, /*advanced_extension=*/{});
+      }]>,
+    ];
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    ::llvm::StringRef $cppClass::getDefaultDialect() {
+      return SubstraitDialect::getDialectNamespace();
+    }
+  }];
 }
 
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITOPS

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -53,6 +53,8 @@ FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
     return getCommon(rel.read());
   case Rel::RelTypeCase::kSet:
     return getCommon(rel.set());
+  case Rel::RelTypeCase::kSort:
+    return getCommon(rel.sort());
   default:
     const pb::FieldDescriptor *desc =
         Rel::GetDescriptor()->FindFieldByNumber(relType);
@@ -86,6 +88,8 @@ FailureOr<RelCommon *> getMutableCommon(Rel *rel, Location loc) {
     return getMutableCommon(rel->mutable_read());
   case Rel::RelTypeCase::kSet:
     return getMutableCommon(rel->mutable_set());
+  case Rel::RelTypeCase::kSort:
+    return getMutableCommon(rel->mutable_sort());
   default:
     const pb::FieldDescriptor *desc =
         Rel::GetDescriptor()->FindFieldByNumber(relType);

--- a/test/Target/SubstraitPB/Export/sort.mlir
+++ b/test/Target/SubstraitPB/Export/sort.mlir
@@ -1,0 +1,144 @@
+// RUN: substrait-translate -substrait-to-protobuf %s --split-input-file --output-split-marker="# ""-----" | FileCheck %s
+
+// CHECK-LABEL: relations {
+// CHECK:         rel {
+// CHECK:           sort {
+// CHECK:             input {
+// CHECK:               read {
+// CHECK:                 base_schema {
+// CHECK:                   names: "a"
+// CHECK:                   names: "b"
+// CHECK:                   struct {
+// CHECK:                     types {
+// CHECK:                       i32 {
+// CHECK:                         nullability: NULLABILITY_REQUIRED
+// CHECK:                       }
+// CHECK:                     }
+// CHECK:                     types {
+// CHECK:                       i32 {
+// CHECK:                         nullability: NULLABILITY_REQUIRED
+// CHECK:                       }
+// CHECK:                     }
+// CHECK:                     nullability: NULLABILITY_REQUIRED
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:                 named_table {
+// CHECK:                   names: "t1"
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:             sorts {
+// CHECK:               expr {
+// CHECK:                 selection {
+// CHECK:                   direct_reference {
+// CHECK:                     struct_field {
+// CHECK:                     }
+// CHECK:                   }
+// CHECK:                   root_reference {
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:               }
+// CHECK:               direction: SORT_DIRECTION_ASC_NULLS_FIRST
+// CHECK:             }
+// CHECK:             sorts {
+// CHECK:               expr {
+// CHECK:                 selection {
+// CHECK:                   direct_reference {
+// CHECK:                     struct_field {
+// CHECK:                       field: 1
+// CHECK:                     }
+// CHECK:                   }
+// CHECK:                   root_reference {
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:               }
+// CHECK:               direction: SORT_DIRECTION_DESC_NULLS_LAST
+// CHECK:             }
+// CHECK:           }
+// CHECK:         }
+// CHECK:       }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
+    %1 = sort %0 : rel<si32, si32> by {
+      ^bb0(%arg0 : tuple<si32, si32>, %arg1 : tuple<si32, si32>):
+        %2 = field_reference %arg0[0] : tuple<si32, si32>
+        %3 = field_reference %arg1[0] : tuple<si32, si32>
+        %4 = sort_field_compare ASC_NULLS_FIRST %2, %3: (si32, si32) -> si8
+        yield %4 : si8
+      ^bb1(%arg2 : tuple<si32, si32>, %arg3 : tuple<si32, si32>):
+        %5 = field_reference %arg2[1] : tuple<si32, si32>
+        %6 = field_reference %arg3[1] : tuple<si32, si32>
+        %7 = sort_field_compare DESC_NULLS_LAST %5, %6: (si32, si32) -> si8
+        yield %7 : si8
+    }
+    yield %1 : rel<si32, si32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK:         rel {
+// CHECK:           sort {
+// CHECK:             input {
+// CHECK:               read {
+// CHECK:                 base_schema {
+// CHECK:                   names: "a"
+// CHECK:                   struct {
+// CHECK:                     types {
+// CHECK:                       i32 {
+// CHECK:                         nullability: NULLABILITY_REQUIRED
+// CHECK:                       }
+// CHECK:                     }
+// CHECK:                     nullability: NULLABILITY_REQUIRED
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:                 named_table {
+// CHECK:                   names: "t2"
+// CHECK:                 }
+// CHECK:               }
+// CHECK:             }
+// CHECK:             sorts {
+// CHECK:               expr {
+// CHECK:                 literal {
+// CHECK:                   i32: 100
+// CHECK:                 }
+// CHECK:               }
+// CHECK:               direction: SORT_DIRECTION_ASC_NULLS_FIRST
+// CHECK:             }
+// CHECK:             sorts {
+// CHECK:               expr {
+// CHECK:                 selection {
+// CHECK:                   direct_reference {
+// CHECK:                     struct_field {
+// CHECK:                     }
+// CHECK:                   }
+// CHECK:                   root_reference {
+// CHECK:                   }
+// CHECK:                 }
+// CHECK:               }
+// CHECK:               direction: SORT_DIRECTION_DESC_NULLS_LAST
+// CHECK:             }
+// CHECK:           }
+// CHECK:         }
+// CHECK:       }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t2 as ["a"] : rel<si32>
+    %1 = sort %0 : rel<si32> by {
+      ^bb0(%arg0 : tuple<si32>, %arg1 : tuple<si32>):
+        %2 = literal 100 : si32
+        %3 = sort_field_compare ASC_NULLS_FIRST %2, %2 : (si32, si32) -> si8
+        yield %3 : si8
+      ^bb1(%arg2 : tuple<si32>, %arg3 : tuple<si32>):
+        %4 = field_reference %arg2[0] : tuple<si32>
+        %5 = field_reference %arg3[0] : tuple<si32>
+        %6 = sort_field_compare DESC_NULLS_LAST %4, %5 : (si32, si32) -> si8
+        yield %6 : si8
+    }
+    yield %1 : rel<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Import/sort.textpb
+++ b/test/Target/SubstraitPB/Import/sort.textpb
@@ -1,0 +1,138 @@
+# RUN: substrait-translate -protobuf-to-substrait %s --split-input-file="# ""-----" | FileCheck %s
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation {
+# CHECK-NEXT:      %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<si32, si32>
+# CHECK-NEXT:      %[[V1:.*]] = sort %[[V0]] : rel<si32, si32> by {
+# CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: tuple<si32, si32>, %[[ARG1:.*]]: tuple<si32, si32>):
+# CHECK-NEXT:        %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V3:.*]] = field_reference %[[ARG1]][0] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V4:.*]] = sort_field_compare ASC_NULLS_FIRST %[[V2]], %[[V3]] : (si32, si32) -> si8
+# CHECK-NEXT:        yield %[[V4]] : si8
+# CHECK-NEXT:      ^bb1(%[[ARG2:.*]]: tuple<si32, si32>, %[[ARG3:.*]]: tuple<si32, si32>):
+# CHECK-NEXT:        %[[V5:.*]] = field_reference %[[ARG2]][1] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V6:.*]] = field_reference %[[ARG3]][1] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V7:.*]] = sort_field_compare DESC_NULLS_LAST %[[V5]], %[[V6]] : (si32, si32) -> si8
+# CHECK-NEXT:        yield %[[V7]] : si8
+# CHECK-NEXT:      }
+# CHECK-NEXT:      yield %[[V1]] : rel<si32, si32>
+
+relations {
+  rel {
+    sort {
+      common { direct {} }
+      input {
+        read {
+          common { direct {} }
+          base_schema {
+            names: "a"
+            names: "b"
+            struct {
+              types { i32 { nullability: NULLABILITY_REQUIRED } }
+              types { i32 { nullability: NULLABILITY_REQUIRED } }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table { names: "t1" }
+        }
+      }
+      sorts {
+        expr {
+          selection {
+            direct_reference { struct_field { field: 0 } }
+            root_reference {}
+          }
+        }
+        direction: SORT_DIRECTION_ASC_NULLS_FIRST
+      }
+      sorts {
+        expr {
+          selection {
+            direct_reference { struct_field { field: 1 } }
+            root_reference {}
+          }
+        }
+        direction: SORT_DIRECTION_DESC_NULLS_LAST
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation {
+# CHECK-NEXT:      %[[V0:.*]] = named_table @t1 as ["a", "b"] : rel<si32, si32>
+# CHECK-NEXT:      %[[V1:.*]] = sort %[[V0]] : rel<si32, si32> by {
+# CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: tuple<si32, si32>, %[[ARG1:.*]]: tuple<si32, si32>):
+# CHECK-NEXT:        %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V3:.*]] = field_reference %[[ARG1]][0] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V4:.*]] = sort_field_compare ASC_NULLS_FIRST %[[V2]], %[[V3]] : (si32, si32) -> si8
+# CHECK-NEXT:        yield %[[V4]] : si8
+# CHECK-NEXT:      ^bb1(%[[ARG2:.*]]: tuple<si32, si32>, %[[ARG3:.*]]: tuple<si32, si32>):
+# CHECK-NEXT:        %[[LIT1:.*]] = literal 42 : si32
+# CHECK-NEXT:        %[[LIT2:.*]] = literal 42 : si32
+# CHECK-NEXT:        %[[V5:.*]] = sort_field_compare DESC_NULLS_LAST %[[LIT1]], %[[LIT2]] : (si32, si32) -> si8
+# CHECK-NEXT:        yield %[[V5]] : si8
+# CHECK-NEXT:      ^bb2(%[[ARG4:.*]]: tuple<si32, si32>, %[[ARG5:.*]]: tuple<si32, si32>):
+# CHECK-NEXT:        %[[V6:.*]] = field_reference %[[ARG4]][0] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V7:.*]] = field_reference %[[ARG5]][0] : tuple<si32, si32>
+# CHECK-NEXT:        %[[V8:.*]] = sort_field_compare ASC_NULLS_LAST %[[V6]], %[[V7]] : (si32, si32) -> si8
+# CHECK-NEXT:        yield %[[V8]] : si8
+# CHECK-NEXT:      }
+# CHECK-NEXT:      yield %[[V1]] : rel<si32, si32>
+
+relations {
+  rel {
+    sort {
+      common { direct {} }
+      input {
+        read {
+          common { direct {} }
+          base_schema {
+            names: "a"
+            names: "b"
+            struct {
+              types { i32 { nullability: NULLABILITY_REQUIRED } }
+              types { i32 { nullability: NULLABILITY_REQUIRED } }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table { names: "t1" }
+        }
+      }
+      sorts {
+        expr {
+          selection {
+            direct_reference { struct_field { field: 0 } }
+            root_reference {}
+          }
+        }
+        direction: SORT_DIRECTION_ASC_NULLS_FIRST
+      }
+      sorts {
+        expr {
+          literal { i32: 42 }
+        }
+        direction: SORT_DIRECTION_DESC_NULLS_LAST
+      }
+      sorts {
+        expr {
+          selection {
+            direct_reference { struct_field { field: 0 } }
+            root_reference {}
+          }
+        }
+        direction: SORT_DIRECTION_ASC_NULLS_LAST
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
This commit adds support for the Substrait `SortRel` relation in the MLIR dialect.

Key Changes:
- **Operations**: Added `substrait.sort` and `substrait.sort_field_compare` operations to `SubstraitOps.td`.
- **Enums**: Added `SortFieldComparisonType` to `SubstraitEnums.td` to represent standard sort directions (e.g., `ASC_NULLS_FIRST`, `DESC_NULLS_LAST`).
- **Import Logic**: Implemented `importSortRel` in `Import.cpp`. This uses a temporary dummy region to instantiate the sort expression once, which is then cloned using `IRMapping` to populate the comparison block for both the LHS and RHS rows.
- **Export Logic**: Implemented `exportOperation` for `SortOp` in `Export.cpp` to generate the corresponding `SortRel` protobuf message.
- **Verification**: Added `SortOp::verifyRegions` to ensure the sort region is well-formed (blocks take two arguments and yield `si8`).

Supported Features:
- All standard sort directions defined in the Substrait specification (`ASC_NULLS_FIRST`, `ASC_NULLS_LAST`, `DESC_NULLS_FIRST`, `DESC_NULLS_LAST`, `CLUSTERED`).
- Sorting by arbitrary expressions supported by the dialect (field references, literals, etc.).

Limitations:
- **Custom Comparison Functions**: `comparison_function_reference` in `SortField` is not yet supported. The import process will emit an error if this field is set.

Tests:
- Added `test/Target/SubstraitPB/Import/sort.textpb`
- Added `test/Target/SubstraitPB/Export/sort.mlir`