### PR TITLE
feat: replace `tuple` placeholder with proper `struct` type

### DIFF
--- a/include/substrait-mlir-c/Dialects.h
+++ b/include/substrait-mlir-c/Dialects.h
@@ -41,6 +41,15 @@ bool mlirTypeIsASubstraitNullableType(MlirType type);
 MLIR_CAPI_EXPORTED
 MlirType mlirSubstraitNullableTypeGet(MlirContext context, MlirType innerType);
 
+/// Checks whether the given type is a `StructType`.
+MLIR_CAPI_EXPORTED
+bool mlirTypeIsASubstraitStructType(MlirType type);
+
+/// Gets the `StructType` with the given `fieldTypes`.
+MLIR_CAPI_EXPORTED
+MlirType mlirSubstraitStructTypeGet(MlirContext context, intptr_t numFields,
+                                    MlirType *fieldTypes);
+
 /// Serialization/deserialization format for exporting/importing Substrait
 /// plans. The enum values correspond exactly to those in
 /// `mlir::substrait::SerializationFormat`, i.e., conversion through integers

--- a/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/substrait-mlir/Dialect/Substrait/IR/SubstraitTypes.td
@@ -129,6 +129,21 @@ def Substrait_VarCharType : Substrait_Type<"VarChar", "var_char"> {
   let assemblyFormat = [{ `<` $length `>` }];
 }
 
