### PR TITLE
ci(actions): set up zizmor code scanning and implement fixes

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Set up bazel
-      uses: bazel-contrib/setup-bazel@0.19.0
+      uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
@@ -25,16 +25,17 @@ jobs:
         external-cache: true
 
     - name: Cache git folder
-      uses: actions/cache@v6
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
       with:
         path: substrait-mlir/.git
         key: git-folder
 
     - name: Checkout project
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         path: substrait-mlir
         submodules: recursive
+        persist-credentials: false
 
     - name: Lint bazel files
       run: |

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Set up bazel
-      uses: bazel-contrib/setup-bazel@e8776f58fb6a6e9055cbaf1b38c52ccc5247e9c4 # v0.14.0
+      uses: bazel-contrib/setup-bazel@0.19.0
       with:
         # Avoid downloading Bazel every time.
         bazelisk-cache: true
@@ -25,13 +25,13 @@ jobs:
         external-cache: true
 
     - name: Cache git folder
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: substrait-mlir/.git
         key: git-folder
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         path: substrait-mlir
         submodules: recursive

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,33 +34,34 @@ jobs:
         echo "MLIR_C_RUNNER_UTILS_LIB=${GITHUB_WORKSPACE}/substrait-mlir/build/lib/libmlir_c_runner_utils.so" | tee -a $GITHUB_ENV
 
     - name: Set up Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: 3.12
 
     - name: Cache git folder
-      uses: actions/cache@v6
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
       with:
         path: substrait-mlir/.git
         key: git-folder
 
     - name: Install dependencies from apt
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
+      uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1
       with:
         packages: libcurl4-gnutls-dev
         version: 1.0
 
     - name: Checkout project
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         path: substrait-mlir
         submodules: recursive
+        persist-credentials: false
 
     - name: Install Ninja
       uses: llvm/actions/install-ninja@89a8cf80982d830faab019237860b344a6390c30 # June 25, 2026
 
     - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
         key: ${{ runner.os }}-substrait-mlir-${{ matrix.llvm_enable_assertions }}
         # LLVM needs serious cache size
@@ -112,7 +113,7 @@ jobs:
 
     # Run this as part of the `build` job because we need the `build` folder.
     - name: Run pyright to test if typing annotations are correct
-      uses: jakebailey/pyright-action@v3.0.2
+      uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3.0.2
       with:
         stats: true
         working-directory: substrait-mlir
@@ -124,21 +125,22 @@ jobs:
     timeout-minutes: 240
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: 3.12
 
     - name: Cache git folder
-      uses: actions/cache@v6
+      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
       with:
         path: substrait-mlir/.git
         key: git-folder
 
     - name: Checkout project
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         path: substrait-mlir
         submodules: recursive
+        persist-credentials: false
 
     - name: "Remap base folder to X: and store path in environment"
       run: |
@@ -146,7 +148,7 @@ jobs:
         echo "SUBSTRAIT_MLIR_MAIN_SRC_DIR=X:\" >> $env:GITHUB_ENV
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v5.3.0
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         distribution: 'temurin'
         java-version: '11'
@@ -157,7 +159,7 @@ jobs:
     # builds due to a bug between cmake and sccache. See:
     #   - https://gitlab.kitware.com/cmake/cmake/-/issues/22529
     - name: sccache
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
         key: ${{ runner.os }}-substrait-mlir
         max-size: 6G
@@ -165,7 +167,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        cd "${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}"
+        cd "$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR"
         python -m pip install -v -r requirements.txt
 
     # We build the project without zlib; it isn't needed for any substrait-related
@@ -176,7 +178,7 @@ jobs:
     - name: Configure CMake
       run: |
         $ErrorActionPreference = 'Stop'
-        & "${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}\utils\find_vs.ps1"
+        & "$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR\utils\find_vs.ps1"
         cmake `
           -DPython3_EXECUTABLE=$(where python) `
           -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE `
@@ -189,7 +191,7 @@ jobs:
           -DLLVM_INSTALL_UTILS=ON `
           -DLLVM_LIT_ARGS=-v `
           -DLLVM_EXTERNAL_PROJECTS=substrait_mlir `