+def Substrait_StructType : Substrait_Type<"Struct", "struct"> {
+  let summary = "Substrait struct type";
+  let description = [{
+    Represents a Substrait `Type.struct` — an ordered sequence of field types.
+    The nullability of the struct value itself is indicated by wrapping this
+    type in `NullableType` (e.g., `struct<i32, string?>?` is a nullable struct
+    with a required `i32` field and a nullable `string` field). Individual
+    field nullability is expressed the same way as for any expression type.
+  }];
+  let parameters = (ins
+    ArrayRefParameter<"::mlir::Type", "field types">:$fieldTypes
+  );
+  let hasCustomAssemblyFormat = 1;
+}
+
 def Substrait_NullableType : Substrait_Type<"Nullable", "nullable"> {
   let summary = "Nullable wrapper for a Substrait expression type";
   let description = [{
@@ -203,10 +218,8 @@ def Substrait_AtomicTypes {
 def Substrait_AtomicType :
   AnyTypeOf<Substrait_SimpleTypes.types#Substrait_ParametrizedTypes.types>;
 
-/// Any container type, i.e., structs, maps, lists, and nestings thereof,
-/// including those with nullable elements (e.g., `tuple<si32?>`).
-def Substrait_ContainerType : NestedTupleOf<
-    Substrait_AtomicTypes.types#[Substrait_NullableType]>;
+/// Any container type; currently only `StructType` (`MapType`/`ListType` TBD).
+def Substrait_ContainerType : AnyTypeOf<[Substrait_StructType]>;
 
 /// Currently supported expression types.
 def Substrait_ExpressionTypes {
@@ -232,13 +245,14 @@ def Substrait_Relation : Substrait_Type<"Relation", "relation"> {
   let summary = "Substrait relation, i.e., result of `RelOpInterface` ops";
   let description = [{
   }];
-  let parameters = (ins AnyTuple:$structType);
+  let parameters = (ins Substrait_StructType:$structType);
   let builders = [
     TypeBuilder<(ins "TypeRange":$fieldTypes), [{
-      return $_get($_ctxt, ::mlir::TupleType::get($_ctxt, fieldTypes));
+      return $_get($_ctxt, StructType::get($_ctxt,
+          SmallVector<Type>(fieldTypes.begin(), fieldTypes.end())));
     }]>,
     TypeBuilder<(ins), [{
-      return $_get($_ctxt, ::mlir::TupleType::get($_ctxt));
+      return $_get($_ctxt, StructType::get($_ctxt, SmallVector<Type>{}));
     }]>,
   ];
   let skipDefaultBuilders = 1;
@@ -246,11 +260,8 @@ def Substrait_Relation : Substrait_Type<"Relation", "relation"> {
   let extraClassDeclaration = [{
     /// Get the field types of the relation.
     ArrayRef<Type> getFieldTypes() const {
-      return getStructType().getTypes();
+      return getStructType().getFieldTypes();
     }
-
-    /// Get the field types of the relation (for symmetry with `TupleType`).
-    ArrayRef<Type> getTypes() const { return getFieldTypes(); }
 
     /// Return the number of fields.
     size_t size() const { return getFieldTypes().size(); }

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -56,6 +56,17 @@ MlirType mlirSubstraitNullableTypeGet(MlirContext context, MlirType innerType) {
   return wrap(NullableType::get(unwrap(context), unwrap(innerType)));
 }
 
+bool mlirTypeIsASubstraitStructType(MlirType type) {
+  return mlir::isa<StructType>(unwrap(type));
+}
+
+MlirType mlirSubstraitStructTypeGet(MlirContext context, intptr_t numFields,
+                                    MlirType *fieldTypes) {
+  SmallVector<Type, 4> types;
+  ArrayRef<Type> typesRef = unwrapList(numFields, fieldTypes, types);
+  return wrap(StructType::get(unwrap(context), typesRef));
+}
+
 MlirModule mlirSubstraitImportPlan(MlirContext context, MlirStringRef input,
                                    MlirSubstraitSerdeFormat format) {
   ImportExportOptions options;

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -637,6 +637,7 @@ static StringRef getTypeKeyword(Type type) {
       .Case<IntervalYearMonthType>([&](Type) { return "interval_ym"; })
       .Case<RelationType>([&](Type) { return "rel"; })
       .Case<StringType>([&](Type) { return "string"; })
+      .Case<StructType>([&](Type) { return "struct"; })
       .Case<TimeType>([&](Type) { return "time"; })
       .Case<TimestampType>([&](Type) { return "timestamp"; })
       .Case<TimestampTzType>([&](Type) { return "timestamp_tz"; })
@@ -684,6 +685,7 @@ static ParseResult parseSubstraitType(AsmParser &parser, Type &valueType) {
                 [&] { return IntervalYearMonthType::get(context); })
           .Case("rel", [&] { return RelationType::parse(parser); })
           .Case("string", [&] { return StringType::get(context); })
+          .Case("struct", [&] { return StructType::parse(parser); })
           .Case("time", [&] { return TimeType::get(context); })
           .Case("timestamp", [&] { return TimestampType::get(context); })
           .Case("timestamp_tz", [&] { return TimestampTzType::get(context); })
@@ -742,6 +744,7 @@ static void printSubstraitType(AsmPrinter &printer, Operation * /*op*/,
           FixedBinaryType,
           FixedCharType,
           RelationType,
+          StructType,
           VarCharType
           // clang-format on
           >([&](auto type) { type.print(printer); });
@@ -752,6 +755,36 @@ static void printSubstraitType(AsmPrinter &printer, Operation *op,
   llvm::interleaveComma(valueTypes, printer, [&](Type type) {
     printSubstraitType(printer, op, type);
   });
+}
+
+// StructType custom assembly format.
+Type StructType::parse(AsmParser &parser) {
+  SmallVector<Type> fieldTypes;
+  if (parser.parseLess())
+    return {};
+  // Allow empty struct<>.
+  if (succeeded(parser.parseOptionalGreater()))
+    return StructType::get(parser.getContext(), fieldTypes);
+  if (parser.parseCommaSeparatedList(
+          AsmParser::Delimiter::None,
+          [&]() -> ParseResult {
+            Type fieldType;
+            if (failed(parseSubstraitType(parser, fieldType)))
+              return failure();
+            fieldTypes.push_back(fieldType);
+            return success();
+          }) ||
+      parser.parseGreater())
+    return {};
+  return StructType::get(parser.getContext(), fieldTypes);
+}
+
+void StructType::print(AsmPrinter &printer) const {
+  printer << "<";
+  llvm::interleaveComma(getFieldTypes(), printer, [&](Type t) {
+    printSubstraitType(printer, /*op=*/nullptr, t);
+  });
+  printer << ">";
 }
 
 //===----------------------------------------------------------------------===//
@@ -767,31 +800,23 @@ static void printSubstraitType(AsmPrinter &printer, Operation *op,
 static FailureOr<Type> computeTypeAtPosition(Location loc, Type type,
                                              ArrayRef<int64_t> position);
 
-/// Helper that extracts computes the type at a position given a container type.
-template <typename ContainerType>
+/// Helper that computes the type at a position given a list of field types.
 static FailureOr<Type> computeTypeAtPositionHelper(Location loc,
-                                                   ContainerType containerType,
+                                                   ArrayRef<Type> fieldTypes,
                                                    ArrayRef<int64_t> position) {
   assert(!position.empty() && "expected to be called with non-empty position");
 
   // Recurse into fields of first index in position array.
   int64_t index = position[0];
-  ArrayRef<Type> fieldTypes = containerType.getTypes();
   if (index >= static_cast<int64_t>(fieldTypes.size()) || index < 0)
-    return emitError(loc) << index << " is not a valid index for "
-                          << containerType;
+    return emitError(loc) << index << " is not a valid index for a struct with "
+                          << fieldTypes.size() << " fields";
 
   return computeTypeAtPosition(loc, fieldTypes[index], position.drop_front());
 }
 
-// Implementation of `computeTypeAtPosition`.
-//
-// The function is implemented corecursively with `computeTypeAtPositionHelper`,
-// where each recursion level extracts the type of the outer-most level
-// identified by the first index in the `position` array. In each level, this
-// function handles the leaf case and type-switches into the helper, which is
-// templated using the container type such that the extraction of the nested
-// types can use the concrete container type.
+// Corecursive with `computeTypeAtPositionHelper`; each call peels one index off
+// the `position` array, dispatching into the appropriate container type.
 static FailureOr<Type> computeTypeAtPosition(Location loc, Type type,
                                              ArrayRef<int64_t> position) {
   if (position.empty())
@@ -802,8 +827,8 @@ static FailureOr<Type> computeTypeAtPosition(Location loc, Type type,
     type = nullable.getInnerType();
 
   return TypeSwitch<Type, FailureOr<Type>>(type)
-      .Case<RelationType, TupleType>([&](auto type) {
-        return computeTypeAtPositionHelper(loc, type, position);
+      .Case<RelationType, StructType>([&](auto t) {
+        return computeTypeAtPositionHelper(loc, t.getFieldTypes(), position);
       })
       .Default([&](auto type) {
         return emitError(loc) << "can't extract element from type " << type;
@@ -832,12 +857,12 @@ verifyNamedStructHelper(Location loc, llvm::ArrayRef<Attribute> fieldNames,
                                 currentName.getValue() + "'");
     numConsumedNames++;
 
-    // Recurse for nested structs/tuples, also through NullableType.
+    // Recurse for nested structs, also through NullableType.
     Type innerType = type;
     if (auto nullableType = llvm::dyn_cast<NullableType>(type))
       innerType = nullableType.getInnerType();
-    if (auto tupleType = llvm::dyn_cast<TupleType>(innerType)) {
-      llvm::ArrayRef<Type> nestedFieldTypes = tupleType.getTypes();
+    if (auto structType = llvm::dyn_cast<StructType>(innerType)) {
+      llvm::ArrayRef<Type> nestedFieldTypes = structType.getFieldTypes();
       llvm::ArrayRef<Attribute> remainingNames =
           fieldNames.drop_front(numConsumedNames);
       FailureOr<int> res =
@@ -852,16 +877,16 @@ verifyNamedStructHelper(Location loc, llvm::ArrayRef<Attribute> fieldNames,
 
 static LogicalResult verifyNamedStruct(Operation *op,
                                        llvm::ArrayRef<Attribute> fieldNames,
-                                       TupleType tupleType) {
+                                       StructType structType) {
   Location loc = op->getLoc();
-  TypeRange fieldTypes = tupleType.getTypes();
+  ArrayRef<Type> fieldTypes = structType.getFieldTypes();
 
   // Emits error message with context on failure.
   auto emitErrorMessage = [&]() {
     InFlightDiagnostic error = op->emitOpError()
                                << "has mismatching 'field_names' ([";
     llvm::interleaveComma(fieldNames, error);
-    error << "]) and result type (" << tupleType << ")";
+    error << "]) and result type (" << structType << ")";
     return error;
   };
 
@@ -949,16 +974,16 @@ LogicalResult AggregateOp::inferReturnTypes(
 LogicalResult AggregateOp::verifyRegions() {
   // Verify properties that need to hold for both regions.
   RelationType inputType = getInput().getType();
-  TupleType inputTupleType = inputType.getStructType();
+  StructType inputStructType = inputType.getStructType();
   for (auto [idx, region] : llvm::enumerate(getRegions())) {
     if (region->empty()) // Regions are allowed to be empty.
       continue;
 
     // Verify that the regions have the input struct as argument.
-    if (region->getArgumentTypes() != TypeRange{inputTupleType}) {
+    if (region->getArgumentTypes() != TypeRange{inputStructType}) {
       return emitOpError() << "has region #" << idx
                            << " with invalid argument types (expected: "
-                           << inputTupleType
+                           << inputStructType
                            << ", got: " << region->getArgumentTypes() << ")";
     }
 
@@ -1156,8 +1181,8 @@ EmitOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 LogicalResult ExtensionTableOp::verify() {
   llvm::ArrayRef<Attribute> fieldNames = getFieldNames().getValue();
   RelationType relationType = getResult().getType();
-  TupleType tupleType = relationType.getStructType();
-  return verifyNamedStruct(getOperation(), fieldNames, tupleType);
+  StructType structType = relationType.getStructType();
+  return verifyNamedStruct(getOperation(), fieldNames, structType);
 }
 
 LogicalResult FieldReferenceOp::inferReturnTypes(
@@ -1206,12 +1231,12 @@ LogicalResult FilterOp::verifyRegions() {
 
   // Verify that block has argument of input tuple type.
   RelationType relationType = getResult().getType();
-  TupleType tupleType = relationType.getStructType();
+  StructType structType = relationType.getStructType();
   if (condition.getNumArguments() != 1 ||
-      condition.getArgument(0).getType() != tupleType) {
+      condition.getArgument(0).getType() != structType) {
     InFlightDiagnostic diag = emitOpError()
                               << "must have 'condition' region taking "
-                              << tupleType << " as argument (takes ";
+                              << structType << " as argument (takes ";
     if (condition.getNumArguments() == 0)
       diag << "no arguments)";
     else
@@ -1288,8 +1313,8 @@ JoinOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
 LogicalResult NamedTableOp::verify() {
   llvm::ArrayRef<Attribute> fieldNames = getFieldNames().getValue();
   RelationType relationType = getResult().getType();
-  TupleType tupleType = relationType.getStructType();
-  return verifyNamedStruct(getOperation(), fieldNames, tupleType);
+  StructType structType = relationType.getStructType();
+  return verifyNamedStruct(getOperation(), fieldNames, structType);
 }
 
 LogicalResult PlanRelOp::verifyRegions() {
@@ -1309,8 +1334,8 @@ LogicalResult PlanRelOp::verifyRegions() {
   // Otherwise, use helper to verify.
   llvm::ArrayRef<Attribute> fieldNames = getFieldNames()->getValue();
   auto relationType = cast<RelationType>(yieldOp.getValue().getTypes()[0]);
-  TupleType tupleType = relationType.getStructType();
-  return verifyNamedStruct(getOperation(), fieldNames, tupleType);
+  StructType structType = relationType.getStructType();
+  return verifyNamedStruct(getOperation(), fieldNames, structType);
 }
 
 OpFoldResult ProjectOp::fold(FoldAdaptor adaptor) {
@@ -1327,12 +1352,12 @@ OpFoldResult ProjectOp::fold(FoldAdaptor adaptor) {
 LogicalResult ProjectOp::verifyRegions() {
   // Verify that the expression block has a matching argument type.
   RelationType inputType = getInput().getType();
-  TupleType inputTupleType = inputType.getStructType();
+  StructType inputStructType = inputType.getStructType();
   TypeRange blockArgTypes = getExpressions().front().getArgumentTypes();
-  if (blockArgTypes != TypeRange{inputTupleType}) {
+  if (blockArgTypes != TypeRange{inputStructType}) {
     return emitOpError()
            << "has 'expressions' region with mismatching argument type"
-           << " (has: " << blockArgTypes << ", expected: " << inputTupleType
+           << " (has: " << blockArgTypes << ", expected: " << inputStructType
            << ")";
   }
 

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -155,8 +155,8 @@ static void deduplicateRegionArgs(Region &region, ArrayAttr newMapping,
                                   PatternRewriter &rewriter) {
   assert(region.getNumArguments() == 1 &&
          "only regions with 1 argument are supported");
-  auto oldElementType = cast<TupleType>(region.getArgument(0).getType());
-  int64_t numOldFields = oldElementType.getTypes().size();
+  auto oldElementType = cast<StructType>(region.getArgument(0).getType());
+  int64_t numOldFields = oldElementType.getFieldTypes().size();
 
   // For each position in the original input type, compute which position it
   // corresponds to in the deduplicated input. This is required for replacing
@@ -251,7 +251,7 @@ struct EliminateDuplicateYieldsInProjectPattern
     SmallVector<Type> outputTypes;
     int64_t numNewYields = terminator->getNumOperands();
     outputTypes.reserve(inputType.size() + numNewYields);
-    append_range(outputTypes, inputType.getTypes());
+    append_range(outputTypes, inputType.getFieldTypes());
     append_range(outputTypes, terminator->getOperandTypes());
     auto newOutputType = RelationType::get(context, outputTypes);
 
@@ -320,7 +320,7 @@ struct EliminateIdentityYieldsInProjectPattern
     SmallVector<Type> outputTypes;
     int64_t numNewYields = terminator->getNumOperands();
     outputTypes.reserve(inputType.size() + numNewYields);
-    append_range(outputTypes, inputType.getTypes());
+    append_range(outputTypes, inputType.getFieldTypes());
     append_range(outputTypes, terminator->getOperandTypes());
     auto newOutputType = RelationType::get(context, outputTypes);
 
@@ -481,7 +481,7 @@ struct PushDuplicatesThroughProjectPattern
 
     SmallVector<Type> outputTypes;
     outputTypes.reserve(newInputType.size() + terminator->getNumOperands());
-    append_range(outputTypes, newInputType.getTypes());
+    append_range(outputTypes, newInputType.getFieldTypes());
     append_range(outputTypes, terminator->getOperandTypes());
     auto newOutputType = RelationType::get(context, outputTypes);
 

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -120,7 +120,7 @@ public:
 
   std::unique_ptr<google::protobuf::Any> exportAny(StringAttr attr);
   FailureOr<std::unique_ptr<NamedStruct>>
-  exportNamedStruct(Location loc, ArrayAttr fieldNames, TupleType tupleType);
+  exportNamedStruct(Location loc, ArrayAttr fieldNames, StructType structType);
   FailureOr<std::unique_ptr<google::protobuf::Message>>
   exportOperation(Operation *op);
   FailureOr<std::unique_ptr<proto::Type>> exportType(Location loc,
@@ -427,20 +427,20 @@ SubstraitExporter::exportType(Location loc, mlir::Type mlirType) {
     return std::move(type);
   }
 
-  // Handle tuple types.
-  if (auto tupleType = llvm::dyn_cast<TupleType>(innerType)) {
-    auto structType = std::make_unique<proto::Type::Struct>();
-    setNullability(structType.get(), nullable);
-    for (mlir::Type fieldType : tupleType.getTypes()) {
+  // Handle struct types.
+  if (auto structType = llvm::dyn_cast<StructType>(innerType)) {
+    auto structMsg = std::make_unique<proto::Type::Struct>();
+    setNullability(structMsg.get(), nullable);
+    for (mlir::Type fieldType : structType.getFieldTypes()) {
       // Convert field type recursively.
       FailureOr<std::unique_ptr<proto::Type>> type = exportType(loc, fieldType);
       if (failed(type))
         return failure();
-      *structType->add_types() = *type.value();
+      *structMsg->add_types() = *type.value();
     }
 
     auto type = std::make_unique<proto::Type>();
-    type->set_allocated_struct_(structType.release());
+    type->set_allocated_struct_(structMsg.release());
     return std::move(type);
   }
 
@@ -784,9 +784,9 @@ SubstraitExporter::exportOperation(ExtensionTableOp op) {
   // TODO(ingomueller): factor out common logic of `ReadRel`.
   // Export field names and result type into `base_schema`.
   RelationType relationType = op.getResult().getType();
-  TupleType tupleType = relationType.getStructType();
+  StructType structType = relationType.getStructType();
   FailureOr<std::unique_ptr<NamedStruct>> baseSchema =
-      exportNamedStruct(loc, op.getFieldNames(), tupleType);
+      exportNamedStruct(loc, op.getFieldNames(), structType);
   if (failed(baseSchema))
     return failure();
 
@@ -1102,13 +1102,13 @@ SubstraitExporter::exportOperation(ModuleOp op) {
 
 FailureOr<std::unique_ptr<NamedStruct>>
 SubstraitExporter::exportNamedStruct(Location loc, ArrayAttr fieldNames,
-                                     TupleType tupleType) {
+                                     StructType structType) {
 
   // Build `Struct` message.
   auto structMsg = std::make_unique<proto::Type::Struct>();
   structMsg->set_nullability(
       Type_Nullability::Type_Nullability_NULLABILITY_REQUIRED);
-  for (mlir::Type fieldType : tupleType.getTypes()) {
+  for (mlir::Type fieldType : structType.getFieldTypes()) {
     FailureOr<std::unique_ptr<proto::Type>> type = exportType(loc, fieldType);
     if (failed(type))
       return (failure());
@@ -1144,9 +1144,9 @@ SubstraitExporter::exportOperation(NamedTableOp op) {
   // TODO(ingomueller): factor out common logic of `ReadRel`.
   // Export field names and result type into `base_schema`.
   RelationType relationType = op.getResult().getType();
-  TupleType tupleType = relationType.getStructType();
+  StructType structType = relationType.getStructType();
   FailureOr<std::unique_ptr<NamedStruct>> baseSchema =
-      exportNamedStruct(loc, op.getFieldNames(), tupleType);
+      exportNamedStruct(loc, op.getFieldNames(), structType);
   if (failed(baseSchema))
     return failure();
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -69,7 +69,7 @@ using namespace ::substrait::proto;
 
 namespace {
 
-using ImportedNamedStruct = std::tuple<ArrayAttr, TupleType>;
+using ImportedNamedStruct = std::tuple<ArrayAttr, StructType>;
 
 // Copied from
 // https://github.com/llvm/llvm-project/blob/dea33c/mlir/lib/Transforms/CSE.cpp.
@@ -323,7 +323,7 @@ static mlir::FailureOr<mlir::Type> importType(MLIRContext *context,
         return failure();
       fieldTypes.push_back(mlirFieldType.value());
     }
-    baseType = TupleType::get(context, fieldTypes);
+    baseType = StructType::get(context, fieldTypes);
     nullable = isNullable(type.struct_());
     break;
   }
@@ -390,13 +390,13 @@ importAggregateRel(ImplicitLocOpBuilder builder, const Rel &message) {
   if (failed(inputOp))
     return failure();
   TypedValue<RelationType> inputVal = inputOp.value().getResult();
-  TupleType inputTupleType = inputVal.getType().getStructType();
+  StructType inputStructType = inputVal.getType().getStructType();
 
   // Import measures if any.
   auto measuresRegion = std::make_unique<Region>();
   if (aggregateRel.measures_size() > 0) {
     Block *measuresBlock = &measuresRegion->emplaceBlock();
-    measuresBlock->addArgument(inputTupleType, loc);
+    measuresBlock->addArgument(inputStructType, loc);
 
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(measuresBlock);
@@ -421,7 +421,7 @@ importAggregateRel(ImplicitLocOpBuilder builder, const Rel &message) {
   SmallVector<Attribute> groupingSetsAttrs;
   if (aggregateRel.groupings_size() > 0) {
     Block *groupingsBlock = &groupingsRegion->emplaceBlock();
-    groupingsBlock->addArgument(inputTupleType, loc);
+    groupingsBlock->addArgument(inputStructType, loc);
 
     // Grouping expressions, i.e., values yielded from `groupings`.
     SmallVector<Value> groupingExprValues;
@@ -622,7 +622,7 @@ importExtensionTable(ImplicitLocOpBuilder builder, const Rel &message) {
       importNamedStruct(builder, baseSchema);
   if (failed(importedNamedStruct))
     return failure();
-  auto [fieldNamesAttr, tupleType] = importedNamedStruct.value();
+  auto [fieldNamesAttr, structType] = importedNamedStruct.value();
 
   // Import `detail` attribute.
   const ::google::protobuf::Any &detail = extensionTable.detail();
@@ -630,7 +630,7 @@ importExtensionTable(ImplicitLocOpBuilder builder, const Rel &message) {
 
   // Assemble final op.
   auto resultType =
-      RelationType::get(builder.getContext(), tupleType.getTypes());
+      RelationType::get(builder.getContext(), structType.getFieldTypes());
   auto extensionTableOp =
       ExtensionTableOp::create(builder, resultType, fieldNamesAttr, detailAttr);
 
@@ -938,7 +938,7 @@ importNamedStruct(ImplicitLocOpBuilder builder, const NamedStruct &message) {
       return failure();
     resultTypes.push_back(mlirType.value());
   }
-  auto resultType = TupleType::get(context, resultTypes);
+  auto resultType = StructType::get(context, resultTypes);
 
   return ImportedNamedStruct{fieldNamesAttr, resultType};
 }
@@ -969,10 +969,10 @@ importNamedTable(ImplicitLocOpBuilder builder, const Rel &message) {
       importNamedStruct(builder, baseSchema);
   if (failed(importedNamedStruct))
     return failure();
-  auto [fieldNamesAttr, tupleType] = importedNamedStruct.value();
+  auto [fieldNamesAttr, structType] = importedNamedStruct.value();
 
   // Assemble final op.
-  auto resultType = RelationType::get(context, tupleType.getTypes());
+  auto resultType = RelationType::get(context, structType.getFieldTypes());
   auto namedTableOp =
       NamedTableOp::create(builder, resultType, tableName, fieldNamesAttr);
 

--- a/python/SubstraitDialects.cpp
+++ b/python/SubstraitDialects.cpp
@@ -105,6 +105,22 @@ NB_MODULE(_substraitDialects, mainModule) {
                   "context: typing.Optional[substrait_mlir.ir.Context] = None) "
                   "-> NullableType"));
 
+  mlir_type_subclass(substraitModule, "StructType",
+                     mlirTypeIsASubstraitStructType)
+      .def_classmethod(
+          "get",
+          [](const nb::object &cls, std::vector<MlirType> fieldTypes,
+             MlirContext context) {
+            return cls(mlirSubstraitStructTypeGet(context, fieldTypes.size(),
+                                                  fieldTypes.data()));
+          },
+          nb::arg("cls"), nb::arg("field_types"),
+          nb::arg("context").none() = nb::none(),
+          nb::sig("def get(cls: object, "
+                  "field_types: typing.Sequence[substrait_mlir.ir.Type], "
+                  "context: typing.Optional[substrait_mlir.ir.Context] = None) "
+                  "-> StructType"));
+
   //
   // Import
   //

--- a/test/Dialect/Substrait/aggregate-invalid.mlir
+++ b/test/Dialect/Substrait/aggregate-invalid.mlir
@@ -5,10 +5,10 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    // expected-error@+1 {{'substrait.aggregate' op has region #0 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
+    // expected-error@+1 {{'substrait.aggregate' op has region #0 with invalid argument types (expected: '!substrait.struct<si32>', got: '!substrait.struct<si1>')}}
     %1 = aggregate %0 : rel<si32> -> rel<si1>
       groupings {
-      ^bb0(%arg : tuple<si1>):
+      ^bb0(%arg : !substrait.struct<si1>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
@@ -23,10 +23,10 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    // expected-error@+1 {{'substrait.aggregate' op has region #1 with invalid argument types (expected: 'tuple<si32>', got: 'tuple<si1>')}}
+    // expected-error@+1 {{'substrait.aggregate' op has region #1 with invalid argument types (expected: '!substrait.struct<si32>', got: '!substrait.struct<si1>')}}
     %1 = aggregate %0 : rel<si32> -> rel<si1>
       measures {
-      ^bb0(%arg : tuple<si1>):
+      ^bb0(%arg : !substrait.struct<si1>):
         %2 = literal 0 : si1
         %3 = call @function(%2) aggregate : (si1) -> si1
         yield %3 : si1
@@ -45,7 +45,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+1 {{'substrait.aggregate' op has invalid grouping set #0: column reference 1 (column #0) is out of bounds}}
     %1 = aggregate %0 : rel<si32> -> rel<si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
@@ -65,7 +65,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+1 {{'substrait.aggregate' op has invalid grouping sets: the first occerrences of the column references must be densely increasing}}
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
@@ -84,7 +84,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+1 {{'substrait.aggregate' op has 'groupings' region whose operand #1 is not contained in any 'grouping_set'}}
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
@@ -117,7 +117,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error-re@+1 {{'substrait.aggregate' op yields value from 'measures' region that was not produced by an aggregate function: {{.*}}substrait.call{{.*}}}}
     %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si32
         %3 = call @function(%2) : (si32) -> si32
         yield %3 : si32
@@ -135,7 +135,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si32
         // expected-error@+1 {{custom op 'substrait.call' has invalid aggregate invocation type specification: foo}}
         %3 = call @function(%2) aggregate foo : (si32) -> si32
@@ -153,7 +153,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+1 {{'substrait.aggregate' op has region #1 that yields no values (use empty region instead)}}
     %1 = aggregate %0 : rel<si32> -> rel<>
       measures {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         yield
       }
     yield %1 : rel<>
@@ -168,7 +168,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+1 {{'substrait.aggregate' op has region #0 that yields no values (use empty region instead)}}
     %1 = aggregate %0 : rel<si32> -> rel<>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         yield
       }
     yield %1 : rel<>

--- a/test/Dialect/Substrait/aggregate.mlir
+++ b/test/Dialect/Substrait/aggregate.mlir
@@ -8,13 +8,13 @@
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si1, si1, si32, si32>
 // CHECK-NEXT:      groupings {
-// CHECK-NEXT:        ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:        ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si32>):
 // CHECK-NEXT:        %[[V2:.*]] = literal 0 : si1
 // CHECK-NEXT:        yield %[[V2]], %[[V2]] : si1, si1
 // CHECK-NEXT:      }
 // CHECK-NEXT:      grouping_sets {{\[}}[0], [0, 1], [1], []]
 // CHECK-NEXT:      measures {
-// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
+// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: !substrait.struct<si32>):
 // CHECK-DAG:         %[[V3:.*]] = field_reference %[[ARG1]][0]
 // CHECK-DAG:         %[[V4:.*]] = call @function(%[[V3]]) aggregate :
 // CHECK-NEXT:        yield %[[V4]] : si32
@@ -28,14 +28,14 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32, si32>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
       grouping_sets [[0], [0, 1], [1], []]
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
@@ -55,7 +55,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:           }
 // CHECK-NEXT:      grouping_sets
 // CHECK-NEXT:      measures {
-// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
+// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: !substrait.struct<si32>):
 // CHECK-DAG:         %[[V3:.*]] = field_reference %[[ARG1]][0]
 // CHECK-DAG:         %[[V4:.*]] = call @function(%[[V3]]) aggregate :
 // CHECK-NEXT:        yield %[[V4]] : si32
@@ -69,14 +69,14 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32, si32>
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
       grouping_sets [[0], [0, 1], [1], []]
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
@@ -102,7 +102,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
@@ -128,7 +128,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
@@ -154,7 +154,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2, %2 : si1, si1
       }
@@ -183,8 +183,8 @@ substrait.plan version 0 : 42 : 1 {
     %1 = aggregate %0 : rel<si32> -> rel<si32>
       grouping_sets []
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
@@ -211,8 +211,8 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
@@ -240,8 +240,8 @@ substrait.plan version 0 : 42 : 1 {
     %1 = aggregate %0 : rel<si32> -> rel<si32>
       grouping_sets [[]]
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
@@ -258,7 +258,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = aggregate %[[V0]]
 // CHECK-NEXT:      measures {
-// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: tuple<si32>):
+// CHECK-NEXT:      ^[[BB1:.*]](%[[ARG1:.*]]: !substrait.struct<si32>):
 // CHECK-DAG:         %[[V2:.*]] = field_reference %[[ARG1]][0]
 // CHECK-DAG:         %[[V3:.*]] = call @function(%[[V2]]) aggregate :
 // CHECK-DAG:         %[[V4:.*]] = call @function(%[[V2]]) aggregate :
@@ -284,8 +284,8 @@ substrait.plan version 0 : 42 : 1 {
     %1 = aggregate %0 : rel<si32>
           -> rel<si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32, si32>
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         %4 = call @function(%2) aggregate all : (si32) -> si32
         %5 = call @function(%2) aggregate initial_to_result : (si32) -> si32
@@ -324,7 +324,7 @@ substrait.plan version 0 : 42 : 1 {
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> -> rel<si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }

--- a/test/Dialect/Substrait/call.mlir
+++ b/test/Dialect/Substrait/call.mlir
@@ -5,7 +5,7 @@
 // CHECK:         relation
 // CHECK:         named_table
 // CHECK-NEXT:    filter
-// CHECK-NEXT:    (%[[ARG0:.*]]: tuple<si32>)
+// CHECK-NEXT:    (%[[ARG0:.*]]: !substrait.struct<si32>)
 // CHECK-NEXT:      %[[V0:.*]] = field_reference %[[ARG0]]
 // CHECK-NEXT:      %[[V1:.*]] = call @function(%[[V0]]) : (si32) -> si1
 // CHECK-NEXT:      yield
@@ -17,8 +17,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
-      %2 = field_reference %arg[0] : tuple<si32>
+    ^bb0(%arg : !substrait.struct<si32>):
+      %2 = field_reference %arg[0] : !substrait.struct<si32>
       %3 = call @function(%2) : (si32) -> si1
       yield %3 : si1
     }

--- a/test/Dialect/Substrait/canonicalize.mlir
+++ b/test/Dialect/Substrait/canonicalize.mlir
@@ -86,7 +86,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32> {
-    ^bb0(%arg0: tuple<si32>):
+    ^bb0(%arg0: !substrait.struct<si32>):
     }
     yield %1 : rel<si32>
   }

--- a/test/Dialect/Substrait/cast-invalid.mlir
+++ b/test/Dialect/Substrait/cast-invalid.mlir
@@ -5,7 +5,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si64> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 42 : si32
       // expected-error@+1 {{result type must be nullable (T?) when 'failure_behavior' is 'return_null', but got 'si64'}}
       %3 = cast %2 or return_null : si32 to si64
@@ -23,7 +23,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si64> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or throw_exception : si32 to si64
       yield %3 : si64
@@ -40,7 +40,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si64?> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si64?
       yield %3 : si64?

--- a/test/Dialect/Substrait/cast.mlir
+++ b/test/Dialect/Substrait/cast.mlir
@@ -5,7 +5,7 @@
 // CHECK-LABEL: substrait.plan
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] :
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal 42 : si32
 // CHECK-NEXT:      %[[V3:.*]] = cast %[[V2]] or return_null : si32 to si32?
 // CHECK-NEXT:      %[[V4:.*]] = cast %[[V2]] or throw_exception : si32 to si64
@@ -18,7 +18,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si32?, si64, si64> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si32?
       %4 = cast %2 or throw_exception : si32 to si64
@@ -41,7 +41,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si32?> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si32?
       yield %3 : si32?

--- a/test/Dialect/Substrait/field-reference-invalid.mlir
+++ b/test/Dialect/Substrait/field-reference-invalid.mlir
@@ -4,10 +4,10 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       // expected-error@+2 {{can't extract element from type 'si32'}}
-      // expected-error@+1 {{mismatching position and type (position: array<i64: 0, 0>, type: 'tuple<si32>')}}
-      %2 = field_reference %arg[0, 0] : tuple<si32>
+      // expected-error@+1 {{mismatching position and type (position: array<i64: 0, 0>, type: '!substrait.struct<si32>')}}
+      %2 = field_reference %arg[0, 0] : !substrait.struct<si32>
       %3 = literal 0 : si1
       yield %3 : si1
     }
@@ -21,10 +21,10 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
-      // expected-error@+2 {{2 is not a valid index for 'tuple<si32>'}}
-      // expected-error@+1 {{mismatching position and type (position: array<i64: 2>, type: 'tuple<si32>')}}
-      %2 = field_reference %arg[2] : tuple<si32>
+    ^bb0(%arg : !substrait.struct<si32>):
+      // expected-error@+2 {{2 is not a valid index for a struct with 1 fields}}
+      // expected-error@+1 {{mismatching position and type (position: array<i64: 2>, type: '!substrait.struct<si32>')}}
+      %2 = field_reference %arg[2] : !substrait.struct<si32>
       %3 = literal 0 : si1
       yield %3 : si1
     }

--- a/test/Dialect/Substrait/field-reference.mlir
+++ b/test/Dialect/Substrait/field-reference.mlir
@@ -5,16 +5,16 @@
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      named_table
 // CHECK-NEXT:      filter
-// CHECK-NEXT:      (%[[ARG0:.*]]: tuple<si1>):
-// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][0] : tuple<si1>
+// CHECK-NEXT:      (%[[ARG0:.*]]: !substrait.struct<si1>):
+// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][0] : !substrait.struct<si1>
 // CHECK-NEXT:        yield %[[V0]] : si1
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = filter %0 : rel<si1> {
-    ^bb0(%arg : tuple<si1>):
-      %2 = field_reference %arg[0] : tuple<si1>
+    ^bb0(%arg : !substrait.struct<si1>):
+      %2 = field_reference %arg[0] : !substrait.struct<si1>
       yield %2 : si1
     }
     yield %1 : rel<si1>
@@ -27,19 +27,19 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      named_table
 // CHECK-NEXT:      filter
-// CHECK-NEXT:      (%[[ARG0:.*]]: tuple<si1, tuple<si1>>):
-// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][1, 0] : tuple<si1, tuple<si1>>
+// CHECK-NEXT:      (%[[ARG0:.*]]: !substrait.struct<si1, struct<si1>>):
+// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][1, 0] : !substrait.struct<si1, struct<si1>>
 // CHECK-NEXT:        yield %[[V0]] : si1
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    %1 = filter %0 : rel<si1, tuple<si1>> {
-    ^bb0(%arg : tuple<si1, tuple<si1>>):
-      %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, struct<si1>>
+    %1 = filter %0 : rel<si1, struct<si1>> {
+    ^bb0(%arg : !substrait.struct<si1, struct<si1>>):
+      %2 = field_reference %arg[1, 0] : !substrait.struct<si1, struct<si1>>
       yield %2 : si1
     }
-    yield %1 : rel<si1, tuple<si1>>
+    yield %1 : rel<si1, struct<si1>>
   }
 }
 
@@ -49,47 +49,104 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      named_table
 // CHECK-NEXT:      filter
-// CHECK-NEXT:      (%[[ARG0:.*]]: tuple<si1, tuple<si1>>):
-// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][1] : tuple<si1, tuple<si1>>
-// CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]][0] : tuple<si1>
+// CHECK-NEXT:      (%[[ARG0:.*]]: !substrait.struct<si1, struct<si1>>):
+// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][1] : !substrait.struct<si1, struct<si1>>
+// CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]][0] : !substrait.struct<si1>
 // CHECK-NEXT:        yield %[[V1]] : si1
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    %1 = filter %0 : rel<si1, tuple<si1>> {
-    ^bb0(%arg : tuple<si1, tuple<si1>>):
-      %2 = field_reference %arg[1] : tuple<si1, tuple<si1>>
-      %3 = field_reference %2[0] : tuple<si1>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, struct<si1>>
+    %1 = filter %0 : rel<si1, struct<si1>> {
+    ^bb0(%arg : !substrait.struct<si1, !substrait.struct<si1>>):
+      %2 = field_reference %arg[1] : !substrait.struct<si1, struct<si1>>
+      %3 = field_reference %2[0] : !substrait.struct<si1>
       yield %3 : si1
     }
-    yield %1 : rel<si1, tuple<si1>>
+    yield %1 : rel<si1, struct<si1>>
   }
 }
 
 // -----
 
-// Check that field_reference works into a relation with a nullable element
-// type (tuple<si32?>). This covers the computeTypeAtPosition path that strips
-// the NullableType wrapper before descending into nested types. The block
-// argument type uses the canonical form because the MLIR block-arg parser does
-// not apply the T? sugar syntax; only the op assembly format does.
+// Check that field_reference strips NullableType before descending into a
+// nullable element type (struct<si32?>).
 // CHECK-LABEL: substrait.plan
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      named_table
 // CHECK-NEXT:      project
-// CHECK-NEXT:      (%[[ARG0:.*]]: tuple<!substrait.nullable<si32>>):
-// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][0] : tuple<!substrait.nullable<si32>>
+// CHECK-NEXT:      (%[[ARG0:.*]]: !substrait.struct<si32?>):
+// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][0] : !substrait.struct<si32?>
 // CHECK-NEXT:        yield %[[V0]] : si32?
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32?>
     %1 = project %0 : rel<si32?> -> rel<si32?, si32?> {
-    ^bb0(%arg : tuple<!substrait.nullable<si32>>):
-      %2 = field_reference %arg[0] : tuple<!substrait.nullable<si32>>
+    ^bb0(%arg : !substrait.struct<si32?>):
+      %2 = field_reference %arg[0] : !substrait.struct<si32?>
       yield %2 : si32?
     }
     yield %1 : rel<si32?, si32?>
+  }
+}
+
+// -----
+
+// Check that field_reference into a struct column yields a StructType, and a
+// further reference into that StructType works.
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      named_table
+// CHECK-NEXT:      filter
+// CHECK-NEXT:      (%[[ARG0:.*]]: !substrait.struct<struct<si32>>):
+// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][0]
+// CHECK-SAME:            : !substrait.struct<struct<si32>>
+// CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]][0]
+// CHECK-SAME:            : !substrait.struct<si32>
+// CHECK-NEXT:        %[[V2:.*]] = literal 0 : si1
+// CHECK-NEXT:        yield %[[V2]] : si1
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["s", "x"] : rel<struct<si32>>
+    %1 = filter %0 : rel<struct<si32>> {
+    ^bb0(%arg : !substrait.struct<struct<si32>>):
+      // Extract the struct column, then descend into it.
+      %2 = field_reference %arg[0] : !substrait.struct<struct<si32>>
+      %3 = field_reference %2[0] : !substrait.struct<si32>
+      %4 = literal 0 : si1
+      yield %4 : si1
+    }
+    yield %1 : rel<struct<si32>>
+  }
+}
+
+// -----
+
+// Check two-level descent into a nested struct column.
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      named_table
+// CHECK-NEXT:      filter
+// CHECK-NEXT:      (%[[ARG0:.*]]: !substrait.struct<struct<si32, si64>>):
+// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]][0]
+// CHECK-SAME:            : !substrait.struct<struct<si32, si64>>
+// CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]][1]
+// CHECK-SAME:            : !substrait.struct<si32, si64>
+// CHECK-NEXT:        %[[V2:.*]] = literal 0 : si1
+// CHECK-NEXT:        yield %[[V2]] : si1
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["col", "x", "y"] : rel<struct<si32, si64>>
+    %1 = filter %0 : rel<struct<si32, si64>> {
+    ^bb0(%arg : !substrait.struct<struct<si32, si64>>):
+      %2 = field_reference %arg[0] : !substrait.struct<struct<si32, si64>>
+      %3 = field_reference %2[1] : !substrait.struct<si32, si64>
+      %4 = literal 0 : si1
+      yield %4 : si1
+    }
+    yield %1 : rel<struct<si32, si64>>
   }
 }

--- a/test/Dialect/Substrait/filter-invalid.mlir
+++ b/test/Dialect/Substrait/filter-invalid.mlir
@@ -5,7 +5,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding one value (yields 2)}}
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 0 : si1
       yield %2, %2 : si1, si1
     }
@@ -20,7 +20,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding 'si1' (yields 'si32')}}
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 42 : si32
       yield %2 : si32
     }
@@ -33,7 +33,7 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes no arguments)}}
+    // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking '!substrait.struct<si32>' as argument (takes no arguments)}}
     %1 = filter %0 : rel<si32> {
       %2 = literal 0 : si1
       yield %2 : si1
@@ -47,9 +47,9 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes 'tuple<>')}}
+    // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking '!substrait.struct<si32>' as argument (takes '!substrait.struct<>')}}
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<>):
+    ^bb0(%arg : !substrait.struct<>):
       %2 = literal 0 : si1
       yield %2 : si1
     }

--- a/test/Dialect/Substrait/filter.mlir
+++ b/test/Dialect/Substrait/filter.mlir
@@ -5,7 +5,7 @@
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = filter %[[V0]] : rel<si32> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 // CHECK-NEXT:      yield %[[V2]] : si1
 // CHECK-NEXT:    }
@@ -15,7 +15,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
@@ -37,7 +37,7 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }

--- a/test/Dialect/Substrait/literal.mlir
+++ b/test/Dialect/Substrait/literal.mlir
@@ -35,7 +35,7 @@
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_binary<10>> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 // CHECK-NEXT:      yield %[[V2]] : fixed_binary<10>
 // CHECK-NEXT:    }
@@ -45,7 +45,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, fixed_binary<10>> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %bytes = literal #substrait.fixed_binary<"8181818181">
       yield %bytes : fixed_binary<10>
     }
@@ -59,7 +59,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, var_char<6>> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 6>
 // CHECK-NEXT:      yield %[[V2]] : var_char<6>
 // CHECK-NEXT:    }
@@ -69,7 +69,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, var_char<6>> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %var_char = literal #substrait.var_char<"hello", 6>
       yield %var_char : var_char<6>
     }
@@ -83,7 +83,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_char<5>> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 // CHECK-NEXT:      yield %[[V2]] : fixed_char<5>
 // CHECK-NEXT:    }
@@ -93,7 +93,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, fixed_char<5>> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %fixed_char = literal #substrait.fixed_char<"hello">
       yield %fixed_char : fixed_char<5>
     }
@@ -107,7 +107,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, uuid> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 // CHECK-NEXT:      yield %[[V2]] : uuid
 // CHECK-NEXT:    }
@@ -117,7 +117,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, uuid> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : uuid
     }
@@ -130,7 +130,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, interval_ym, interval_ds> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>{{$}}
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : interval_ym, interval_ds
@@ -141,7 +141,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, interval_ym, interval_ds> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
       yield %interval_year_month, %interval_day_second : interval_ym, interval_ds
@@ -156,7 +156,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, time> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : time
 // CHECK-NEXT:    }
@@ -166,7 +166,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, time> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %time = literal #substrait.time<200000000us>
       yield %time : time
     }
@@ -180,7 +180,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, date> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>{{$}}
 // CHECK-NEXT:      yield %[[V2]] : date
 // CHECK-NEXT:    }
@@ -190,7 +190,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, date> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %date = literal #substrait.date<200000000>
       yield %date : date
     }
@@ -204,7 +204,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>{{$}}
 // CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>{{$}}
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, timestamp_tz
@@ -215,7 +215,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
       yield %timestamp, %timestamp_tz : timestamp, timestamp_tz
@@ -230,7 +230,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, binary> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 // CHECK-NEXT:      yield %[[V2]] : binary
 // CHECK-NEXT:    }
@@ -240,7 +240,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, binary> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : binary
     }
@@ -254,7 +254,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, string> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 // CHECK-NEXT:      yield %[[V2]] : string
 // CHECK-NEXT:    }
@@ -264,7 +264,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, string> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %hi = literal "hi" : !substrait.string
       yield %hi : string
     }
@@ -278,7 +278,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<f32> -> rel<f32, f32, f64> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<f32>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<f32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal 3.535000e+01 : f32
 // CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : f32, f64
@@ -289,7 +289,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<f32>
     %1 = project %0 : rel<f32> -> rel<f32, f32, f64> {
-    ^bb0(%arg : tuple<f32>):
+    ^bb0(%arg : !substrait.struct<f32>):
       %35 = literal 35.35 : f32
       %42 = literal 42.42 : f64
       yield %35, %42 : f32, f64
@@ -304,7 +304,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 // CHECK-NEXT:      %[[V2:.*]] = literal 0 : si1
 // CHECK-NEXT:      %[[V3:.*]] = literal 2 : si8
 // CHECK-NEXT:      %[[V4:.*]] = literal -1 : si16
@@ -318,7 +318,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %false = literal 0 : si1
       %2 = literal 2 : si8
       %-1 = literal -1 : si16

--- a/test/Dialect/Substrait/named-table-invalid.mlir
+++ b/test/Dialect/Substrait/named-table-invalid.mlir
@@ -3,7 +3,7 @@
 // Test error if providing too many names (1 name for 0 fields).
 substrait.plan version 0 : 42 : 1 {
   relation {
-    // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a"]) and result type ('tuple<>')}}
+    // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a"]) and result type ('!substrait.struct<>')}}
     // expected-note@+1 {{too many field names provided}}
     %0 = named_table @t1 as ["a"] : rel<>
     yield %0 : rel<>
@@ -15,7 +15,7 @@ substrait.plan version 0 : 42 : 1 {
 // Test error if providing too few names (0 names for 1 field).
 substrait.plan version 0 : 42 : 1 {
   relation {
-    // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' ([]) and result type ('tuple<si32>')}}
+    // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' ([]) and result type ('!substrait.struct<si32>')}}
     // expected-error@+1 {{not enough field names provided}}
     %0 = named_table @t1 as [] : rel<si32>
     yield %0 : rel<si32>
@@ -27,7 +27,7 @@ substrait.plan version 0 : 42 : 1 {
 // Test error if providing duplicate field names in the same nesting level.
 substrait.plan version 0 : 42 : 1 {
   relation {
-    // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a", "a"]) and result type ('tuple<si32, si32>')}}
+    // expected-error@+2 {{'substrait.named_table' op has mismatching 'field_names' (["a", "a"]) and result type ('!substrait.struct<si32, si32>')}}
     // expected-error@+1 {{duplicate field name: 'a'}}
     %0 = named_table @t1 as ["a", "a"] : rel<si32, si32>
     yield %0 : rel<si32, si32>

--- a/test/Dialect/Substrait/named-table.mlir
+++ b/test/Dialect/Substrait/named-table.mlir
@@ -46,13 +46,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1
-// CHECK-SAME:      as ["outer", "inner"] : rel<tuple<si32>>
+// CHECK-SAME:      as ["outer", "inner"] : rel<struct<si32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["outer", "inner"] : rel<tuple<si32>>
-    yield %0 : rel<tuple<si32>>
+    %0 = named_table @t1 as ["outer", "inner"] : rel<struct<si32>>
+    yield %0 : rel<struct<si32>>
   }
 }
 
@@ -61,13 +61,13 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
 // CHECK:         %[[V0:.*]] = named_table @t1
-// CHECK-SAME:      as ["a", "a"] : rel<tuple<si32>>
+// CHECK-SAME:      as ["a", "a"] : rel<struct<si32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "a"] : rel<tuple<si32>>
-    yield %0 : rel<tuple<si32>>
+    %0 = named_table @t1 as ["a", "a"] : rel<struct<si32>>
+    yield %0 : rel<struct<si32>>
   }
 }
 

--- a/test/Dialect/Substrait/plan.mlir
+++ b/test/Dialect/Substrait/plan.mlir
@@ -62,8 +62,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
-    %0 = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
-    yield %0 : rel<si32, tuple<si32>>
+    %0 = named_table @t as ["a", "b", "c"] : rel<si32, struct<si32>>
+    yield %0 : rel<si32, struct<si32>>
   }
 }
 

--- a/test/Dialect/Substrait/project-invalid.mlir
+++ b/test/Dialect/Substrait/project-invalid.mlir
@@ -5,7 +5,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32' vs 'si1')}}
     %1 = project %0 : rel<si32> -> rel<si1, si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %42 = literal 42 : si32
       yield %42 : si32
     }
@@ -20,7 +20,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32', 'si32' vs 'si32')}}
     %1 = project %0 : rel<si32, si32> -> rel<si32> {
-    ^bb0(%arg : tuple<si32, si32>):
+    ^bb0(%arg : !substrait.struct<si32, si32>):
       %42 = literal 42 : si32
       yield %42 : si32
     }
@@ -35,7 +35,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.project' op has output field type whose new fields are different from the yielded operand types ('si1' vs 'si32')}}
     %1 = project %0 : rel<si32> -> rel<si32, si1> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %42 = literal 42 : si32
       yield %42 : si32
     }
@@ -48,10 +48,10 @@ substrait.plan version 0 : 42 : 1 {
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
-    // expected-error@+1 {{'substrait.project' op has 'expressions' region with mismatching argument type (has: 'tuple<si1>', expected: 'tuple<si32>')}}
+    // expected-error@+1 {{'substrait.project' op has 'expressions' region with mismatching argument type (has: '!substrait.struct<si1>', expected: '!substrait.struct<si32>')}}
     %1 = project %0 : rel<si32> -> rel<si32, si1> {
-    ^bb0(%arg : tuple<si1>):
-      %3 = field_reference %arg[0] : tuple<si1>
+    ^bb0(%arg : !substrait.struct<si1>):
+      %3 = field_reference %arg[0] : !substrait.struct<si1>
       yield %3 : si1
     }
     yield %1 : rel<si32, si1>

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -5,7 +5,7 @@
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si32> -> rel<si32, si1, si32> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si32>):
 // CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 // CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32
 // CHECK-NEXT:      yield %[[V2]], %[[V3]] : si1, si32
@@ -16,7 +16,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si1, si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %true = literal -1 : si1
       %42 = literal 42 : si32
       yield %true, %42 : si1, si32
@@ -31,14 +31,14 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:   relation
 // CHECK:         %[[V0:.*]] = named_table
 // CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si32> -> rel<si32> {
-// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si32>):
 // CHECK-NEXT:    }
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32> {
-    ^bb0(%arg0: tuple<si32>):
+    ^bb0(%arg0: !substrait.struct<si32>):
       yield
     }
     yield %1 : rel<si32>
@@ -62,7 +62,7 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> -> rel<si32> {
-    ^bb0(%arg0: tuple<si32>):
+    ^bb0(%arg0: !substrait.struct<si32>):
       yield
     }
     yield %1 : rel<si32>

--- a/test/Dialect/Substrait/relation-invalid.mlir
+++ b/test/Dialect/Substrait/relation-invalid.mlir
@@ -2,7 +2,7 @@
 
 // Test error if providing too many names (1 name for 0 fields).
 substrait.plan version 0 : 42 : 1 {
-  // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "y"]) and result type ('tuple<si32>')}}
+  // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "y"]) and result type ('!substrait.struct<si32>')}}
   // expected-note@+1 {{too many field names provided}}
   relation as ["x", "y"] {
     %0 = named_table @t1 as ["a"] : rel<si32>
@@ -14,7 +14,7 @@ substrait.plan version 0 : 42 : 1 {
 
 // Test error if providing too few names (0 names for 1 field).
 substrait.plan version 0 : 42 : 1 {
-  // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x"]) and result type ('tuple<si32, si32>')}}
+  // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x"]) and result type ('!substrait.struct<si32, si32>')}}
   // expected-error@+1 {{not enough field names provided}}
   relation as ["x"] {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>
@@ -26,7 +26,7 @@ substrait.plan version 0 : 42 : 1 {
 
 // Test error if providing duplicate field names in the same nesting level.
 substrait.plan version 0 : 42 : 1 {
-  // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "x"]) and result type ('tuple<si32, si32>')}}
+  // expected-error@+2 {{'substrait.relation' op has mismatching 'field_names' (["x", "x"]) and result type ('!substrait.struct<si32, si32>')}}
   // expected-error@+1 {{duplicate field name: 'x'}}
   relation as ["x", "x"] {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si32>

--- a/test/Dialect/Substrait/struct-type-invalid.mlir
+++ b/test/Dialect/Substrait/struct-type-invalid.mlir
@@ -1,0 +1,43 @@
+// RUN: substrait-opt -verify-diagnostics -split-input-file %s
+
+// Tests that double-nullable `StructType` is rejected, mirroring
+// `nullable-type-invalid.mlir`.
+
+// Check that `struct<si32>??` causes a parse error (only one '?' is consumed).
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    // expected-error @+1 {{expected '>'}}
+    %0 = named_table @t1 as ["s", "x"] : rel<struct<si32>??>
+    yield %0 : rel<struct<si32>??>
+  }
+}
+
+// -----
+
+// Check that `!substrait.nullable<!substrait.struct<si32>>?` is rejected
+// at parse time.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    // expected-error @+2 {{NullableType cannot be made nullable again}}
+    %0 = named_table @t1 as ["s", "x"]
+        : rel<!substrait.nullable<!substrait.struct<si32>>?>
+    yield %0 : rel<!substrait.nullable<!substrait.struct<si32>>?>
+  }
+}
+
+// -----
+
+// Check that `NullableType<NullableType<StructType>>` is rejected by the
+// verifier.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    // expected-error @+2 {{NullableType cannot wrap another NullableType}}
+    %0 = named_table @t1 as ["s", "x"]
+        : rel<!substrait.nullable<!substrait.nullable<!substrait.struct<si32>>>>
+    yield %0
+        : rel<!substrait.nullable<!substrait.nullable<!substrait.struct<si32>>>>
+  }
+}

--- a/test/Dialect/Substrait/struct-type.mlir
+++ b/test/Dialect/Substrait/struct-type.mlir
@@ -1,0 +1,73 @@
+// RUN: substrait-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: substrait-opt -split-input-file %s | substrait-opt -split-input-file \
+// RUN: | FileCheck %s
+
+// Tests parsing, printing, and round-tripping of `StructType`.
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:       named_table @t1 as ["s", "x"] : rel<struct<si32>>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["s", "x"] : rel<struct<si32>>
+    yield %0 : rel<struct<si32>>
+  }
+}
+
+// -----
+
+// Check round-trip of an empty struct (exercises the early-out path in parse).
+// CHECK-LABEL: substrait.plan
+// CHECK:       named_table @t1 as ["s"] : rel<struct<>>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["s"] : rel<struct<>>
+    yield %0 : rel<struct<>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK:       named_table @t1 as ["s", "x", "y"] : rel<struct<si32, string?>?>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["s", "x", "y"] : rel<struct<si32, string?>?>
+    yield %0 : rel<struct<si32, string?>?>
+  }
+}
+
+// -----
+
+// Check round-trip of a nested struct (field names are consumed depth-first).
+// CHECK-LABEL: substrait.plan
+// CHECK:       named_table @t1 as ["outer", "inner", "inner_a", "inner_b", "z"]
+// CHECK-SAME:    : rel<struct<struct<si32, si64>, string>>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["outer", "inner", "inner_a", "inner_b", "z"]
+        : rel<struct<struct<si32, si64>, string>>
+    yield %0 : rel<struct<struct<si32, si64>, string>>
+  }
+}
+
+// -----
+
+// Check that the canonical `!substrait.struct<...>` form round-trips to
+// short form.
+// CHECK-LABEL: substrait.plan
+// CHECK:       named_table @t1 as ["s", "x"] : rel<struct<si32>>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["s", "x"] : rel<!substrait.struct<si32>>
+    yield %0 : rel<!substrait.struct<si32>>
+  }
+}

--- a/test/Dialect/Substrait/types.mlir
+++ b/test/Dialect/Substrait/types.mlir
@@ -199,13 +199,13 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : rel<f32, struct<f32>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
-    yield %0 : rel<f32, tuple<f32>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, struct<f32>>
+    yield %0 : rel<f32, struct<f32>>
   }
 }
 
@@ -227,12 +227,12 @@ substrait.plan version 0 : 42 : 1 {
 
 // CHECK-LABEL: substrait.plan
 // CHECK:         relation
-// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
+// CHECK:         %[[V0:.*]] = named_table @t1 as ["a", "b", "c"] : rel<si1, struct<si1>>
 // CHECK-NEXT:    yield %[[V0]] :
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    yield %0 : rel<si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, struct<si1>>
+    yield %0 : rel<si1, struct<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate-invalid.mlir
@@ -10,7 +10,7 @@ substrait.plan version 0 : 42 : 1 {
     // expected-error@+1 {{'substrait.aggregate' op cannot be exported: values yielded from 'groupings' region are not all distinct after CSE}}
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         %3 = literal 0 : si1
         yield %2, %3 : si1, si1

--- a/test/Target/SubstraitPB/Export/aggregate.mlir
+++ b/test/Target/SubstraitPB/Export/aggregate.mlir
@@ -80,15 +80,15 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si1, si1, si32, si32>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         %3 = literal -1 : si1
         yield %2, %3 : si1, si1
       }
       grouping_sets [[0], [0, 1], [1], []]
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate : (si32) -> si32
         yield %3 : si32
       }
@@ -113,7 +113,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }
@@ -141,8 +141,8 @@ substrait.plan version 0 : 42 : 1 {
     %1 = aggregate %0 : rel<si32> -> rel<si32>
       grouping_sets []
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %4 = call @function(%2) aggregate : (si32) -> si32
         yield %4 : si32
       }
@@ -168,8 +168,8 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = aggregate %0 : rel<si32> -> rel<si32>
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %4 = call @function(%2) aggregate : (si32) -> si32
         yield %4 : si32
       }
@@ -227,8 +227,8 @@ substrait.plan version 0 : 42 : 1 {
     %1 = aggregate %0 : rel<si32>
           -> rel<si32, si32, si32, si32, si32, si32, si32>
       measures {
-      ^bb0(%arg : tuple<si32>):
-        %2 = field_reference %arg[0] : tuple<si32>
+      ^bb0(%arg : !substrait.struct<si32>):
+        %2 = field_reference %arg[0] : !substrait.struct<si32>
         %3 = call @function(%2) aggregate initial_to_intermediate all : (si32) -> si32
         %4 = call @function(%2) aggregate intermediate_to_intermediate all : (si32) -> si32
         %5 = call @function(%2) aggregate intermediate_to_result all : (si32) -> si32
@@ -266,7 +266,7 @@ substrait.plan version 0 : 42 : 1 {
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> -> rel<si1>
       groupings {
-      ^bb0(%arg : tuple<si32>):
+      ^bb0(%arg : !substrait.struct<si32>):
         %2 = literal 0 : si1
         yield %2 : si1
       }

--- a/test/Target/SubstraitPB/Export/call.mlir
+++ b/test/Target/SubstraitPB/Export/call.mlir
@@ -41,8 +41,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
-      %2 = field_reference %arg[0] : tuple<si32>
+    ^bb0(%arg : !substrait.struct<si32>):
+      %2 = field_reference %arg[0] : !substrait.struct<si32>
       %3 = call @f2(%2) : (si32) -> si1
       yield %3 : si1
     }

--- a/test/Target/SubstraitPB/Export/cast.mlir
+++ b/test/Target/SubstraitPB/Export/cast.mlir
@@ -61,7 +61,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si32?, si64, si64> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal 42 : si32
       %3 = cast %2 or return_null : si32 to si32?
       %4 = cast %2 or throw_exception : si32 to si64

--- a/test/Target/SubstraitPB/Export/emit.mlir
+++ b/test/Target/SubstraitPB/Export/emit.mlir
@@ -69,7 +69,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
     %1 = filter %0 : rel<si32, si1> {
-    ^bb0(%arg : tuple<si32, si1>):
+    ^bb0(%arg : !substrait.struct<si32, si1>):
       %2 = literal -1 : si1
       yield %2 : si1
     }

--- a/test/Target/SubstraitPB/Export/field-reference.mlir
+++ b/test/Target/SubstraitPB/Export/field-reference.mlir
@@ -27,13 +27,13 @@
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    %1 = filter %0 : rel<si1, tuple<si1>> {
-    ^bb0(%arg : tuple<si1, tuple<si1>>):
-      %2 = field_reference %arg[1, 0] : tuple<si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, struct<si1>>
+    %1 = filter %0 : rel<si1, struct<si1>> {
+    ^bb0(%arg : !substrait.struct<si1, struct<si1>>):
+      %2 = field_reference %arg[1, 0] : !substrait.struct<si1, struct<si1>>
       yield %2 : si1
     }
-    yield %1 : rel<si1, tuple<si1>>
+    yield %1 : rel<si1, struct<si1>>
   }
 }
 
@@ -64,13 +64,13 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    %1 = filter %0 : rel<si1, tuple<si1>> {
-    ^bb0(%arg : tuple<si1, tuple<si1>>):
-      %2 = field_reference %arg[1] : tuple<si1, tuple<si1>>
-      %3 = field_reference %2[0] : tuple<si1>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, struct<si1>>
+    %1 = filter %0 : rel<si1, struct<si1>> {
+    ^bb0(%arg : !substrait.struct<si1, struct<si1>>):
+      %2 = field_reference %arg[1] : !substrait.struct<si1, struct<si1>>
+      %3 = field_reference %2[0] : !substrait.struct<si1>
       yield %3 : si1
     }
-    yield %1 : rel<si1, tuple<si1>>
+    yield %1 : rel<si1, struct<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Export/filter.mlir
+++ b/test/Target/SubstraitPB/Export/filter.mlir
@@ -23,7 +23,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = filter %0 : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }
@@ -49,7 +49,7 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %2 = literal -1 : si1
       yield %2 : si1
     }

--- a/test/Target/SubstraitPB/Export/literal.mlir
+++ b/test/Target/SubstraitPB/Export/literal.mlir
@@ -29,7 +29,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, decimal<9, 2>> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %hi = literal #substrait.decimal<"0.05", P = 9, S = 2>
       yield %hi : decimal<9, 2>
     }
@@ -56,7 +56,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, fixed_binary<10>> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %fixed_binary = literal #substrait.fixed_binary<"8181818181">
       yield %fixed_binary : fixed_binary<10>
     }
@@ -87,7 +87,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, var_char<6>> {
-    ^bb0(%arg0: tuple<si1>):
+    ^bb0(%arg0: !substrait.struct<si1>):
       %2 = literal #substrait.var_char<"hello", 6>
       yield %2 : var_char<6>
     }
@@ -116,7 +116,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, fixed_char<5>> {
-    ^bb0(%arg0: tuple<si1>):
+    ^bb0(%arg0: !substrait.struct<si1>):
       %2 = literal #substrait.fixed_char<"hello">
       yield %2 : fixed_char<5>
     }
@@ -143,7 +143,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, uuid> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %uuid = literal #substrait.uuid<1000000000 : i128>
       yield %uuid : uuid
     }
@@ -180,7 +180,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, interval_ym, interval_ds> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %interval_year_month = literal #substrait.interval_year_month<2024y 1m>
       %interval_day_second = literal #substrait.interval_day_second<9d 8000s>
       yield %interval_year_month, %interval_day_second : interval_ym, interval_ds
@@ -210,7 +210,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, time> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %time = literal #substrait.time<200000000us>
       yield %time : time
     }
@@ -237,7 +237,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, date> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %date = literal #substrait.date<200000000>
       yield %date : date
     }
@@ -269,7 +269,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %timestamp = literal #substrait.timestamp<10000000000us>
       %timestamp_tz = literal #substrait.timestamp_tz<10000000000us>
       yield %timestamp, %timestamp_tz : timestamp, timestamp_tz
@@ -297,7 +297,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, binary> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %bytes = literal "4,5,6,7" : !substrait.binary
       yield %bytes : binary
     }
@@ -324,7 +324,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, string> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %hi = literal "hi" : !substrait.string
       yield %hi : string
     }
@@ -356,7 +356,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<f32>
     %1 = project %0 : rel<f32> -> rel<f32, f32, f64> {
-    ^bb0(%arg : tuple<f32>):
+    ^bb0(%arg : !substrait.struct<f32>):
       %35 = literal 35.35 : f32
       %42 = literal 42.42 : f64
       yield %35, %42 : f32, f64
@@ -404,7 +404,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si1>
     %1 = project %0 : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
-    ^bb0(%arg : tuple<si1>):
+    ^bb0(%arg : !substrait.struct<si1>):
       %false = literal 0 : si1
       %2 = literal 2 : si8
       %-1 = literal -1 : si16

--- a/test/Target/SubstraitPB/Export/named-table.mlir
+++ b/test/Target/SubstraitPB/Export/named-table.mlir
@@ -148,8 +148,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["outer", "inner"] : rel<tuple<si32>>
-    yield %0 : rel<tuple<si32>>
+    %0 = named_table @t1 as ["outer", "inner"] : rel<struct<si32>>
+    yield %0 : rel<struct<si32>>
   }
 }
 
@@ -189,8 +189,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "a"] : rel<tuple<si32>>
-    yield %0 : rel<tuple<si32>>
+    %0 = named_table @t1 as ["a", "a"] : rel<struct<si32>>
+    yield %0 : rel<struct<si32>>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/nullable-types.mlir
+++ b/test/Target/SubstraitPB/Export/nullable-types.mlir
@@ -52,9 +52,9 @@ substrait.plan version 0 : 42 : 1 {
 
 // -----
 
-// Check that a nullable tuple<si32> is exported with the struct sub-message
-// having nullability: NULLABILITY_NULLABLE, covering the exportType path for
-// tuple types wrapped in NullableType.
+// Check that a nullable !substrait.struct<si32> is exported with the struct
+// sub-message having nullability: NULLABILITY_NULLABLE, covering the
+// exportType path for tuple types wrapped in NullableType.
 
 // CHECK-LABEL: relations {
 // CHECK:         struct {
@@ -64,8 +64,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b"] : rel<tuple<si32>?>
-    yield %0 : rel<tuple<si32>?>
+    %0 = named_table @t1 as ["a", "b"] : rel<struct<si32>?>
+    yield %0 : rel<struct<si32>?>
   }
 }
 

--- a/test/Target/SubstraitPB/Export/plan.mlir
+++ b/test/Target/SubstraitPB/Export/plan.mlir
@@ -51,8 +51,8 @@ substrait.plan
 
 substrait.plan version 0 : 42 : 1 {
   relation as ["x", "y", "z"] {
-    %0 = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
-    yield %0 : rel<si32, tuple<si32>>
+    %0 = named_table @t as ["a", "b", "c"] : rel<si32, struct<si32>>
+    yield %0 : rel<si32, struct<si32>>
   }
   relation  {
     %0 = named_table @t as ["a"] : rel<si32>

--- a/test/Target/SubstraitPB/Export/project-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/project-invalid.mlir
@@ -8,7 +8,7 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a"] : rel<si32>
     // expected-error@+1 {{'substrait.project' op not supported for export: no expressions}}
     %1 = project %0 : rel<si32> -> rel<si32> {
-    ^bb0(%arg0: tuple<si32>):
+    ^bb0(%arg0: !substrait.struct<si32>):
       yield
     }
     yield %1 : rel<si32>

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -31,7 +31,7 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si1, si32> {
-    ^bb0(%arg : tuple<si32>):
+    ^bb0(%arg : !substrait.struct<si32>):
       %true = literal -1 : si1
       %42 = literal 42 : si32
       yield %true, %42 : si1, si32
@@ -61,8 +61,8 @@ substrait.plan version 0 : 42 : 1 {
             advanced_extension optimization = "\08*"
               : !substrait.any<"type.googleapis.com/google.protobuf.Int32Value">
             : rel<si32> -> rel<si32, si32> {
-    ^bb0(%arg0: tuple<si32>):
-      %2 = field_reference %arg0[0] : tuple<si32>
+    ^bb0(%arg0: !substrait.struct<si32>):
+      %2 = field_reference %arg0[0] : !substrait.struct<si32>
       yield %2 : si32
     }
     yield %1 : rel<si32, si32>

--- a/test/Target/SubstraitPB/Export/struct-type.mlir
+++ b/test/Target/SubstraitPB/Export/struct-type.mlir
@@ -1,0 +1,77 @@
+// RUN: substrait-translate -substrait-to-protobuf --split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: substrait-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | substrait-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
+// RUN: | substrait-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | FileCheck %s
+
+// Tests exporting `StructType` columns to protobuf.
+
+// Check that struct<si32, string?> is exported with per-field nullability.
+
+// CHECK-LABEL: relations {
+// CHECK:         base_schema {
+// CHECK-NEXT:      names: "s"
+// CHECK-NEXT:      names: "x"
+// CHECK-NEXT:      names: "y"
+// CHECK-NEXT:      struct {
+// CHECK-NEXT:        types {
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              i32 {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              string {
+// CHECK-NEXT:                nullability: NULLABILITY_NULLABLE
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["s", "x", "y"] : rel<struct<si32, string?>>
+    yield %0 : rel<struct<si32, string?>>
+  }
+}
+
+// -----
+
+// Check that `struct<si32>?` is exported with NULLABILITY_NULLABLE on the
+// struct sub-message.
+
+// CHECK-LABEL: relations {
+// CHECK:         base_schema {
+// CHECK-NEXT:      names: "s"
+// CHECK-NEXT:      names: "x"
+// CHECK-NEXT:      struct {
+// CHECK-NEXT:        types {
+// CHECK-NEXT:          struct {
+// CHECK-NEXT:            types {
+// CHECK-NEXT:              i32 {
+// CHECK-NEXT:                nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            nullability: NULLABILITY_NULLABLE
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:        nullability: NULLABILITY_REQUIRED
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["s", "x"] : rel<struct<si32>?>
+    yield %0 : rel<struct<si32>?>
+  }
+}

--- a/test/Target/SubstraitPB/Export/types.mlir
+++ b/test/Target/SubstraitPB/Export/types.mlir
@@ -362,8 +362,8 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, tuple<f32>>
-    yield %0 : rel<f32, tuple<f32>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<f32, !substrait.struct<f32>>
+    yield %0 : rel<f32, !substrait.struct<f32>>
   }
 }
 
@@ -448,7 +448,7 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, tuple<si1>>
-    yield %0 : rel<si1, tuple<si1>>
+    %0 = named_table @t1 as ["a", "b", "c"] : rel<si1, !substrait.struct<si1>>
+    yield %0 : rel<si1, !substrait.struct<si1>>
   }
 }

--- a/test/Target/SubstraitPB/Import/aggregate.textpb
+++ b/test/Target/SubstraitPB/Import/aggregate.textpb
@@ -17,15 +17,15 @@
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si1, si1, si32, si32>
 # CHECK-NEXT:        groupings {
-# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
+# CHECK-NEXT:        (%[[ARG0:.*]]: !substrait.struct<si32>):
 # CHECK-DAG:           %[[V2:.*]] = literal -1 : si1
 # CHECK-DAG:           %[[V3:.*]] = literal 0 : si1
 # CHECK-NEXT:          yield %[[V3]], %[[V2]] : si1, si1
 # CHECK-NEXT:        }
 # CHECK-NEXT:        grouping_sets {{\[}}[0], [0, 1], [1], []]
 # CHECK-NEXT:        measures {
-# CHECK-NEXT:        (%[[ARG1:.*]]: tuple<si32>):
-# CHECK-DAG:           %[[V4:.*]] = field_reference %[[ARG1]][0] : tuple<si32>
+# CHECK-NEXT:        (%[[ARG1:.*]]: !substrait.struct<si32>):
+# CHECK-DAG:           %[[V4:.*]] = field_reference %[[ARG0]][0] : !substrait.struct<si32>
 # CHECK-DAG:           %[[V5:.*]] = call @[[F1]](%[[V4]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V5]] : si32
 # CHECK-NEXT:        }
@@ -134,7 +134,7 @@ version {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si1>
 # CHECK-NEXT:        groupings {
-# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
+# CHECK-NEXT:        (%[[ARG0:.*]]: !substrait.struct<si32>):
 # CHECK-DAG:           %[[V2:.*]] = literal 0 : si1
 # CHECK-NEXT:          yield %[[V2]] : si1
 # CHECK-NEXT:        }
@@ -193,8 +193,8 @@ version {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si32>
 # CHECK-NEXT:        measures {
-# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
-# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
+# CHECK-NEXT:        (%[[ARG1:.*]]: !substrait.struct<si32>):
+# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : !substrait.struct<si32>
 # CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V3]] : si32
 # CHECK-NEXT:        }
@@ -280,8 +280,8 @@ version {
 # CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> -> rel<si32>
 # CHECK-NEXT:        grouping_sets []
 # CHECK-NEXT:        measures {
-# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
-# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : tuple<si32>
+# CHECK-NEXT:        (%[[ARG1:.*]]: !substrait.struct<si32>):
+# CHECK-DAG:           %[[V2:.*]] = field_reference %[[ARG0]][0] : !substrait.struct<si32>
 # CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%[[V2]]) aggregate : (si32) -> si32
 # CHECK-NEXT:          yield %[[V3]] : si32
 # CHECK-NEXT:        }
@@ -364,7 +364,7 @@ version {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = aggregate %[[V0]] : rel<si32> ->
 # CHECK-NEXT:        measures {
-# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si32>):
+# CHECK-NEXT:        (%[[ARG1:.*]]: !substrait.struct<si32>):
 # CHECK-DAG:           %[[V2:.*]] = call @[[F1]](%{{.*}}) aggregate initial_to_intermediate : (si32) -> si32
 # CHECK-DAG:           %[[V3:.*]] = call @[[F1]](%{{.*}}) aggregate intermediate_to_intermediate : (si32) -> si32
 # CHECK-DAG:           %[[V4:.*]] = call @[[F1]](%{{.*}}) aggregate intermediate_to_result : (si32) -> si32

--- a/test/Target/SubstraitPB/Import/call.textpb
+++ b/test/Target/SubstraitPB/Import/call.textpb
@@ -17,8 +17,8 @@
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      named_table
 # CHECK-NEXT:      filter
-# CHECK-NEXT:      (%[[V0:.*]]: tuple<si32>):
-# CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]][0] : tuple<si32>
+# CHECK-NEXT:      (%[[V0:.*]]: !substrait.struct<si32>):
+# CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]][0] : !substrait.struct<si32>
 # CHECK-NEXT:        %[[V2:.*]] = call @[[F2]](%[[V1]]) : (si32) -> si1
 # CHECK-NEXT:        yield %[[V2]] : si1
 

--- a/test/Target/SubstraitPB/Import/cast.textpb
+++ b/test/Target/SubstraitPB/Import/cast.textpb
@@ -14,8 +14,8 @@
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      named_table
 # CHECK-NEXT:      project
-# CHECK-NEXT:      (%[[V0:.*]]: tuple<si32>):
-# CHECK-DAG:         %[[V1:.*]] = cast %{{.*}} or return_null : si32 to si64?
+# CHECK-NEXT:      (%[[V0:.*]]: !substrait.struct<si32>):
+# CHECK-DAG:         %[[V1:.*]] = cast %{{.*}} or return_null : si32 to si64
 # CHECK-DAG:         %[[V2:.*]] = cast %{{.*}} or throw_exception : si32 to si64
 # CHECK-DAG:         %[[V3:.*]] = cast %{{.*}} or unspecified : si32 to si64
 # CHECK-NEXT:        yield %[[V1]], %[[V2]], %[[V3]] :

--- a/test/Target/SubstraitPB/Import/field-reference.textpb
+++ b/test/Target/SubstraitPB/Import/field-reference.textpb
@@ -14,9 +14,9 @@
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      named_table
 # CHECK-NEXT:      filter
-# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si1, tuple<si1>>)
+# CHECK-NEXT:        (%[[ARG0:.*]]: !substrait.struct<si1, struct<si1>>):
 # CHECK-NEXT:          %[[V0:.*]] = field_reference %[[ARG0]][1, 0]
-# CHECK-SAME:            : tuple<si1, tuple<si1>>
+# CHECK-SAME:            : !substrait.struct<si1, struct<si1>>
 # CHECK-NEXT:          yield %[[V0]] : si1
 
 relations {
@@ -89,11 +89,11 @@ version {
 # CHECK-NEXT:    relation
 # CHECK-NEXT:      named_table
 # CHECK-NEXT:      filter
-# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si1, tuple<si1>>)
+# CHECK-NEXT:        (%[[ARG0:.*]]: !substrait.struct<si1, struct<si1>>):
 # CHECK-NEXT:          %[[V0:.*]] = field_reference %[[ARG0]][1]
-# CHECK-SAME:            : tuple<si1, tuple<si1>>
+# CHECK-SAME:            : !substrait.struct<si1, struct<si1>>
 # CHECK-NEXT:          %[[V1:.*]] = field_reference %[[V0]][0]
-# CHECK-SAME:            : tuple<si1>
+# CHECK-SAME:            : !substrait.struct<si1>
 # CHECK-NEXT:          yield %[[V1]] : si1
 
 relations {

--- a/test/Target/SubstraitPB/Import/filter.textpb
+++ b/test/Target/SubstraitPB/Import/filter.textpb
@@ -14,7 +14,7 @@
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V0:.*]] = named_table
 # CHECK-NEXT:      %[[V1:.*]] = filter %[[V0]] : rel<si32>
-# CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: tuple<si32>):
+# CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: !substrait.struct<si32>):
 # CHECK-NEXT:        %[[V2:.*]] = literal -1 : si1
 # CHECK-NEXT:        yield %[[V2]] : si1
 # CHECK-NEXT:      }

--- a/test/Target/SubstraitPB/Import/literal.textpb
+++ b/test/Target/SubstraitPB/Import/literal.textpb
@@ -14,7 +14,7 @@
 # CHECK-NEXT:           relation {
 # CHECK-NEXT:             %[[VAL_0:.*]] = named_table @t1 as ["a"] : rel<f32>
 # CHECK-NEXT:             %[[VAL_1:.*]] = project %[[VAL_0]] : rel<f32> -> rel<f32, decimal<3, 2>> {
-# CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: tuple<f32>):
+# CHECK-NEXT:             ^bb0(%[[VAL_2:.*]]: !substrait.struct<f32>):
 # CHECK-NEXT:               %[[VAL_3:.*]] = literal #substrait.decimal<"0.05", P = 3, S = 2>
 # CHECK-NEXT:               yield %[[VAL_3]] : decimal<3, 2>
 # CHECK-NEXT:             }
@@ -72,7 +72,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_binary<10>> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_binary<"8181818181">
 # CHECK-NEXT:      yield %[[V2]] : fixed_binary<10>
 # CHECK-NEXT:    }
@@ -126,7 +126,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, var_char<5>> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.var_char<"hello", 5>
 # CHECK-NEXT:      yield %[[V2]] : var_char<5>
 # CHECK-NEXT:    }
@@ -182,7 +182,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, fixed_char<5>> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.fixed_char<"hello">
 # CHECK-NEXT:      yield %[[V2]] : fixed_char<5>
 # CHECK-NEXT:    }
@@ -236,7 +236,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, uuid> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.uuid<1000000000 : i128>
 # CHECK-NEXT:      yield %[[V2]] : uuid
 # CHECK-NEXT:    }
@@ -290,7 +290,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, interval_ym, interval_ds> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.interval_year_month<2024y 1m>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.interval_day_second<9d 8000s>
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : interval_ym, interval_ds
@@ -356,7 +356,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, time> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.time<200000000us>
 # CHECK-NEXT:      yield %[[V2]] : time
 # CHECK-NEXT:    }
@@ -410,7 +410,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, date> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.date<200000000>
 # CHECK-NEXT:      yield %[[V2]] : date
 # CHECK-NEXT:    }
@@ -464,7 +464,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, timestamp, timestamp_tz> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal #substrait.timestamp<10000000000us>
 # CHECK-NEXT:      %[[V3:.*]] = literal #substrait.timestamp_tz<10000000000us>
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : timestamp, timestamp_tz
@@ -524,7 +524,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, binary> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "4,5,6,7" : !substrait.binary
 # CHECK-NEXT:      yield %[[V2]] : binary
 # CHECK-NEXT:    }
@@ -578,7 +578,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, string> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal "hi" : !substrait.string
 # CHECK-NEXT:      yield %[[V2]] : string
 # CHECK-NEXT:    }
@@ -632,7 +632,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<f32> -> rel<f32, f32, f64> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<f32>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<f32>):
 # CHECK-NEXT:      %[[V2:.*]] = literal 3.535000e+01 : f32
 # CHECK-NEXT:      %[[V3:.*]] = literal 4.242000e+01 : f64
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : f32, f64
@@ -692,7 +692,7 @@ version {
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si1> -> rel<si1, si1, si8, si16, si32, si64> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si1>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si1>):
 # CHECK-NEXT:      %[[V2:.*]] = literal 0 : si1
 # CHECK-NEXT:      %[[V3:.*]] = literal 2 : si8
 # CHECK-NEXT:      %[[V4:.*]] = literal -1 : si16

--- a/test/Target/SubstraitPB/Import/named-table.textpb
+++ b/test/Target/SubstraitPB/Import/named-table.textpb
@@ -121,7 +121,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:         %[[V0:.*]] = named_table @t1
-# CHECK-SAME:      as ["outer", "inner"] : rel<tuple<si32>>
+# CHECK-SAME:      as ["outer", "inner"] : rel<struct<si32>>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {
@@ -164,7 +164,7 @@ version {
 # CHECK-LABEL: substrait.plan
 # CHECK:         relation
 # CHECK:         %[[V0:.*]] = named_table @t1
-# CHECK-SAME:      as ["a", "a"] : rel<tuple<si32>>
+# CHECK-SAME:      as ["a", "a"] : rel<struct<si32>>
 # CHECK-NEXT:    yield %[[V0]] :
 
 relations {

--- a/test/Target/SubstraitPB/Import/plan.textpb
+++ b/test/Target/SubstraitPB/Import/plan.textpb
@@ -25,8 +25,8 @@ version {
 
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:    relation as ["x", "y", "z"] {
-# CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : rel<si32, tuple<si32>>
-# CHECK-NEXT:      yield %[[V0]] : rel<si32, tuple<si32>>
+# CHECK-NEXT:      %[[V0:.*]] = named_table @t as ["a", "b", "c"] : rel<si32, struct<si32>>
+# CHECK-NEXT:      yield %[[V0]] : rel<si32, struct<si32>>
 # CHECK-NEXT:    }
 # CHECK-NEXT:    relation {
 # CHECK-NEXT:      %[[V1:.*]] = named_table @t as ["a"] : rel<si32>

--- a/test/Target/SubstraitPB/Import/project.textpb
+++ b/test/Target/SubstraitPB/Import/project.textpb
@@ -14,7 +14,7 @@
 # CHECK-NEXT:   relation
 # CHECK:         %[[V0:.*]] = named_table
 # CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : rel<si32> -> rel<si32, si1, si32> {
-# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: !substrait.struct<si32>):
 # CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
 # CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32
 # CHECK-NEXT:      yield %[[V2]], %[[V3]] : si1, si32

--- a/test/Target/SubstraitPB/Import/struct-type.textpb
+++ b/test/Target/SubstraitPB/Import/struct-type.textpb
@@ -10,11 +10,14 @@
 # RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | FileCheck %s
 
-# Check that a nullable i32 field is imported as si32?.
+# Tests importing `Type.struct` from protobuf as `StructType`.
+
+# Check that a required struct column with one field is imported as
+# struct<si32>.
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<si32?>
+# CHECK-SAME:       : rel<struct<si32>>
 
 relations {
   rel {
@@ -24,11 +27,17 @@ relations {
         }
       }
       base_schema {
-        names: "a"
+        names: "s"
+        names: "x"
         struct {
           types {
-            i32 {
-              nullability: NULLABILITY_NULLABLE
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
             }
           }
           nullability: NULLABILITY_REQUIRED
@@ -47,11 +56,11 @@ version {
 
 # -----
 
-# Check that NULLABILITY_UNSPECIFIED is also imported as nullable (T?).
+# Check that mixed-nullability fields are imported with per-field nullability.
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
-# CHECK-SAME:       : rel<f64?>
+# CHECK-SAME:       : rel<struct<si32, string?>>
 
 relations {
   rel {
@@ -61,11 +70,23 @@ relations {
         }
       }
       base_schema {
-        names: "a"
+        names: "s"
+        names: "x"
+        names: "y"
         struct {
           types {
-            fp64 {
-              nullability: NULLABILITY_UNSPECIFIED
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              types {
+                string {
+                  nullability: NULLABILITY_NULLABLE
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
             }
           }
           nullability: NULLABILITY_REQUIRED
@@ -84,7 +105,8 @@ version {
 
 # -----
 
-# Check that a nullable struct is imported as !substrait.struct<si32>?.
+# Check that NULLABILITY_NULLABLE on the struct sub-message is imported
+# as struct<si32>?.
 # CHECK-LABEL: substrait.plan
 # CHECK-NEXT:   relation
 # CHECK-NEXT:     named_table
@@ -98,8 +120,8 @@ relations {
         }
       }
       base_schema {
-        names: "a"
-        names: "b"
+        names: "s"
+        names: "x"
         struct {
           types {
             struct {

--- a/test/Target/SubstraitPB/Import/types.textpb
+++ b/test/Target/SubstraitPB/Import/types.textpb
@@ -471,7 +471,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : rel<f32, tuple<f32>>
+# CHECK-NEXT:     named_table {{.*}} : rel<f32, struct<f32>>
 
 relations {
   rel {
@@ -577,7 +577,7 @@ version {
 
 # CHECK:      substrait.plan
 # CHECK-NEXT:   relation
-# CHECK-NEXT:     named_table {{.*}} : rel<si1, tuple<si1>>
+# CHECK-NEXT:     named_table {{.*}} : rel<si1, struct<si1>>
 
 relations {
   rel {

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -173,25 +173,25 @@ substrait.plan version 0 : 42 : 1 {
 
 substrait.plan version 0 : 42 : 1 {
   relation {
-    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si1, tuple<si1, si32>>
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : rel<si1, si1, struct<si1, si32>>
     // Fields in position 1 and 3 are duplicates of field in position 0, so we
     // expect all references to the former to be replaced by the latter and an
     // `emit` re-establishing the original fields after the `filter`.
     %1 = emit [1, 1, 2, 1, 0] from %0
-        : rel<si1, si1, tuple<si1, si32>> -> rel<si1, si1, tuple<si1, si32>, si1, si1>
-    %2 = filter %1 : rel<si1, si1, tuple<si1, si32>, si1, si1> {
-    ^bb0(%arg0: tuple<si1, si1, tuple<si1, si32>, si1, si1>):
-      %3 = field_reference %arg0[0] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
-      %4 = field_reference %arg0[1] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
-      %5 = field_reference %arg0[2, 0] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
-      %6 = field_reference %arg0[2] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
-      %7 = field_reference %6[1] : tuple<si1, si32>
-      %8 = field_reference %arg0[3] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
-      %9 = field_reference %arg0[4] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+        : rel<si1, si1, struct<si1, si32>> -> rel<si1, si1, struct<si1, si32>, si1, si1>
+    %2 = filter %1 : rel<si1, si1, struct<si1, si32>, si1, si1> {
+    ^bb0(%arg0: !substrait.struct<si1, si1, struct<si1, si32>, si1, si1>):
+      %3 = field_reference %arg0[0] : !substrait.struct<si1, si1, struct<si1, si32>, si1, si1>
+      %4 = field_reference %arg0[1] : !substrait.struct<si1, si1, struct<si1, si32>, si1, si1>
+      %5 = field_reference %arg0[2, 0] : !substrait.struct<si1, si1, struct<si1, si32>, si1, si1>
+      %6 = field_reference %arg0[2] : !substrait.struct<si1, si1, struct<si1, si32>, si1, si1>
+      %7 = field_reference %6[1] : !substrait.struct<si1, si32>
+      %8 = field_reference %arg0[3] : !substrait.struct<si1, si1, struct<si1, si32>, si1, si1>
+      %9 = field_reference %arg0[4] : !substrait.struct<si1, si1, struct<si1, si32>, si1, si1>
       %a = "test.op"(%3, %4, %5, %7, %8, %9) : (si1, si1, si1, si32, si1, si1) -> si1
       yield %a : si1
     }
-    yield %2 : rel<si1, si1, tuple<si1, si32>, si1, si1>
+    yield %2 : rel<si1, si1, struct<si1, si32>, si1, si1>
   }
 }
 
@@ -216,9 +216,9 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
     %2 = project %1 : rel<si32, si32> -> rel<si32, si32, si1> {
-    ^bb0(%arg : tuple<si32, si32>):
-      %3 = field_reference %arg[0] : tuple<si32, si32>
-      %4 = field_reference %arg[1] : tuple<si32, si32>
+    ^bb0(%arg : !substrait.struct<si32, si32>):
+      %3 = field_reference %arg[0] : !substrait.struct<si32, si32>
+      %4 = field_reference %arg[1] : !substrait.struct<si32, si32>
       %5 = "test.op"(%3, %4) : (si32, si32) -> si1
       yield %5 : si1
     }
@@ -245,8 +245,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : rel<si32>
     %1 = project %0 : rel<si32> -> rel<si32, si1, si1> {
-    ^bb0(%arg : tuple<si32>):
-      %2 = field_reference %arg[0] : tuple<si32>
+    ^bb0(%arg : !substrait.struct<si32>):
+      %2 = field_reference %arg[0] : !substrait.struct<si32>
       %3 = "test.op"(%2) : (si32) -> si1
       // We yield two times the same value. This pattern should remove one of
       // the two and re-establish the duplicate with an `amit` after the
@@ -276,8 +276,8 @@ substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : rel<si32, si1>
     %1 = project %0 : rel<si32, si1> -> rel<si32, si1, si32, si1> {
-    ^bb0(%arg0: tuple<si32, si1>):
-      %2 = field_reference %arg0[0] : tuple<si32, si1>
+    ^bb0(%arg0: !substrait.struct<si32, si1>):
+      %2 = field_reference %arg0[0] : !substrait.struct<si32, si1>
       %3 = "test.op"(%2) : (si32) -> si1
       // `%2` yields an input field without modifications. This pattern removes
       // that yielding and re-establishes the duplicated field with an `emit`
@@ -311,9 +311,9 @@ substrait.plan version 0 : 42 : 1 {
     %0 = named_table @t1 as ["a", "b"] : rel<si1, si32>
     %1 = emit [1, 1] from %0 : rel<si1, si32> -> rel<si32, si32>
     %2 = project %1 : rel<si32, si32> -> rel<si32, si32, si32, si32> {
-    ^bb0(%arg : tuple<si32, si32>):
-      %3 = field_reference %arg[0] : tuple<si32, si32>
-      %4 = field_reference %arg[1] : tuple<si32, si32>
+    ^bb0(%arg : !substrait.struct<si32, si32>):
+      %3 = field_reference %arg[0] : !substrait.struct<si32, si32>
+      %4 = field_reference %arg[1] : !substrait.struct<si32, si32>
       yield %3, %4 : si32, si32
     }
     yield %2 : rel<si32, si32, si32, si32>

--- a/test/python/dialects/substrait/dialect.py
+++ b/test/python/dialects/substrait/dialect.py
@@ -77,3 +77,36 @@ def testNullableType():
   print(nullable_type)
   # CHECK: !substrait.nullable<si32>
   assert isinstance(nullable_type, ss.NullableType)
+
+
+# CHECK-LABEL: TEST: testStructType
+@run
+def testStructType():
+  si32 = ir.IntegerType.get_signed(32)
+  si64 = ir.IntegerType.get_signed(64)
+
+  # Plain struct with two fields.
+  struct_type = ss.StructType.get([si32, si64])
+  print(struct_type)
+  # CHECK: !substrait.struct<si32, si64>
+  assert isinstance(struct_type, ss.StructType)
+
+  # Empty struct.
+  empty_struct = ss.StructType.get([])
+  print(empty_struct)
+  # CHECK: !substrait.struct<>
+  assert isinstance(empty_struct, ss.StructType)
+
+  # Nullable field inside a struct.
+  nullable_si32 = ss.NullableType.get(si32)
+  struct_with_nullable = ss.StructType.get([si32, nullable_si32])
+  print(struct_with_nullable)
+  # CHECK: !substrait.struct<si32, si32?>
+  assert isinstance(struct_with_nullable, ss.StructType)
+
+  # Nested struct.
+  inner = ss.StructType.get([si32])
+  outer = ss.StructType.get([inner, si64])
+  print(outer)
+  # CHECK: !substrait.struct<struct<si32>, si64>
+  assert isinstance(outer, ss.StructType)


### PR DESCRIPTION
This PR is stacked on top of #198.

This PR implements a custom type for Substrait's `struct` type. Previously, this had been represented by the built-in `tuple` type. We had planned for a long time (#94) to implement this type. It now becomes a requirement to implement proper nullability (#95).

This resolves #94.