-          -DLLVM_EXTERNAL_SUBSTRAIT_MLIR_SOURCE_DIR="${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}" `
+          -DLLVM_EXTERNAL_SUBSTRAIT_MLIR_SOURCE_DIR="$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR" `
           -DLLVM_ENABLE_LLD=ON `
           -DLLVM_ENABLE_ZLIB=OFF `
           -DMLIR_INCLUDE_INTEGRATION_TESTS=ON `
@@ -199,19 +201,19 @@ jobs:
           -DSUBSTRAIT_MLIR_COMPILE_WARNING_AS_ERROR=OFF `
           -DCMAKE_C_COMPILER_LAUNCHER=sccache `
           -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
-          -S "${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}\third_party\llvm-project\llvm" `
-          -B "${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}\build" `
+          -S "$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR\third_party\llvm-project\llvm" `
+          -B "$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR\build" `
           -G Ninja
-        echo "PYTHONPATH=${env:PYTHONPATH}:${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}\build\tools\substrait_mlir\python_packages" | Out-File -Append -FilePath $env:GITHUB_ENV
+        echo "PYTHONPATH=${env:PYTHONPATH}:$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR\build\tools\substrait_mlir\python_packages" | Out-File -Append -FilePath $env:GITHUB_ENV
 
     - name: Build main project
       run: |
         $ErrorActionPreference = 'Stop'
-        & "${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}\utils\find_vs.ps1"
-        cmake --build ${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}/build --target substrait-mlir-all
+        & "$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR\utils\find_vs.ps1"
+        cmake --build $env:SUBSTRAIT_MLIR_MAIN_SRC_DIR/build --target substrait-mlir-all
         sccache --show-stats
 
     - name: Run lit tests
       run: |
-        & "${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}\utils\find_vs.ps1"
-        cmake --build ${{ env.SUBSTRAIT_MLIR_MAIN_SRC_DIR }}/build --target check-substrait-mlir
+        & "$env:SUBSTRAIT_MLIR_MAIN_SRC_DIR\utils\find_vs.ps1"
+        cmake --build $env:SUBSTRAIT_MLIR_MAIN_SRC_DIR/build --target check-substrait-mlir

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,33 +34,33 @@ jobs:
         echo "MLIR_C_RUNNER_UTILS_LIB=${GITHUB_WORKSPACE}/substrait-mlir/build/lib/libmlir_c_runner_utils.so" | tee -a $GITHUB_ENV
 
     - name: Set up Python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+      uses: actions/setup-python@v6.3.0
       with:
         python-version: 3.12
 
     - name: Cache git folder
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: substrait-mlir/.git
         key: git-folder
 
     - name: Install dependencies from apt
-      uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
       with:
         packages: libcurl4-gnutls-dev
         version: 1.0
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         path: substrait-mlir
         submodules: recursive
 
     - name: Install Ninja
-      uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c # Jan 17
+      uses: llvm/actions/install-ninja@89a8cf80982d830faab019237860b344a6390c30 # June 25, 2026
 
     - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@53911442209d5c18de8a31615e0923161e435875 # v1.2.16
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ runner.os }}-substrait-mlir-${{ matrix.llvm_enable_assertions }}
         # LLVM needs serious cache size
@@ -112,7 +112,7 @@ jobs:
 
     # Run this as part of the `build` job because we need the `build` folder.
     - name: Run pyright to test if typing annotations are correct
-      uses: jakebailey/pyright-action@v2
+      uses: jakebailey/pyright-action@v3.0.2
       with:
         stats: true
         working-directory: substrait-mlir
@@ -124,18 +124,18 @@ jobs:
     timeout-minutes: 240
     steps:
     - name: Set up Python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+      uses: actions/setup-python@v6.3.0
       with:
         python-version: 3.12
 
     - name: Cache git folder
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: substrait-mlir/.git
         key: git-folder
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
       with:
         path: substrait-mlir
         submodules: recursive
@@ -146,7 +146,7 @@ jobs:
         echo "SUBSTRAIT_MLIR_MAIN_SRC_DIR=X:\" >> $env:GITHUB_ENV
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5.3.0
       with:
         distribution: 'temurin'
         java-version: '11'
@@ -157,7 +157,7 @@ jobs:
     # builds due to a bug between cmake and sccache. See:
     #   - https://gitlab.kitware.com/cmake/cmake/-/issues/22529
     - name: sccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: hendrikmuhs/ccache-action@v1.2.23
       with:
         key: ${{ runner.os }}-substrait-mlir
         max-size: 6G

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: DoozyX/clang-format-lint-action@v0.20
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
       with:
         source: '.'
         exclude: './third_party'

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.18.1
+    - uses: actions/checkout@v7
+    - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: '.'
         exclude: './third_party'

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Format CMake files
-      uses: puneetmatharu/cmake-format-lint-action@960ee17edd4678e2793d49b96ae7608a91a78a5a # v1.0.6
+      uses: puneetmatharu/cmake-format-lint-action@v1.0.8
       with:
         args: --in-place
     - name: Check for diff

--- a/.github/workflows/cmake_format.yml
+++ b/.github/workflows/cmake_format.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: Format CMake files
-      uses: puneetmatharu/cmake-format-lint-action@v1.0.8
+      uses: puneetmatharu/cmake-format-lint-action@4ed77e1b4e9ae7b072e4e34c54461316771566c9 # v1.0.8
       with:
         args: --in-place
     - name: Check for diff

--- a/.github/workflows/coverage_stats.yml
+++ b/.github/workflows/coverage_stats.yml
@@ -23,12 +23,12 @@ jobs:
         echo "MLIR_C_RUNNER_UTILS_LIB=${GITHUB_WORKSPACE}/substrait-mlir/build/lib/libmlir_c_runner_utils.so" | tee -a $GITHUB_ENV
 
     - name: Set up Python
-      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+      uses: actions/setup-python@v6.3.0
       with:
         python-version: 3.12
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Install Python depends
       run: |

--- a/.github/workflows/coverage_stats.yml
+++ b/.github/workflows/coverage_stats.yml
@@ -23,12 +23,14 @@ jobs:
         echo "MLIR_C_RUNNER_UTILS_LIB=${GITHUB_WORKSPACE}/substrait-mlir/build/lib/libmlir_c_runner_utils.so" | tee -a $GITHUB_ENV
 
     - name: Set up Python
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: 3.12
 
     - name: Checkout project
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
 
     - name: Install Python depends
       run: |

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -9,6 +9,8 @@ jobs:
   validate:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Validate dependabot config
         uses: marocchino/validate-dependabot@d8ae5c0d03dd75fbd0ad5f8ab4ba8101ebbd4b37 # v3.0.0

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -9,6 +9,6 @@ jobs:
   validate:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Validate dependabot config
         uses: marocchino/validate-dependabot@d8ae5c0d03dd75fbd0ad5f8ab4ba8101ebbd4b37 # v3.0.0

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -6,7 +6,9 @@ jobs:
   license:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
 
     - name: Run SPDX license checker
       uses: enarx/spdx@d4020ee98e3101dd487c5184f27c6a6fb4f88709  # June 25, 2026

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -6,9 +6,9 @@ jobs:
   license:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Run SPDX license checker
-      uses: enarx/spdx@8524ffcc5b5ffc02b0e8f0389a2bbb3cb4bbb5a2  # November 23, 2024
+      uses: enarx/spdx@d4020ee98e3101dd487c5184f27c6a6fb4f88709  # June 25, 2026
       env:
         INPUT_LICENSES: '["Apache-2.0 WITH LLVM-exception"]'

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: DavidAnson/markdownlint-cli2-action@v23.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
         with:
           globs: '**/*.md'
           config: .markdownlint.jsonc

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: DavidAnson/markdownlint-cli2-action@v17
+      - uses: actions/checkout@v7
+      - uses: DavidAnson/markdownlint-cli2-action@v23.2.0
         with:
           globs: '**/*.md'
           config: .markdownlint.jsonc

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check that commit message forms a "Semantic Commit"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/setup-node@v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
       - run: npm install @commitlint/config-conventional@19.5.0

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check that commit message forms a "Semantic Commit"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
       - run: npm install @commitlint/config-conventional@19.5.0

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -13,7 +13,9 @@ jobs:
     name: Run yapf
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
     - name: run YAPF to test if python code is correctly formatted
       uses: AlexanderMelde/yapf-action@efc672c0c96776f74b4fb4197b334dc07035ec4f # v2.0
       with:

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run yapf
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: run YAPF to test if python code is correctly formatted
       uses: AlexanderMelde/yapf-action@efc672c0c96776f74b4fb4197b334dc07035ec4f # v2.0
       with:

--- a/.github/workflows/zizmore.yml
+++ b/.github/workflows/zizmore.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ implement database query compilers.
 ## Status
 
 The project is work in progress with no stability guarantees. The coverage of
-the Substrait specification is tracked [here](docs/stats.md) and current and
-future work is tracked in the GitHub
+the Substrait specification is tracked in [this doc](docs/stats.md) and current
+and future work is tracked in the GitHub
 [issues](https://github.com/substrait-io/substrait-mlir-contrib/issues) and
 [milestones](https://github.com/substrait-io/substrait-mlir-contrib/milestones).
 


### PR DESCRIPTION
This PR sets up [zizmore](https://zizmor.sh/) static code analysis as a Github action and implements its fixes. One set of fixes consists in pinning the hashes of Github actions rather than using release tags. In addition to implementing that, this PR also upgrades all actions to the latest respective version. Finally, the PR applies a fix required by the new version of the markdown linter, which was updated in that process.